### PR TITLE
[Refactor] 이메일 회원가입 form 검증 로직 구현

### DIFF
--- a/src/features/auth/model/useSignUpByEmailForm.ts
+++ b/src/features/auth/model/useSignUpByEmailForm.ts
@@ -1,4 +1,3 @@
-import { useDebounce } from "@/shared/lib";
 import { useState } from "react";
 
 interface SignUpByEmailFormType {
@@ -21,22 +20,30 @@ export const useSignUpByEmailForm = () => {
     setForm((prevForm) => ({ ...prevForm, [name]: value }));
   };
 
-  const { email } = form;
+  const { email, password } = form;
 
-  const validateEmail = () => {
-    if (email.length === 0) return true;
+  const validateEmail = (email: string) => {
     const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
     return emailRegex.test(email);
   };
+  const validatePassword = (password: string) => {
+    // 조건
+    // 1. 영문, 숫자, 특수문자 3가지 조합 포함
+    // 2. 8~15자 이내
+    const passwordRegex =
+      /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/;
 
-  const isValidEmail = useDebounce(validateEmail, true);
+    return passwordRegex.test(password);
+  };
 
-  const isErrorEmail = !isValidEmail;
+  const isValidEmail = validateEmail(email);
+  const isValidPassword = validatePassword(password);
 
   return {
     form,
-    isErrorEmail,
+    isValidEmail,
+    isValidPassword,
     handleChange,
   };
 };

--- a/src/features/auth/model/useSignUpByEmailForm.ts
+++ b/src/features/auth/model/useSignUpByEmailForm.ts
@@ -20,7 +20,7 @@ export const useSignUpByEmailForm = () => {
     setForm((prevForm) => ({ ...prevForm, [name]: value }));
   };
 
-  const { email, password } = form;
+  const { email, password, passwordConfirm } = form;
 
   const validateEmail = (email: string) => {
     const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
@@ -39,11 +39,13 @@ export const useSignUpByEmailForm = () => {
 
   const isValidEmail = validateEmail(email);
   const isValidPassword = validatePassword(password);
+  const isPasswordMatched = password === passwordConfirm;
 
   return {
     form,
     isValidEmail,
     isValidPassword,
+    isPasswordMatched,
     handleChange,
   };
 };

--- a/src/features/auth/ui/SignUpByEmailForm.stories.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.stories.tsx
@@ -124,5 +124,7 @@ export const Default: Story = {
         expect($statusText.textContent).toBe("");
       },
     );
+
+    // todo: 비밀번호 확인 input 테스트 코드
   },
 };

