### PR TITLE
[Feat] 이메일 회원가입 페이지 생성 및 이메일 검증 로직 구현

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Outlet } from "react-router-dom";
 import { MainLayout, MainPage } from "../pages";
 import { LoginPage, LoginLayout } from "@/pages/login";
 import { ROUTER_PATH } from "@/shared/constants";
+import { SignUpPage } from "@/pages/sign-up";
 
 export const router = createBrowserRouter([
   {
@@ -38,7 +39,7 @@ export const router = createBrowserRouter([
         children: [
           {
             index: true,
-            element: <div>sign-up</div>,
+            element: <SignUpPage />,
           },
           {
             path: "user-info",

--- a/src/entities/auth/ui/index.ts
+++ b/src/entities/auth/ui/index.ts
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
 export * from "./Input";
-=======
-export * from "./login";
->>>>>>> 652f1dd (feat[#52] : 로그인 HyperLink 추가)

--- a/src/features/auth/model/index.ts
+++ b/src/features/auth/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./useSignUpByEmailForm";

--- a/src/features/auth/model/useSignUpByEmailForm.ts
+++ b/src/features/auth/model/useSignUpByEmailForm.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+interface SignUpByEmailFormType {
+  email: string;
+  confirmCode: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+export const useSignUpByEmailForm = () => {
+  const [form, setForm] = useState<SignUpByEmailFormType>({
+    email: "",
+    confirmCode: "",
+    password: "",
+    passwordConfirm: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prevForm) => ({ ...prevForm, [name]: value }));
+  };
+
+  return { form, handleChange };
+};

--- a/src/features/auth/model/useSignUpByEmailForm.ts
+++ b/src/features/auth/model/useSignUpByEmailForm.ts
@@ -1,3 +1,4 @@
+import { useDebounce } from "@/shared/lib";
 import { useState } from "react";
 
 interface SignUpByEmailFormType {
@@ -20,5 +21,22 @@ export const useSignUpByEmailForm = () => {
     setForm((prevForm) => ({ ...prevForm, [name]: value }));
   };
 
-  return { form, handleChange };
+  const { email } = form;
+
+  const validateEmail = () => {
+    if (email.length === 0) return true;
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+    return emailRegex.test(email);
+  };
+
+  const isValidEmail = useDebounce(validateEmail, true);
+
+  const isErrorEmail = !isValidEmail;
+
+  return {
+    form,
+    isErrorEmail,
+    handleChange,
+  };
 };

--- a/src/features/auth/ui/SignUpByEmailForm.stories.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import SignUpByEmailForm from "./SignUpByEmailForm";
+import { expect, userEvent, within } from "@storybook/test";
+
+const meta: Meta<typeof SignUpByEmailForm> = {
+  title: "features/auth/SignUpByEmailForm",
+  component: SignUpByEmailForm,
+  tags: ["autodocs"],
+  args: {},
+  argTypes: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SignUpByEmailForm>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-96">
+      <SignUpByEmailForm />
+    </div>
+  ),
+
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const $emailInput = canvasElement.querySelector(
+      'input[name="email"]',
+    ) as HTMLInputElement;
+
+    await step(
+      '이메일 입력 필드를 focus하면, "이메일 형식으로 입력해 주세요" 문구가 뜨고 색상은 grey-500으로 표시된다.',
+      async () => {
+        await userEvent.click($emailInput);
+
+        const $statusText = canvas.getByText("이메일 형식으로 입력해 주세요");
+        expect($statusText).toBeInTheDocument();
+        expect($statusText).toHaveClass("text-grey-500");
+      },
+    );
+
+    await step(
+      '이메일 형식에 맞지 않게 입력할 경우, "이메일 형식으로 입력해 주세요" 색상이 pink-500으로 표시된다.',
+      async () => {
+        const DELAY = 500;
+        const DELTA = 100;
+
+        await userEvent.type($emailInput, "invalid-email");
+        await new Promise((resolve) => setTimeout(resolve, DELAY + DELTA));
+
+        const $statusText = canvas.getByText("이메일 형식으로 입력해 주세요");
+        expect($statusText).toHaveClass("text-pink-500");
+      },
+    );
+
+    await step(
+      '이메일 형식에 맞게 입력한 경우, "이메일 형식으로 입력해 주세요" 색상이 grey-500으로 표시된다.',
+      async () => {
+        // 이메일 입력 필드의 값을 초기화합니다.
+        await userEvent.clear($emailInput);
+        await userEvent.type($emailInput, "hi@example.com");
+
+        const DELAY = 500;
+        const DELTA = 100;
+
+        const $statusText = canvas.getByText("이메일 형식으로 입력해 주세요");
+        await new Promise((resolve) => setTimeout(resolve, DELAY + DELTA));
+
+        expect($statusText).toHaveClass("text-grey-500");
+      },
+    );
+
+    await step(
+      '이메일 형식에 맞게 입력한 상태에서 outfocus되면, "이메일 형식으로 입력해 주세요" 문구가 사라진다.',
+      async () => {
+        await userEvent.tab();
+
+        const $statusText = canvas.queryByText("이메일 형식으로 입력해 주세요");
+        expect($statusText).not.toBeInTheDocument();
+      },
+    );
+  },
+};

--- a/src/features/auth/ui/SignUpByEmailForm.stories.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.stories.tsx
@@ -47,6 +47,8 @@ export const Default: Story = {
 
         await userEvent.type($emailInput, "invalid-email");
         await new Promise((resolve) => setTimeout(resolve, DELAY + DELTA));
+        // outfocus되도 statusText를 pink-500 색상으로 표시
+        await userEvent.tab();
 
         const $statusText = canvas.getByText("이메일 형식으로 입력해 주세요");
         expect($statusText).toHaveClass("text-pink-500");

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -2,10 +2,14 @@ import { useState } from "react";
 import { EmailInput, PasswordInput } from "@/entities/auth/ui";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
+import { useSignUpByEmailForm } from "../model";
 
 const SignUpByEmailForm = () => {
   const [isFocusedEmailInput, setIsFocusedEmailInput] =
     useState<boolean>(false);
+
+  const { form, handleChange } = useSignUpByEmailForm();
+  const { email, confirmCode, password, passwordConfirm } = form;
 
   return (
     <form className="flex flex-col gap-8 self-stretch">
@@ -14,12 +18,15 @@ const SignUpByEmailForm = () => {
           <div className="flex items-end justify-between gap-2">
             <EmailInput
               id="email"
+              name="email"
               label="이메일"
               placeholder="이메일을 입력해 주세요"
               statusText={undefined}
               essential
               onFocus={() => setIsFocusedEmailInput(true)}
               onBlur={() => setIsFocusedEmailInput(false)}
+              value={email}
+              onChange={handleChange}
             />
             <Button
               type="button"
@@ -41,9 +48,12 @@ const SignUpByEmailForm = () => {
         <Input
           componentType="outlinedText"
           id="confirm-code"
+          name="confirmCode"
           type="text"
           placeholder="인증코드 7자리를 입력해 주세요"
           statusText="인증코드 7자리를 입력해 주세요"
+          value={confirmCode}
+          onChange={handleChange}
         />
       </div>
 
@@ -51,17 +61,23 @@ const SignUpByEmailForm = () => {
         <PasswordInput
           id="password"
           label="비밀번호"
+          name="password"
           placeholder="비밀번호를 입력해 주세요"
           statusText="비밀번호를 입력해 주세요"
           essential
           isError={false}
+          value={password}
+          onChange={handleChange}
         />
         <PasswordInput
           id="password-confirm"
+          name="passwordConfirm"
           placeholder="비밀번호를 다시 한번 입력해 주세요"
           statusText="비밀번호를 다시 한번 입력해 주세요"
           essential
           isError={false}
+          value={passwordConfirm}
+          onChange={handleChange}
         />
         <span className="body-3 px-3 pt-1 text-grey-500">
           영문, 숫자, 특수문자 3가지 조합을 포함하는 8자 이상 15자 이내로 입력해

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { EmailInput, PasswordInput } from "@/entities/auth/ui";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+
+const SignUpByEmailForm = () => {
+  const [isFocusedEmailInput, setIsFocusedEmailInput] =
+    useState<boolean>(false);
+
+  return (
+    <form className="flex flex-col gap-8 self-stretch">
+      <div className="flex flex-col gap-2">
+        <div>
+          <div className="flex items-end justify-between gap-2">
+            <EmailInput
+              id="email"
+              label="이메일"
+              placeholder="이메일을 입력해 주세요"
+              statusText={undefined}
+              essential
+              onFocus={() => setIsFocusedEmailInput(true)}
+              onBlur={() => setIsFocusedEmailInput(false)}
+            />
+            <Button
+              type="button"
+              colorType="secondary"
+              variant="filled"
+              size="medium"
+              fullWidth={false}
+            >
+              코드전송
+            </Button>
+          </div>
+          {isFocusedEmailInput && (
+            <p className="body-3 pl-1 pr-3 pt-1 text-grey-500">
+              이메일 형식으로 입력해 주세요
+            </p>
+          )}
+        </div>
+
+        <Input
+          componentType="outlinedText"
+          id="confirm-code"
+          type="text"
+          placeholder="인증코드 7자리를 입력해 주세요"
+          statusText="인증코드 7자리를 입력해 주세요"
+        />
+      </div>
+
+      <div>
+        <PasswordInput
+          id="password"
+          label="비밀번호"
+          placeholder="비밀번호를 입력해 주세요"
+          statusText="비밀번호를 입력해 주세요"
+          essential
+          isError={false}
+        />
+        <PasswordInput
+          id="password-confirm"
+          placeholder="비밀번호를 다시 한번 입력해 주세요"
+          statusText="비밀번호를 다시 한번 입력해 주세요"
+          essential
+          isError={false}
+        />
+        <span className="body-3 px-3 pt-1 text-grey-500">
+          영문, 숫자, 특수문자 3가지 조합을 포함하는 8자 이상 15자 이내로 입력해
+          주세요.
+        </span>
+      </div>
+
+      <Button type="submit" colorType="primary" variant="filled" size="large">
+        다음
+      </Button>
+    </form>
+  );
+};
+
+export default SignUpByEmailForm;

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -8,8 +8,10 @@ const SignUpByEmailForm = () => {
   const [isFocusedEmailInput, setIsFocusedEmailInput] =
     useState<boolean>(false);
 
-  const { form, handleChange } = useSignUpByEmailForm();
+  const { form, handleChange, isErrorEmail } = useSignUpByEmailForm();
   const { email, confirmCode, password, passwordConfirm } = form;
+
+  const shouldShowEmailStatusText = isFocusedEmailInput || isErrorEmail;
 
   return (
     <form className="flex flex-col gap-8 self-stretch">
@@ -20,13 +22,14 @@ const SignUpByEmailForm = () => {
               id="email"
               name="email"
               label="이메일"
+              isError={isErrorEmail}
               placeholder="이메일을 입력해 주세요"
               statusText={undefined}
               essential
-              onFocus={() => setIsFocusedEmailInput(true)}
-              onBlur={() => setIsFocusedEmailInput(false)}
               value={email}
               onChange={handleChange}
+              onFocus={() => setIsFocusedEmailInput(true)}
+              onBlur={() => setIsFocusedEmailInput(false)}
             />
             <Button
               type="button"
@@ -38,8 +41,10 @@ const SignUpByEmailForm = () => {
               코드전송
             </Button>
           </div>
-          {isFocusedEmailInput && (
-            <p className="body-3 pl-1 pr-3 pt-1 text-grey-500">
+          {shouldShowEmailStatusText && (
+            <p
+              className={`body-3 pl-1 pr-3 pt-1 ${isErrorEmail ? "text-pink-500" : "text-grey-500"}`}
+            >
               이메일 형식으로 입력해 주세요
             </p>
           )}
@@ -65,7 +70,6 @@ const SignUpByEmailForm = () => {
           placeholder="비밀번호를 입력해 주세요"
           statusText="비밀번호를 입력해 주세요"
           essential
-          isError={false}
           value={password}
           onChange={handleChange}
         />
@@ -75,7 +79,6 @@ const SignUpByEmailForm = () => {
           placeholder="비밀번호를 다시 한번 입력해 주세요"
           statusText="비밀번호를 다시 한번 입력해 주세요"
           essential
-          isError={false}
           value={passwordConfirm}
           onChange={handleChange}
         />

--- a/src/features/auth/ui/index.ts
+++ b/src/features/auth/ui/index.ts
@@ -1,1 +1,2 @@
 export * from "./hyperlinks";
+export { default as SignUpByEmailForm } from "./SignUpByEmailForm";

--- a/src/pages/sign-up/index.ts
+++ b/src/pages/sign-up/index.ts
@@ -1,0 +1,1 @@
+export { default as SignUpPage } from "./page";

--- a/src/pages/sign-up/page.tsx
+++ b/src/pages/sign-up/page.tsx
@@ -1,0 +1,28 @@
+import { SignUpByEmailForm } from "@/features/auth/ui";
+import { ROUTER_PATH } from "@/shared/constants";
+import { Link } from "react-router-dom";
+
+const SignUpPage = () => {
+  return (
+    <div>
+      {/* todo: 이전으로 돌아가는 navigationbar 만들어지면 추가 */}
+
+      <main className="flex flex-col gap-8 self-stretch px-4">
+        {/* progress bar */}
+        <div></div>
+        <h1 className="headline-3 mx-auto">이메일로 회원가입</h1>
+
+        <SignUpByEmailForm />
+      </main>
+
+      <footer className="mt-8 flex items-center justify-center">
+        <span className="title-3 text-grey-500">이미 회원이신가요?</span>
+        <Link to={ROUTER_PATH.LOGIN} className="btn-3 ml-4 text-tangerine-500">
+          로그인
+        </Link>
+      </footer>
+    </div>
+  );
+};
+
+export default SignUpPage;

--- a/src/shared/assets/visibility-off.svg
+++ b/src/shared/assets/visibility-off.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="current" height="current" viewBox="0 0 24 24" fill="none">
-<mask id="mask0_319_16042" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="current" height="current">
+<mask id="mask0_319_16042" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
 <rect width="24" height="24" fill="#D9D9D9"/>
 </mask>
 <g mask="url(#mask0_319_16042)">


### PR DESCRIPTION
# 관련 이슈 번호

#23 

# 설명

- 이메일 회원가입 페이지 view 작성
- 이메일 회원가입 form 생성
- 이메일 회원가입 상태를 관리하는 커스텀 훅 생성
- 이메일 input validation 검증
  - 이메일 입력 필드를 focus하면, "이메일 형식으로 입력해 주세요" 문구가 뜨고 색상은 grey-500으로 표시된다.
  - 이메일 형식에 맞지 않게 입력할 경우, "이메일 형식으로 입력해 주세요" 색상이 pink-500으로 표시된다.
  - 이메일 형식에 맞게 입력한 경우, "이메일 형식으로 입력해 주세요" 색상이 grey-500으로 표시된다.
  - 이메일 형식에 맞게 입력한 상태에서 outfocus되면, "이메일 형식으로 입력해 주세요" 문구가 사라진다.

