### PR TITLE
[Feat] useDebounce 훅 추가 

### DIFF
--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 /**
  * useDebounce 훅은 입력된 콜백 함수를 지연시간만큼 지연시킨 후 실행합니다.
  * 첫 번째 인수인 콜백 함수는 디바운스 될 값을 반환해야 합니다.
- * 두 번째 인수인 defaultValue는 디바운스 초기값을 설정합니다.
+ * 두 번째 인수인 initialValue는 디바운스 되기 전 초기 값을 설정합니다.
  * 세 번째 인수인 delay는 디바운스 지연시간을 설정합니다.
  */
 export const useDebounce = <F extends (...args: unknown[]) => ReturnType<F>>(

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from "react";
+
+/**
+ * useDebounce 훅은 입력된 콜백 함수를 지연시간만큼 지연시킨 후 실행합니다.
+ * 첫 번째 인수인 콜백 함수는 디바운스 될 값을 반환해야 합니다.
+ * 두 번째 인수인 defaultValue는 디바운스 초기값을 설정합니다.
+ * 세 번째 인수인 delay는 디바운스 지연시간을 설정합니다.
+ */
+export const useDebounce = <F extends (...args: unknown[]) => ReturnType<F>>(
+  callbackFn: F,
+  defaultValue: ReturnType<F>,
+  delay: number = 500,
+) => {
+  const [debouncedValue, setDebouncedValue] =
+    useState<ReturnType<F>>(defaultValue);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(callbackFn());
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [callbackFn, delay]);
+
+  return debouncedValue;
+};

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -8,11 +8,11 @@ import { useState, useEffect } from "react";
  */
 export const useDebounce = <F extends (...args: unknown[]) => ReturnType<F>>(
   callbackFn: F,
-  defaultValue: ReturnType<F>,
+  initialValue: ReturnType<F>,
   delay: number = 500,
 ) => {
   const [debouncedValue, setDebouncedValue] =
-    useState<ReturnType<F>>(defaultValue);
+    useState<ReturnType<F>>(initialValue);
 
   useEffect(() => {
     const handler = setTimeout(() => {


### PR DESCRIPTION
# 관련 이슈 번호
#55
# 설명

`debounced` 된 값을 반환하는 콜백 함수를 인수로 받는 `useDebounce` 훅을 생성했습니다.

```tsx
/**
 * useDebounce 훅은 입력된 콜백 함수를 지연시간만큼 지연시킨 후 실행합니다.
 * 첫 번째 인수인 콜백 함수는 디바운스 될 값을 반환해야 합니다.
 * 두 번째 인수인 defaultValue는 디바운스 초기값을 설정합니다.
 * 세 번째 인수인 delay는 디바운스 지연시간을 설정합니다.
 */
export const useDebounce = <F extends (...args: unknown[]) => ReturnType<F>>(
  callbackFn: F,
  initialValue: ReturnType<F>,
  delay: number = 500,
) => {
  const [debouncedValue, setDebouncedValue] =
    useState<ReturnType<F>>(initialValue);

  useEffect(() => {
    const handler = setTimeout(() => {
      setDebouncedValue(callbackFn());
    }, delay);

    return () => {
      clearTimeout(handler);
    };
  }, [callbackFn, delay]);

  return debouncedValue;
};
```

테스트 항목 목록은 다음과 같습니다.

- 사용자가 7글자의 글자 수를 입력 했을 때 
  - [x] 딜레이가 지나기 전엔 5글자 이상 입력해주세요 라는 문구가 뜬다.
  - [x] 딜레이가 지난 후엔 현재 글자수는 7개 입니다. 라는 문구가 뜬다.
  - 3글자를 지웠을 때 
    - [x] 딜레이가 지나기 전엔 현재 글자수는 7개입니다. 라는 문구가 뜬다.
    - [x] 딜레이가 지난 후엔 5글자 이상 입력해주세요 라는 문구가 뜬다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
