### PR TITLE
[Hotfix] 디자인 시스템에 맞춰 스타일 변경하기 

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -32,13 +32,13 @@ body {
   }
 
   .btn-1 {
-    @apply text-[1rem] font-semibold leading-[1.2] tracking-[.0138rem];
+    @apply text-[1.375rem] font-semibold leading-[1.65] tracking-[0.01375rem];
   }
   .btn-2 {
-    @apply text-[0.875rem] font-semibold leading-[1.2] tracking-[.01rem];
+    @apply text-[1rem] font-semibold leading-[1.2] tracking-[0.01rem];
   }
   .btn-3 {
-    @apply text-[0.75rem] font-semibold leading-[1.2] tracking-[.0175rem];
+    @apply text-[0.875rem] font-semibold leading-[1.05] tracking-[0.0175rem];
   }
 
   .body-1 {

--- a/src/global.css
+++ b/src/global.css
@@ -32,13 +32,13 @@ body {
   }
 
   .btn-1 {
-    @apply text-[1.375rem] font-semibold leading-[1.65] tracking-[0.01375rem];
+    @apply text-[1.375rem] font-semibold leading-[1.2] tracking-[0.01375rem];
   }
   .btn-2 {
     @apply text-[1rem] font-semibold leading-[1.2] tracking-[0.01rem];
   }
   .btn-3 {
-    @apply text-[0.875rem] font-semibold leading-[1.05] tracking-[0.0175rem];
+    @apply text-[0.875rem] font-semibold leading-[1.2] tracking-[0.0175rem];
   }
 
   .body-1 {

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -86,7 +86,7 @@ export const Input = ({
     <div className={`flex ${fullWidth && "w-full"} flex-col items-start`}>
       {label && (
         <div className="flex gap-1 pb-2">
-          <label htmlFor={id} className="title-3">
+          <label htmlFor={id} className="title-3 text-grey-700">
             {label}
           </label>
           {essential && <Badge colorType="primary" />}

--- a/src/shared/ui/textarea/TextArea.tsx
+++ b/src/shared/ui/textarea/TextArea.tsx
@@ -72,7 +72,7 @@ export const TextArea = ({
     <div className={`flex ${fullWidth && "w-full"} flex-col items-start`}>
       {label && (
         <div className="flex gap-1 pb-2">
-          <label htmlFor={id} className="title-3">
+          <label htmlFor={id} className="title-3 text-grey-700">
             {label}
           </label>
           {essential && <Badge colorType="primary" />}


### PR DESCRIPTION
# 관련 이슈 번호
close #76
# 설명

![image](https://github.com/user-attachments/assets/89da0468-2205-4d7f-b917-380f5bda271e)
`global.css` 에 존재하던 버튼의 스타일을 디자인 시스템에 맞게 수정했습니다.

라벨에 글자색 `text-grey-700` 을 추가했습니다.