### PR TITLE
[Feat] /login 페이지 OAuth API 기능 추가

### DIFF
--- a/src/features/auth/api/login.ts
+++ b/src/features/auth/api/login.ts
@@ -5,7 +5,7 @@ export interface LoginResponse {
   code: number;
   message: string;
   content: {
-    authorization: string;
+    token: string;
     role: string;
     userId: number;
   };

--- a/src/features/auth/api/login.ts
+++ b/src/features/auth/api/login.ts
@@ -1,16 +1,17 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { LOGIN_END_POINT } from "../constants";
 
-interface LoginResponse {
+export interface LoginResponse {
   code: number;
   message: string;
   content: {
-    token: string;
+    authorization: string;
     role: string;
+    userId: number;
   };
 }
 
-export type OAuthServerName = "GOOGLE" | "NAVER";
+export type OAuthServerName = Exclude<keyof typeof LOGIN_END_POINT, "EMAIL">;
 
 /**
  * 해당 훅은 OAuthServerName이 주어지면 해당 OAuthServer로 로그인을 시도합니다.
@@ -19,18 +20,11 @@ export type OAuthServerName = "GOOGLE" | "NAVER";
 export const useOauthLogin = (OAuthServerName: OAuthServerName | null) => {
   const isOauthLoginEnabled = OAuthServerName !== null;
 
-  // OauthLogin을 사용 할 수 없는 경우엔 EndPoint는 false
-  const END_POINT = isOauthLoginEnabled && LOGIN_END_POINT[OAuthServerName];
-
-  // TODO 리액트 쿼리를 활용하여 최적화 하기
   const query = useQuery<LoginResponse>({
     queryKey: ["OAuthLogin", OAuthServerName],
-    // TODO fetch 함수 커스텀 라이브러리로 분리하기
     queryFn: async () => {
-      if (!END_POINT) {
-        return;
-      }
-
+      // 컴파일러에게 OAuthServerName이 null이 아님을 알려줍니다.
+      const END_POINT = LOGIN_END_POINT[OAuthServerName!];
       const response = await fetch(END_POINT);
       if (!response.ok) {
         // TODO 에러 메시지 픽스하기

--- a/src/features/auth/api/login.ts
+++ b/src/features/auth/api/login.ts
@@ -7,7 +7,8 @@ export interface LoginResponse {
   content: {
     authorization: string;
     role: string;
-    userId: number;
+    userId: number | null;
+    nickname: string | null;
   };
 }
 

--- a/src/features/auth/api/login.ts
+++ b/src/features/auth/api/login.ts
@@ -5,7 +5,7 @@ export interface LoginResponse {
   code: number;
   message: string;
   content: {
-    token: string;
+    authorization: string;
     role: string;
     userId: number;
   };
@@ -17,7 +17,7 @@ export type OAuthServerName = Exclude<keyof typeof LOGIN_END_POINT, "EMAIL">;
  * 해당 훅은 OAuthServerName이 주어지면 해당 OAuthServer로 로그인을 시도합니다.
  * 만약 OAuthServerName이 null일 경우엔 로그인을 시도하지 않습니다.
  */
-export const useOauthLogin = (OAuthServerName: OAuthServerName | null) => {
+export const useGetOauthLogin = (OAuthServerName: OAuthServerName | null) => {
   const isOauthLoginEnabled = OAuthServerName !== null;
 
   const query = useQuery<LoginResponse>({
@@ -57,7 +57,7 @@ export const usePostLoginForm = () => {
         body: JSON.stringify(formData),
       });
 
-      const data = await response.json();
+      const data: LoginResponse = await response.json();
 
       if (!response.ok) {
         throw new Error("문제가 발생했습니다. 잠시 후 다시 이용해주세요");

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -29,8 +29,8 @@ const LoginForm = () => {
           { email, password, persistLogin },
           {
             onSuccess: (data) => {
-              const { token, role } = data.content;
-              setToken(token);
+              const { authorization, role } = data.content;
+              setToken(authorization);
               setRole(role);
               // TODO 리다이렉션하기
             },

--- a/src/features/auth/ui/hyperlinks.tsx
+++ b/src/features/auth/ui/hyperlinks.tsx
@@ -60,7 +60,7 @@ export const OAuthLoginHyperLinks = () => {
   const setRole = useAuthStore((state) => state.setRole);
   const setUserId = useAuthStore((state) => state.setUserId);
 
-  const { data: authResponse } = useOauthLogin(OAuthServerName);
+  const { data: authResponse, error } = useOauthLogin(OAuthServerName);
 
   const handleAuthResponse = useCallback(
     (authResponse: LoginResponse) => {
@@ -86,6 +86,14 @@ export const OAuthLoginHyperLinks = () => {
     }
     handleAuthResponse(authResponse);
   }, [authResponse, handleAuthResponse]);
+
+  useEffect(() => {
+    if (error instanceof Error) {
+      // TODO 모달로 변경하기
+      alert(error.message);
+    }
+    console.error(error);
+  }, [error]);
 
   return (
     <>

--- a/src/features/auth/ui/hyperlinks.tsx
+++ b/src/features/auth/ui/hyperlinks.tsx
@@ -70,7 +70,7 @@ export const OAuthLoginHyperLinks = () => {
       setUserId(userId);
 
       if (role === "ROLE_NONE") {
-        navigate(ROUTER_PATH.SIGN_UP);
+        navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
         return;
       }
 

--- a/src/features/auth/ui/hyperlinks.tsx
+++ b/src/features/auth/ui/hyperlinks.tsx
@@ -56,7 +56,7 @@ export const OAuthLoginHyperLinks = () => {
 
   const navigate = useNavigate();
 
-  const setAuthorization = useAuthStore((state) => state.setAuthorization);
+  const setToken = useAuthStore((state) => state.setToken);
   const setRole = useAuthStore((state) => state.setRole);
   const setUserId = useAuthStore((state) => state.setUserId);
 
@@ -64,8 +64,8 @@ export const OAuthLoginHyperLinks = () => {
 
   const handleAuthResponse = useCallback(
     (authResponse: LoginResponse) => {
-      const { authorization, role, userId } = authResponse.content;
-      setAuthorization(authorization);
+      const { token, role, userId } = authResponse.content;
+      setToken(token);
       setRole(role);
       setUserId(userId);
 
@@ -77,7 +77,7 @@ export const OAuthLoginHyperLinks = () => {
       const { lastNoneAuthRoute } = useRouteHistoryStore.getState();
       navigate(lastNoneAuthRoute);
     },
-    [navigate, setAuthorization, setRole, setUserId],
+    [navigate, setToken, setRole, setUserId],
   );
 
   useEffect(() => {

--- a/src/features/auth/ui/hyperlinks.tsx
+++ b/src/features/auth/ui/hyperlinks.tsx
@@ -5,7 +5,7 @@ import { EmailIcon } from "@/shared/ui/icon";
 import { useRouteHistoryStore } from "@/shared/store/history";
 import { useAuthStore } from "@/shared/store/auth";
 import { ROUTER_PATH } from "@/shared/constants";
-import { useOauthLogin } from "../api";
+import { useGetOauthLogin } from "../api";
 import type { LoginResponse, OAuthServerName } from "../api";
 
 /* ----------------------------------컴포넌트 내부에서만 사용되는 컴포넌트------------------------------- */
@@ -59,15 +59,17 @@ export const OAuthLoginHyperLinks = () => {
   const setToken = useAuthStore((state) => state.setToken);
   const setRole = useAuthStore((state) => state.setRole);
   const setUserId = useAuthStore((state) => state.setUserId);
+  const setNickname = useAuthStore((state) => state.setNickname);
 
-  const { data: authResponse, error } = useOauthLogin(OAuthServerName);
+  const { data: authResponse, error } = useGetOauthLogin(OAuthServerName);
 
   const handleAuthResponse = useCallback(
     (authResponse: LoginResponse) => {
-      const { token, role, userId } = authResponse.content;
-      setToken(token);
+      const { authorization, role, userId, nickname } = authResponse.content;
+      setToken(authorization);
       setRole(role);
       setUserId(userId);
+      setNickname(nickname);
 
       if (role === "ROLE_NONE") {
         navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
@@ -77,7 +79,7 @@ export const OAuthLoginHyperLinks = () => {
       const { lastNoneAuthRoute } = useRouteHistoryStore.getState();
       navigate(lastNoneAuthRoute);
     },
-    [navigate, setToken, setRole, setUserId],
+    [navigate, setToken, setRole, setUserId, setNickname],
   );
 
   useEffect(() => {

--- a/src/shared/store/auth.ts
+++ b/src/shared/store/auth.ts
@@ -1,13 +1,15 @@
 import { create } from "zustand";
 
 type AuthStore = {
-  token: string;
-  role: string;
-  userId: number;
+  token: string | null;
+  role: string | null;
+  userId: number | null;
+  nickname: string | null;
 
-  setToken: (token: string) => void;
-  setRole: (role: string) => void;
-  setUserId: (userId: number) => void;
+  setToken: (token: string | null) => void;
+  setRole: (role: string | null) => void;
+  setUserId: (userId: number | null) => void;
+  setNickname: (nickname: string | null) => void;
 };
 
 /**
@@ -16,11 +18,13 @@ type AuthStore = {
  * role은 사용자의 권한을 나타냅니다.
  */
 export const useAuthStore = create<AuthStore>((set) => ({
-  token: "",
-  role: "",
-  userId: 0,
+  token: null,
+  role: null,
+  userId: null,
+  nickname: null,
 
-  setToken: (token: string) => set({ token }),
-  setRole: (role: string) => set({ role }),
-  setUserId: (userId: number) => set({ userId }),
+  setToken: (token: string | null) => set({ token }),
+  setRole: (role: string | null) => set({ role }),
+  setUserId: (userId: number | null) => set({ userId }),
+  setNickname: (nickname: string | null) => set({ nickname }),
 }));

--- a/src/shared/store/auth.ts
+++ b/src/shared/store/auth.ts
@@ -1,11 +1,11 @@
 import { create } from "zustand";
 
 type AuthStore = {
-  authorization: string;
+  token: string;
   role: string;
   userId: number;
 
-  setAuthorization: (token: string) => void;
+  setToken: (token: string) => void;
   setRole: (role: string) => void;
   setUserId: (userId: number) => void;
 };
@@ -16,11 +16,11 @@ type AuthStore = {
  * role은 사용자의 권한을 나타냅니다.
  */
 export const useAuthStore = create<AuthStore>((set) => ({
-  authorization: "",
+  token: "",
   role: "",
   userId: 0,
 
-  setAuthorization: (authorization: string) => set({ authorization }),
+  setToken: (token: string) => set({ token }),
   setRole: (role: string) => set({ role }),
   setUserId: (userId: number) => set({ userId }),
 }));

--- a/src/shared/store/auth.ts
+++ b/src/shared/store/auth.ts
@@ -1,9 +1,13 @@
 import { create } from "zustand";
+
 type AuthStore = {
-  token: string;
+  authorization: string;
   role: string;
-  setToken: (token: string) => void;
+  userId: number;
+
+  setAuthorization: (token: string) => void;
   setRole: (role: string) => void;
+  setUserId: (userId: number) => void;
 };
 
 /**
@@ -12,8 +16,11 @@ type AuthStore = {
  * role은 사용자의 권한을 나타냅니다.
  */
 export const useAuthStore = create<AuthStore>((set) => ({
-  token: "",
+  authorization: "",
   role: "",
-  setToken: (token: string) => set({ token }),
+  userId: 0,
+
+  setAuthorization: (authorization: string) => set({ authorization }),
   setRole: (role: string) => set({ role }),
+  setUserId: (userId: number) => set({ userId }),
 }));


### PR DESCRIPTION
# 관련 이슈 번호
close #80

# 설명

![image](https://github.com/user-attachments/assets/da0c8d5d-90ba-4d55-b2d5-5d081e0c719d)

해당 페이지에서 네이버 , 구글 OAuth 로그인 기능을 구현했습니다. 

### useOAuthLogin 

```tsx
/**
 * 해당 훅은 OAuthServerName이 주어지면 해당 OAuthServer로 로그인을 시도합니다.
 * 만약 OAuthServerName이 null일 경우엔 로그인을 시도하지 않습니다.
 */
export const useOauthLogin = (OAuthServerName: OAuthServerName | null) => {
  const isOauthLoginEnabled = OAuthServerName !== null;

  const query = useQuery<LoginResponse>({
    queryKey: ["OAuthLogin", OAuthServerName],
    queryFn: async () => {
      // 컴파일러에게 OAuthServerName이 null이 아님을 알려줍니다.
      const END_POINT = LOGIN_END_POINT[OAuthServerName!];
      const response = await fetch(END_POINT);
      if (!response.ok) {
        // TODO 에러 메시지 픽스하기
        throw new Error("예기치 못한 네트워크 오류가 발생했습니다.");
      }
      const data = await response.json();
      return data;
    },
    enabled: isOauthLoginEnabled,
  });

  return query;
};
```

해당 커스텀훅은 `props` 로 들어오는 `OAuthServerName` 을 통해 제어됩니다. 

`enabled` 로 해당 페이지에 들어와서 사용 할 `OAuth` 를 설정하지 않은 경우엔 쿼리문이 실행되지 않습니다. 

페이지에서 `OAuth` 버튼을 클릭하면 `useQuery` 문이 실행 되면서 액세스 토큰을 받아옵니다.

```tsx
export const OAuthLoginHyperLinks = () => {
  const [OAuthServerName, setOAuthServerName] =
    useState<OAuthServerName | null>(null);

  const navigate = useNavigate();

  const setAuthorization = useAuthStore((state) => state.setAuthorization);
  const setRole = useAuthStore((state) => state.setRole);
  const setUserId = useAuthStore((state) => state.setUserId);

  const { data: authResponse, error } = useOauthLogin(OAuthServerName);

  const handleAuthResponse = useCallback(
    (authResponse: LoginResponse) => {
       // 응답값에서 값을 꺼내와 스토어에 저장 
      const { authorization, role, userId } = authResponse.content;
      setAuthorization(authorization);
      setRole(role);
      setUserId(userId);

      // 만약 권한에서 개인정보 입력으로 보내야 하는 경우엔 개인 정보 페이지로 리다이렉션
      if (role === "ROLE_NONE") {
        navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
        return;
      }
     // 그렇지 않은 경우엔 로그인을 유발한 경로로 리다이렉션
      const { lastNoneAuthRoute } = useRouteHistoryStore.getState();
      navigate(lastNoneAuthRoute);
    },
    [navigate, setAuthorization, setRole, setUserId],
  );

  useEffect(() => {
    if (!authResponse) {
      return;
    }
    handleAuthResponse(authResponse);
  }, [authResponse, handleAuthResponse]);

  useEffect(() => {
    if (error instanceof Error) {
      // TODO 모달로 변경하기
      alert(error.message);
    }
    console.error(error);
  }, [error]);

  return (
    <>
      <NaverLoginHyperLink onClick={() => setOAuthServerName("NAVER")} />
      <GoogleLoginHyperLink onClick={() => setOAuthServerName("GOOGLE")} />
    </>
  );
};
```

최대한 `useEffect` 를 안쓰는 편으로 어떻게 하나 .. 싶었는데 버전5 되면서부턴 방법이 따로 없나봅니다 .. 더 찾아봐야겠습니다 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
