### PR TITLE
[Feat] 이메일 회원가입 api 로직 구현

### DIFF
--- a/src/features/auth/api/login.ts
+++ b/src/features/auth/api/login.ts
@@ -78,3 +78,49 @@ export const usePostLoginForm = () => {
 
   return mutate;
 };
+
+interface SignUpByEmailResponse {
+  code: number;
+  message: string;
+  content: {
+    authorization: string;
+    role: string;
+    userId: number;
+  };
+}
+
+interface SignUpByEmailRequestData {
+  email: string;
+  password: string;
+}
+
+const postSignUpByEmail = async ({
+  email,
+  password,
+}: SignUpByEmailRequestData) => {
+  const response = await fetch(LOGIN_END_POINT.EMAIL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  const data: SignUpByEmailResponse = await response.json();
+
+  // todo: 예외처리 구체화하기
+  // code = 409이면, 이미 가입된 계정
+  if (!response.ok) {
+    const { message } = data;
+
+    throw new Error(message);
+  }
+
+  return data;
+};
+
+export const usePostSignUpByEmail = () => {
+  return useMutation<SignUpByEmailResponse, Error, SignUpByEmailRequestData>({
+    mutationFn: postSignUpByEmail,
+  });
+};

--- a/src/features/auth/constants/endpoint.ts
+++ b/src/features/auth/constants/endpoint.ts
@@ -4,3 +4,7 @@ export const LOGIN_END_POINT = {
   NAVER: "http://localhost:80/oauth2/authorization/naver",
   EMAIL: "http://localhost:80/login",
 };
+
+export const SIGN_UP_END_POINT = {
+  EMAIL: "http://localhost:80/users",
+};

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -3,10 +3,16 @@ import { EmailInput, PasswordInput } from "@/entities/auth/ui";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { useSignUpByEmailForm } from "../model";
+import { usePostSignUpByEmail } from "../api";
+import { useAuthStore } from "@/shared/store/auth";
 
 const SignUpByEmailForm = () => {
   const [isFocusedEmailInput, setIsFocusedEmailInput] =
     useState<boolean>(false);
+
+  const { mutate: postSignUpByEmail } = usePostSignUpByEmail();
+  const setToken = useAuthStore((state) => state.setToken);
+  const setRole = useAuthStore((state) => state.setRole);
 
   const {
     form,
@@ -35,8 +41,36 @@ const SignUpByEmailForm = () => {
     else passwordConfirmStatusText = "비밀번호가 서로 일치하지 않습니다";
   }
 
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const canSignUp = isValidEmail && isValidPassword && isPasswordMatched;
+
+    if (!canSignUp) {
+      // todo: snackbar 띄우기
+      alert("이메일과 비밀번호를 모두 입력해 주세요");
+      return;
+    }
+
+    postSignUpByEmail(
+      { email, password },
+      {
+        onSuccess: ({ content }) => {
+          const { authorization, role } = content;
+
+          setToken(authorization);
+          setRole(role);
+        },
+        onError: (error) => {
+          // todo: snackbar 띄우기
+          alert(error.message);
+        },
+      },
+    );
+  };
+
   return (
-    <form className="flex flex-col gap-8 self-stretch">
+    <form className="flex flex-col gap-8 self-stretch" onSubmit={handleSubmit}>
       <div className="flex flex-col gap-2">
         <div>
           <div className="flex items-end justify-between gap-2">

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -5,8 +5,12 @@ import { Input } from "@/shared/ui/input";
 import { useSignUpByEmailForm } from "../model";
 import { usePostSignUpByEmail } from "../api";
 import { useAuthStore } from "@/shared/store/auth";
+import { useNavigate } from "react-router-dom";
+import { ROUTER_PATH } from "@/shared/constants";
 
 const SignUpByEmailForm = () => {
+  const navigate = useNavigate();
+
   const [isFocusedEmailInput, setIsFocusedEmailInput] =
     useState<boolean>(false);
 
@@ -60,6 +64,8 @@ const SignUpByEmailForm = () => {
 
           setToken(authorization);
           setRole(role);
+
+          navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
         },
         onError: (error) => {
           // todo: snackbar 띄우기

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -17,6 +17,7 @@ const SignUpByEmailForm = () => {
   const { mutate: postSignUpByEmail } = usePostSignUpByEmail();
   const setToken = useAuthStore((state) => state.setToken);
   const setRole = useAuthStore((state) => state.setRole);
+  const setUserId = useAuthStore((state) => state.setUserId);
 
   const {
     form,
@@ -60,10 +61,11 @@ const SignUpByEmailForm = () => {
       { email, password },
       {
         onSuccess: ({ content }) => {
-          const { authorization, role } = content;
+          const { authorization, role, userId } = content;
 
           setToken(authorization);
           setRole(role);
+          setUserId(userId);
 
           navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
         },

--- a/src/shared/store/auth.ts
+++ b/src/shared/store/auth.ts
@@ -2,8 +2,10 @@ import { create } from "zustand";
 type AuthStore = {
   token: string;
   role: string;
+  userId: number | null;
   setToken: (token: string) => void;
   setRole: (role: string) => void;
+  setUserId: (userId: number) => void;
 };
 
 /**
@@ -14,6 +16,8 @@ type AuthStore = {
 export const useAuthStore = create<AuthStore>((set) => ({
   token: "",
   role: "",
+  userId: null,
   setToken: (token: string) => set({ token }),
   setRole: (role: string) => set({ role }),
+  setUserId: (userId: number) => set({ userId }),
 }));


### PR DESCRIPTION
# 관련 이슈 번호

#23 

# 설명

서버에게 이메일 회원가입 요청을 보내는 로직을 구현했습니다.
서버로부터 에러 응답이 오면, data에 있는 message로 error 처리하였습니다.

```javascript
const postSignUpByEmail = async ({
  email,
  password,
}: SignUpByEmailRequestData) => {
  const response = await fetch(LOGIN_END_POINT.EMAIL, {
    method: "POST",
    headers: {
      "Content-Type": "application/json",
    },
    body: JSON.stringify({ email, password }),
  });

  const data: SignUpByEmailResponse = await response.json();

  // todo: 예외처리 구체화하기
  // code = 409이면, 이미 가입된 계정
  if (!response.ok) {
    const { message } = data;

    throw new Error(message);
  }

  return data;
};
```

그리고 백엔드에서 이메일이 중복일 경우 이미 가입한 계정이라고 판단하여 `code: 409`로 보내주고 있어요.
이 부분은 추후에 snack bar가 만들어지면 에러 처리하려고 합니다.