--- a/src/features/auth/ui/SignUpByEmailForm.stories.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.stories.tsx
@@ -42,11 +42,7 @@ export const Default: Story = {
     await step(
       '이메일 형식에 맞지 않게 입력할 경우, "이메일 형식으로 입력해 주세요" 색상이 pink-500으로 표시된다.',
       async () => {
-        const DELAY = 500;
-        const DELTA = 100;
-
         await userEvent.type($emailInput, "invalid-email");
-        await new Promise((resolve) => setTimeout(resolve, DELAY + DELTA));
         // outfocus되도 statusText를 pink-500 색상으로 표시
         await userEvent.tab();
 
@@ -62,11 +58,7 @@ export const Default: Story = {
         await userEvent.clear($emailInput);
         await userEvent.type($emailInput, "hi@example.com");
 
-        const DELAY = 500;
-        const DELTA = 100;
-
         const $statusText = canvas.getByText("이메일 형식으로 입력해 주세요");
-        await new Promise((resolve) => setTimeout(resolve, DELAY + DELTA));
 
         expect($statusText).toHaveClass("text-grey-500");
       },
@@ -79,6 +71,57 @@ export const Default: Story = {
 
         const $statusText = canvas.queryByText("이메일 형식으로 입력해 주세요");
         expect($statusText).not.toBeInTheDocument();
+      },
+    );
+
+    await step(
+      "이메일 형식에 맞게 입력한 상태에서 [코드전송] 버튼을 클릭할 수 있다.",
+      async () => {
+        const $sendConfirmCodeButton = canvas.getByText("코드전송");
+        expect($sendConfirmCodeButton).toBeEnabled();
+      },
+    );
+
+    const $passwordInput = canvasElement.querySelector(
+      'input[name="password"]',
+    ) as HTMLInputElement;
+
+    await step(
+      '입력하지 않은 상태에서 비밀번호 input을 클릭할 경우, 폰트 색상이 grey-500인 "비밀번호를 입력해 주세요"가 표시된다.',
+      async () => {
+        await userEvent.click($passwordInput);
+
+        const $statusText = canvas.getByText("비밀번호를 입력해 주세요");
+        expect($statusText).toBeInTheDocument();
+        expect($statusText).toHaveClass("text-grey-500");
+      },
+    );
+
+    await step(
+      '비밀번호 형식에 맞지 않게 입력할 경우, "비밀번호 형식에 맞게 입력해 주세요" 색상이 pink-500으로 표시된다.',
+      async () => {
+        await userEvent.type($passwordInput, "password-");
+        // outfocus되도 statusText를 pink-500 색상으로 표시
+        await userEvent.tab();
+
+        const $statusText = canvas.getByText(
+          "비밀번호 형식에 맞게 입력해 주세요",
+        );
+        expect($statusText).toHaveClass("text-pink-500");
+      },
+    );
+
+    await step(
+      '비밀번호 형식에 맞게 입력한 경우, "비밀번호 형식에 맞게 입력해 주세요" 문구가 사라진다.',
+      async () => {
+        const $statusText = canvas.getByText(
+          "비밀번호 형식에 맞게 입력해 주세요",
+        );
+
+        await userEvent.type($passwordInput, "1234");
+
+        expect($statusText).toBeInTheDocument();
+        expect($statusText.textContent).toBe("");
       },
     );
   },

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -22,7 +22,7 @@ const SignUpByEmailForm = () => {
   const isPasswordConfirmEmpty = passwordConfirm.length === 0;
 
   const shouldShowEmailStatusText =
-    (!isValidEmail && email.length > 0) || isFocusedEmailInput;
+    (!isValidEmail && !isEmailEmpty) || isFocusedEmailInput;
 
   let passwordConfirmStatusText = "";
 
@@ -44,7 +44,7 @@ const SignUpByEmailForm = () => {
               id="email"
               name="email"
               label="이메일"
-              isError={!(isValidEmail || isEmailEmpty)}
+              isError={!isEmailEmpty && !isValidEmail}
               placeholder="이메일을 입력해 주세요"
               statusText={undefined}
               essential
@@ -92,7 +92,7 @@ const SignUpByEmailForm = () => {
           name="password"
           placeholder="비밀번호를 입력해 주세요"
           statusText={
-            password.length === 0
+            isPasswordEmpty
               ? "비밀번호를 입력해 주세요"
               : isValidPassword
                 ? ""
@@ -101,7 +101,7 @@ const SignUpByEmailForm = () => {
           essential
           value={password}
           onChange={handleChange}
-          isError={!(isValidPassword || isPasswordEmpty)}
+          isError={!isPasswordEmpty && !isValidPassword}
         />
         <PasswordInput
           id="password-confirm"
@@ -111,7 +111,7 @@ const SignUpByEmailForm = () => {
           essential
           value={passwordConfirm}
           onChange={handleChange}
-          isError={!(isPasswordConfirmEmpty || isPasswordMatched)}
+          isError={!isPasswordConfirmEmpty && !isPasswordMatched}
         />
         <span className="body-3 px-3 pt-1 text-grey-500">
           영문, 숫자, 특수문자 3가지 조합을 포함하는 8자 이상 15자 이내로 입력해

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -17,6 +17,10 @@ const SignUpByEmailForm = () => {
   } = useSignUpByEmailForm();
   const { email, confirmCode, password, passwordConfirm } = form;
 
+  const isEmailEmpty = email.length === 0;
+  const isPasswordEmpty = password.length === 0;
+  const isPasswordConfirmEmpty = passwordConfirm.length === 0;
+
   const shouldShowEmailStatusText =
     (!isValidEmail && email.length > 0) || isFocusedEmailInput;
 
@@ -40,7 +44,7 @@ const SignUpByEmailForm = () => {
               id="email"
               name="email"
               label="이메일"
-              isError={!(isValidEmail || email.length === 0)}
+              isError={!(isValidEmail || isEmailEmpty)}
               placeholder="이메일을 입력해 주세요"
               statusText={undefined}
               essential
@@ -62,7 +66,7 @@ const SignUpByEmailForm = () => {
           </div>
           {shouldShowEmailStatusText && (
             <p
-              className={`body-3 pl-1 pr-3 pt-1 ${isValidEmail || email.length === 0 ? "text-grey-500" : "text-pink-500"}`}
+              className={`body-3 pl-1 pr-3 pt-1 ${isValidEmail || isEmailEmpty ? "text-grey-500" : "text-pink-500"}`}
             >
               이메일 형식으로 입력해 주세요
             </p>
@@ -97,7 +101,7 @@ const SignUpByEmailForm = () => {
           essential
           value={password}
           onChange={handleChange}
-          isError={!(isValidPassword || password.length === 0)}
+          isError={!(isValidPassword || isPasswordEmpty)}
         />
         <PasswordInput
           id="password-confirm"
@@ -107,7 +111,7 @@ const SignUpByEmailForm = () => {
           essential
           value={passwordConfirm}
           onChange={handleChange}
-          isError={!(passwordConfirm.length === 0 || isPasswordMatched)}
+          isError={!(isPasswordConfirmEmpty || isPasswordMatched)}
         />
         <span className="body-3 px-3 pt-1 text-grey-500">
           영문, 숫자, 특수문자 3가지 조합을 포함하는 8자 이상 15자 이내로 입력해

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -12,7 +12,8 @@ const SignUpByEmailForm = () => {
     useSignUpByEmailForm();
   const { email, confirmCode, password, passwordConfirm } = form;
 
-  const shouldShowEmailStatusText = isFocusedEmailInput || !isValidEmail;
+  const shouldShowEmailStatusText =
+    (!isValidEmail && email.length > 0) || isFocusedEmailInput;
 
   return (
     <form className="flex flex-col gap-8 self-stretch">
@@ -23,7 +24,7 @@ const SignUpByEmailForm = () => {
               id="email"
               name="email"
               label="이메일"
-              isError={!isValidEmail}
+              isError={!(isValidEmail || email.length === 0)}
               placeholder="이메일을 입력해 주세요"
               statusText={undefined}
               essential

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -8,12 +8,28 @@ const SignUpByEmailForm = () => {
   const [isFocusedEmailInput, setIsFocusedEmailInput] =
     useState<boolean>(false);
 
-  const { form, handleChange, isValidEmail, isValidPassword } =
-    useSignUpByEmailForm();
+  const {
+    form,
+    handleChange,
+    isValidEmail,
+    isValidPassword,
+    isPasswordMatched,
+  } = useSignUpByEmailForm();
   const { email, confirmCode, password, passwordConfirm } = form;
 
   const shouldShowEmailStatusText =
     (!isValidEmail && email.length > 0) || isFocusedEmailInput;
+
+  let passwordConfirmStatusText = "";
+
+  if (isValidPassword) {
+    if (isPasswordMatched)
+      passwordConfirmStatusText = "사용가능한 비밀번호 입니다";
+    else passwordConfirmStatusText = "비밀번호가 서로 일치하지 않습니다";
+  } else {
+    if (isPasswordMatched) passwordConfirmStatusText = "";
+    else passwordConfirmStatusText = "비밀번호가 서로 일치하지 않습니다";
+  }
 
   return (
     <form className="flex flex-col gap-8 self-stretch">
@@ -87,10 +103,11 @@ const SignUpByEmailForm = () => {
           id="password-confirm"
           name="passwordConfirm"
           placeholder="비밀번호를 다시 한번 입력해 주세요"
-          statusText="비밀번호를 다시 한번 입력해 주세요"
+          statusText={passwordConfirmStatusText}
           essential
           value={passwordConfirm}
           onChange={handleChange}
+          isError={!(passwordConfirm.length === 0 || isPasswordMatched)}
         />
         <span className="body-3 px-3 pt-1 text-grey-500">
           영문, 숫자, 특수문자 3가지 조합을 포함하는 8자 이상 15자 이내로 입력해

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -8,10 +8,11 @@ const SignUpByEmailForm = () => {
   const [isFocusedEmailInput, setIsFocusedEmailInput] =
     useState<boolean>(false);
 
-  const { form, handleChange, isErrorEmail } = useSignUpByEmailForm();
+  const { form, handleChange, isValidEmail, isValidPassword } =
+    useSignUpByEmailForm();
   const { email, confirmCode, password, passwordConfirm } = form;
 
-  const shouldShowEmailStatusText = isFocusedEmailInput || isErrorEmail;
+  const shouldShowEmailStatusText = isFocusedEmailInput || !isValidEmail;
 
   return (
     <form className="flex flex-col gap-8 self-stretch">
@@ -22,7 +23,7 @@ const SignUpByEmailForm = () => {
               id="email"
               name="email"
               label="이메일"
-              isError={isErrorEmail}
+              isError={!isValidEmail}
               placeholder="이메일을 입력해 주세요"
               statusText={undefined}
               essential
@@ -37,13 +38,14 @@ const SignUpByEmailForm = () => {
               variant="filled"
               size="medium"
               fullWidth={false}
+              disabled={!isValidEmail}
             >
               코드전송
             </Button>
           </div>
           {shouldShowEmailStatusText && (
             <p
-              className={`body-3 pl-1 pr-3 pt-1 ${isErrorEmail ? "text-pink-500" : "text-grey-500"}`}
+              className={`body-3 pl-1 pr-3 pt-1 ${isValidEmail || email.length === 0 ? "text-grey-500" : "text-pink-500"}`}
             >
               이메일 형식으로 입력해 주세요
             </p>
@@ -68,10 +70,17 @@ const SignUpByEmailForm = () => {
           label="비밀번호"
           name="password"
           placeholder="비밀번호를 입력해 주세요"
-          statusText="비밀번호를 입력해 주세요"
+          statusText={
+            password.length === 0
+              ? "비밀번호를 입력해 주세요"
+              : isValidPassword
+                ? ""
+                : "비밀번호 형식에 맞게 입력해 주세요"
+          }
           essential
           value={password}
           onChange={handleChange}
+          isError={!(isValidPassword || password.length === 0)}
         />
         <PasswordInput
           id="password-confirm"

--- a/src/pages/sign-up/page.tsx
+++ b/src/pages/sign-up/page.tsx
@@ -1,14 +1,13 @@
 import { SignUpByEmailForm } from "@/features/auth/ui";
 import { ROUTER_PATH } from "@/shared/constants";
+import { BackwardNavigationBar } from "@/widgets/navigationbar/ui";
 import { Link } from "react-router-dom";
 
 const SignUpPage = () => {
   return (
     <div>
-      {/* todo: 이전으로 돌아가는 navigationbar 만들어지면 추가 */}
-
       <main className="flex flex-col gap-8 self-stretch px-4">
-        {/* progress bar */}
+        <BackwardNavigationBar />
         <div></div>
         <h1 className="headline-3 mx-auto">이메일로 회원가입</h1>
 


### PR DESCRIPTION
# 관련 이슈 번호

#23 

# 설명

### 이메일 input과 패스워드 input 검증 로직 수정

기존에는 useDebounce를 이용해서 검증하였으나, 실시간으로 사용자의 입력값이 형식에 맞는지 확인하는 것으로 수정하였습니다.

```javascript
export const useSignUpByEmailForm = () => {
  const [form, setForm] = useState<SignUpByEmailFormType>({
    email: "",
    confirmCode: "",
    password: "",
    passwordConfirm: "",
  });

  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
    const { name, value } = e.target;
    setForm((prevForm) => ({ ...prevForm, [name]: value }));
  };

  const { email, password } = form;

  const validateEmail = (email: string) => {
    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;

    return emailRegex.test(email);
  };
  const validatePassword = (password: string) => {
    // 조건
    // 1. 영문, 숫자, 특수문자 3가지 조합 포함
    // 2. 8~15자 이내
    const passwordRegex =
      /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/;

    return passwordRegex.test(password);
  };

  const isValidEmail = validateEmail(email);
  const isValidPassword = validatePassword(password);

  return {
    form,
    isValidEmail,
    isValidPassword,
    handleChange,
  };
};
```

기존에는 `isErrorEmail`을 사용했으나, isValidEmail을 export 하는 것으로 수정하였습니다.
나중에 서버에 api 요청을 보낼 때 isErrorEmail을 사용하게 되면, 아래 코드와 같이 이중 부정으로 사용하게 되어 더 가독성이 떨어질 수 있겠다고 판단하였습니다.
```javascript
if(!isErrorEmail && !isErrorPassword && ... ) return;

postSignUpByEmail({ email, password })
```

### 패스워드 input 검증 테스트 코드 추가

추가한 테스트는 아래와 같습니다.

- 비밀번호 형식에 맞지 않게 입력할 경우, "비밀번호 형식에 맞게 입력해 주세요" 색상이 pink-500으로 표시된다.
- 비밀번호 형식에 맞게 입력한 경우, "비밀번호 형식에 맞게 입력해 주세요" 문구가 사라진다.

### 페이지 상단에 있을 네비게이션 바 추가

용현님이 만들어주신 네비게이션 바 추가하였습니다.

### 패스워드 확인 input 검증 

이 부분은 기획 회의를 한 번 거쳐야 할 거 같아서, 구현은 해놓았지만 수정될 것 같아요.

1. 패스워드 input 입력값이 형식에 맞고 
2. 패스워드 input 값 = 패스워드 확인 input 값

위 두 조건에 부합하면, 패스워드 확인 input을 outfocus해도 statusText를 표시하더라구요.
지금 저희 input은 **에러 상태일 때만** outfocus되어도 statusText가 표시되도록 구현되어 있어서요 😢 
이 부분을 가은님에게 한 번 여쭤봐야 할 거 같네요 🤔 

<img width="584" alt="스크린샷 2024-08-26 오후 8 06 46" src="https://github.com/user-attachments/assets/d647e08e-6e78-4f53-9f9c-226b0da91fe3">

그래서 테스트 코드는 추후에 작성할 예정입니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
