### PR TITLE
[Refactor] LoginForm 컴포넌트 리팩토링

### DIFF
--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -70,7 +70,7 @@ export const useLoginFormStore = create<LoginFormStore>((set) => ({
   password: "",
   persistLogin: false,
   isEmailNotValidate: false,
-  statusText: "",
+  statusText: "이메일 형식으로 입력해 주세요",
 
   setEmail: (email: string) => set({ email }),
   setPassword: (password: string) => set({ password }),

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -55,13 +55,13 @@ interface LoginFormStore {
   email: string;
   password: string;
   persistLogin: boolean;
-  isEmailNotValidate: boolean;
+  isNotValidEmail: boolean;
   statusText: string;
 
   setEmail: (email: string) => void;
   setPassword: (password: string) => void;
   setPersistLogin: (persistLogin: boolean) => void;
-  setIsEmailNotValidate: (isEmailValidate: boolean) => void;
+  setIsNotValidEmail: (isEmailValidate: boolean) => void;
   setStatusText: (statusText: string) => void;
 }
 
@@ -69,13 +69,12 @@ export const useLoginFormStore = create<LoginFormStore>((set) => ({
   email: "",
   password: "",
   persistLogin: false,
-  isEmailNotValidate: false,
+  isNotValidEmail: false,
   statusText: "이메일 형식으로 입력해 주세요",
 
   setEmail: (email: string) => set({ email }),
   setPassword: (password: string) => set({ password }),
   setPersistLogin: (persistLogin: boolean) => set({ persistLogin }),
-  setIsEmailNotValidate: (isEmailNotValidate: boolean) =>
-    set({ isEmailNotValidate }),
+  setIsNotValidEmail: (isNotValidEmail: boolean) => set({ isNotValidEmail }),
   setStatusText: (statusText: string) => set({ statusText }),
 }));

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -55,13 +55,13 @@ interface LoginFormStore {
   email: string;
   password: string;
   persistLogin: boolean;
-  isNotValidEmail: boolean;
+  isValidEmail: boolean;
   statusText: string;
 
   setEmail: (email: string) => void;
   setPassword: (password: string) => void;
   setPersistLogin: (persistLogin: boolean) => void;
-  setIsNotValidEmail: (isEmailValidate: boolean) => void;
+  setIsValidEmail: (isEmailValidate: boolean) => void;
   setStatusText: (statusText: string) => void;
 }
 
@@ -69,12 +69,12 @@ export const useLoginFormStore = create<LoginFormStore>((set) => ({
   email: "",
   password: "",
   persistLogin: false,
-  isNotValidEmail: false,
+  isValidEmail: true,
   statusText: "이메일 형식으로 입력해 주세요",
 
   setEmail: (email: string) => set({ email }),
   setPassword: (password: string) => set({ password }),
   setPersistLogin: (persistLogin: boolean) => set({ persistLogin }),
-  setIsNotValidEmail: (isNotValidEmail: boolean) => set({ isNotValidEmail }),
+  setIsValidEmail: (isValidEmail: boolean) => set({ isValidEmail }),
   setStatusText: (statusText: string) => set({ statusText }),
 }));

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -50,3 +50,32 @@ export const usePetInfoStore = create<PetInfoStore>((set) => ({
     }),
   setIntroduce: (introduce: string) => set({ introduce }),
 }));
+
+interface LoginFormStore {
+  email: string;
+  password: string;
+  persistLogin: boolean;
+  isEmailNotValidate: boolean;
+  statusText: string;
+
+  setEmail: (email: string) => void;
+  setPassword: (password: string) => void;
+  setPersistLogin: (persistLogin: boolean) => void;
+  setIsEmailNotValidate: (isEmailValidate: boolean) => void;
+  setStatusText: (statusText: string) => void;
+}
+
+export const useLoginFormStore = create<LoginFormStore>((set) => ({
+  email: "",
+  password: "",
+  persistLogin: false,
+  isEmailNotValidate: false,
+  statusText: "",
+
+  setEmail: (email: string) => set({ email }),
+  setPassword: (password: string) => set({ password }),
+  setPersistLogin: (persistLogin: boolean) => set({ persistLogin }),
+  setIsEmailNotValidate: (isEmailNotValidate: boolean) =>
+    set({ isEmailNotValidate }),
+  setStatusText: (statusText: string) => set({ statusText }),
+}));

--- a/src/features/auth/ui/LoginForm.stories.tsx
+++ b/src/features/auth/ui/LoginForm.stories.tsx
@@ -100,7 +100,6 @@ export const Default: StoryObj<typeof LoginForm> = {
 };
 
 const ApiTestComponent = () => {
-  const { token, role, nickname, userId } = useAuthStore((state) => state);
   return (
     <>
       <LoginForm.Form>
@@ -109,10 +108,6 @@ const ApiTestComponent = () => {
         <LoginForm.PersistLogin />
         <LoginForm.SubmitButton />
       </LoginForm.Form>
-      <p data-testid="token">{token}</p>
-      <p data-testid="role">{role}</p>
-      <p data-testid="nickname">{nickname}</p>
-      <p data-testid="userid">{userId}</p>
     </>
   );
 };
@@ -155,16 +150,12 @@ export const APISuccessTest: StoryObj<typeof LoginForm> = {
       name: "login-submit-button",
     });
 
-    const $token = canvas.getByTestId("token");
-    const $role = canvas.getByTestId("role");
-    const $nickname = canvas.getByTestId("nickname");
-    const $userId = canvas.getByTestId("userid");
-
     await step("API 요청이 일어나기 전까지 토큰은 존재하지 않는다.", () => {
-      expect($token).toHaveTextContent("");
-      expect($role).toHaveTextContent("");
-      expect($nickname).toHaveTextContent("");
-      expect($userId).toHaveTextContent("");
+      const { token, role, nickname, userId } = useAuthStore.getState();
+      expect(token).toBe(null);
+      expect(role).toBe(null);
+      expect(nickname).toBe(null);
+      expect(userId).toBe(null);
     });
 
     await userEvent.type($input, "abcd123@naver.com");
@@ -174,10 +165,11 @@ export const APISuccessTest: StoryObj<typeof LoginForm> = {
     await step("API 요청이 일어난 후에는 토큰에 값이 존재한다.", async () => {
       // 목업된 API 데이터를 받기 위한 딜레이 설정
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      expect($token).toHaveTextContent("Bearer token");
-      expect($role).toHaveTextContent("USER_USER");
-      expect($nickname).toHaveTextContent("뽀송이");
-      expect($userId).toHaveTextContent("1234");
+      const { token, role, nickname, userId } = useAuthStore.getState();
+      expect(token).toBe("Bearer token");
+      expect(role).toBe("USER_USER");
+      expect(nickname).toBe("뽀송이");
+      expect(userId).toBe(1234);
     });
   },
 };
@@ -220,16 +212,12 @@ export const APIFailedTest: StoryObj<typeof LoginForm> = {
       name: "login-submit-button",
     });
 
-    const $token = canvas.getByTestId("token");
-    const $role = canvas.getByTestId("role");
-    const $nickname = canvas.getByTestId("nickname");
-    const $userId = canvas.getByTestId("userid");
-
     await step("API 요청이 일어나기 전까지 토큰은 존재하지 않는다.", () => {
-      expect($token).toHaveTextContent("");
-      expect($role).toHaveTextContent("");
-      expect($nickname).toHaveTextContent("");
-      expect($userId).toHaveTextContent("");
+      const { token, role, nickname, userId } = useAuthStore.getState();
+      expect(token).toBe(null);
+      expect(role).toBe(null);
+      expect(nickname).toBe(null);
+      expect(userId).toBe(null);
     });
 
     await step("API 요청이 실패한 경우엔 상태가 변경되지 않는다.", async () => {
@@ -246,10 +234,12 @@ export const APIFailedTest: StoryObj<typeof LoginForm> = {
       // 목업된 API 데이터를 받기 위한 딜레이 설정
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      expect($token).toHaveTextContent("");
-      expect($role).toHaveTextContent("");
-      expect($nickname).toHaveTextContent("");
-      expect($userId).toHaveTextContent("");
+      const { token, role, nickname, userId } = useAuthStore.getState();
+      expect(token).toBe(null);
+      expect(role).toBe(null);
+      expect(nickname).toBe(null);
+      expect(userId).toBe(null);
+
       expect(alertMessage).toEqual("아이디 또는 비밀번호를 다시 확인해 주세요");
       window.alert = originalAlert;
     });

--- a/src/features/auth/ui/LoginForm.stories.tsx
+++ b/src/features/auth/ui/LoginForm.stories.tsx
@@ -1,13 +1,10 @@
+import { http, HttpResponse } from "msw";
 import { Meta, StoryObj } from "@storybook/react";
 import { LoginForm } from ".";
 import { within, userEvent, expect } from "@storybook/test";
+import { useAuthStore } from "@/shared/store/auth";
 const meta: Meta<typeof LoginForm> = {
   title: "features/auth/LoginForm",
-};
-
-export default meta;
-
-export const Default: StoryObj<typeof LoginForm> = {
   decorators: [
     (Story) => (
       <div className="w-96 border border-grey-300 px-2 py-2">
@@ -15,7 +12,11 @@ export const Default: StoryObj<typeof LoginForm> = {
       </div>
     ),
   ],
+};
 
+export default meta;
+
+export const Default: StoryObj<typeof LoginForm> = {
   render: () => (
     <LoginForm.Form>
       <LoginForm.Email />
@@ -95,5 +96,88 @@ export const Default: StoryObj<typeof LoginForm> = {
       expect(alertCalled).toBe(true);
     });
     window.alert = originalAlert;
+  },
+};
+
+const ApiTestComponent = () => {
+  const { token, role, nickname, userId } = useAuthStore((state) => state);
+  return (
+    <>
+      <LoginForm.Form>
+        <LoginForm.Email />
+        <LoginForm.Password />
+        <LoginForm.PersistLogin />
+        <LoginForm.SubmitButton />
+      </LoginForm.Form>
+      <p data-testid="token">{token}</p>
+      <p data-testid="role">{role}</p>
+      <p data-testid="nickname">{nickname}</p>
+      <p data-testid="userid">{userId}</p>
+    </>
+  );
+};
+
+export const APITest: StoryObj<typeof LoginForm> = {
+  decorators: (Story) => {
+    // 스토리 시작 전 스토어 초기화
+    useAuthStore.setState({
+      token: null,
+      role: null,
+      nickname: null,
+      userId: null,
+    });
+    return <Story />;
+  },
+  render: () => <ApiTestComponent />,
+  parameters: {
+    msw: {
+      handlers: [
+        http.post("http://localhost/login", () => {
+          return HttpResponse.json({
+            code: 200,
+            message: "success",
+            content: {
+              authorization: "Bearer token",
+              role: "USER_USER",
+              nickname: "뽀송이",
+              userId: 1234,
+            },
+          });
+        }),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const $input = canvas.getByLabelText("이메일-input");
+    const $password = canvas.getByLabelText("비밀번호-input");
+    const $submit = await canvas.getByRole("submit", {
+      name: "login-submit-button",
+    });
+
+    const $token = canvas.getByTestId("token");
+    const $role = canvas.getByTestId("role");
+    const $nickname = canvas.getByTestId("nickname");
+    const $userId = canvas.getByTestId("userid");
+
+    await step("API 요청이 일어나기 전까지 토큰은 존재하지 않는다.", () => {
+      expect($token).toHaveTextContent("");
+      expect($role).toHaveTextContent("");
+      expect($nickname).toHaveTextContent("");
+      expect($userId).toHaveTextContent("");
+    });
+
+    await userEvent.type($input, "abcd123@naver.com");
+    await userEvent.type($password, "password");
+    await userEvent.click($submit);
+
+    await step("API 요청이 일어난 후에는 토큰에 값이 존재한다.", async () => {
+      // 목업된 API 데이터를 받기 위한 딜레이 설정
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      expect($token).toHaveTextContent("Bearer token");
+      expect($role).toHaveTextContent("USER_USER");
+      expect($nickname).toHaveTextContent("뽀송이");
+      expect($userId).toHaveTextContent("1234");
+    });
   },
 };

--- a/src/features/auth/ui/LoginForm.stories.tsx
+++ b/src/features/auth/ui/LoginForm.stories.tsx
@@ -1,9 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
-import LoginForm from "./LoginForm";
+import { LoginForm } from ".";
 import { within, userEvent, expect } from "@storybook/test";
 const meta: Meta<typeof LoginForm> = {
   title: "features/auth/LoginForm",
-  component: LoginForm,
 };
 
 export default meta;
@@ -17,12 +16,22 @@ export const Default: StoryObj<typeof LoginForm> = {
     ),
   ],
 
-  render: () => <LoginForm />,
+  render: () => (
+    <LoginForm.Form>
+      <LoginForm.Email />
+      <LoginForm.Password />
+      <LoginForm.PersistLogin />
+      <LoginForm.SubmitButton />
+    </LoginForm.Form>
+  ),
 
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const $input = canvas.getByLabelText("이메일-input");
     const $p = await canvas.findByRole("status", { name: "status-text" });
+    const $submit = await canvas.getByRole("submit", {
+      name: "login-submit-button",
+    });
 
     const DEFAULT_STATUS_TEXT = "이메일 형식으로 입력해 주세요";
     const EMPTY_STATUS_TEXT = "이메일 형식으로 입력해 주세요";
@@ -42,36 +51,49 @@ export const Default: StoryObj<typeof LoginForm> = {
       },
     );
 
-    await userEvent.click($input);
     await step(
       "인풋 필드가 포커스 되면 p 태그의 문자는 이메일 형식으로 입력해 주세요 라는 안내 문구가 떠야 한다. ",
-      () => {
+      async () => {
+        await userEvent.click($input);
         expect($p).toHaveTextContent(EMPTY_STATUS_TEXT);
       },
     );
 
-    await userEvent.type($input, "test");
     await step(
       "이메일 유효성 검사를 통과하지 않는 문자가 나타나면 p 태그의 문자열은 올바른 이메일 형식으로 입력해 주세요 라는 안내 문구가 떠야 한다.",
-      () => {
+      async () => {
+        await userEvent.type($input, "test");
         expect($p).toHaveTextContent(ERROR_STATUS_TEXT);
       },
     );
 
-    await userEvent.type($input, "test123@naver.com");
     await step(
       "이메일 유효성 검사를 통과하는 문자가 나타나면 p 태그의 문자열은 빈 문자열이 되어야 한다.",
-      () => {
+      async () => {
+        await userEvent.type($input, "test123@naver.com");
         expect($p).toHaveTextContent("");
       },
     );
 
-    await userEvent.clear($input);
     await step(
       "인풋 필드가 비어 있으면 p 태그의 문자열은 이메일 형식으로 입력해 주세요 라는 안내 문구가 떠야 한다.",
-      () => {
+      async () => {
+        await userEvent.clear($input);
         expect($p).toHaveTextContent(DEFAULT_STATUS_TEXT);
       },
     );
+
+    // window.alert 목업하기
+    const originalAlert = window.alert;
+    let alertCalled = false;
+    window.alert = () => {
+      alertCalled = true;
+    };
+    // TODO 스낵바로 변경하여 테스트 하기
+    await step("유효성을 만족하지 않으면 alert 창이 떠야 한다.", async () => {
+      await userEvent.click($submit);
+      expect(alertCalled).toBe(true);
+    });
+    window.alert = originalAlert;
   },
 };

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -29,15 +29,15 @@ export const Email = () => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value: email } = e.currentTarget;
-    const isValidEmail = !new RegExp(
+    const isValidEmail = new RegExp(
       "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
     ).test(email);
     const isEmailEmpty = email.length === 0;
     const statusText = isEmailEmpty
       ? "이메일 형식으로 입력해 주세요"
       : isValidEmail
-        ? "올바른 이메일 형식으로 입력해 주세요"
-        : "";
+        ? ""
+        : "올바른 이메일 형식으로 입력해 주세요";
 
     setEmail(email);
     setStatusText(statusText);
@@ -113,7 +113,7 @@ export const SubmitButton = () => {
     const isEmailEmpty = email.length === 0;
     const isPasswordEmpty = password.length === 0;
 
-    if (isEmailEmpty || isPasswordEmpty || isValidEmail) {
+    if (isEmailEmpty || isPasswordEmpty || !isValidEmail) {
       // TODO : alert 창 모달로 변경하기
       alert("아이디 또는 비밀번호를 모두 입력해 주세요");
       // TODO : 유효성을 만족하지 않는 경우의 메시지를 디자이너와 상담하여 생성하기

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -1,88 +1,174 @@
 import { EmailInput, PasswordInput } from "@/entities/auth/ui";
 import { Button } from "@/shared/ui/button";
-import { useAuthStore } from "@/shared/store/auth";
-import { useLoginForm } from "../model";
+import { useLoginFormStore } from "../store";
 import { usePostLoginForm } from "../api";
+import { useAuthStore } from "@/shared/store/auth";
+import { useRouteHistoryStore } from "@/shared/store/history";
+import { useNavigate } from "react-router-dom";
 
-const LoginForm = () => {
-  const { loginForm, handler, formValidationResult } = useLoginForm();
-  const setToken = useAuthStore((state) => state.setToken);
-  const setRole = useAuthStore((state) => state.setRole);
-  const { mutate: postLoginForm } = usePostLoginForm();
-
-  const { email, password, persistLogin } = loginForm;
-  const { emailHasError, emailIsEmpty, emailStatusText } = formValidationResult;
-  const { handleChange, handlePersistLogin } = handler;
-  const passwordIsEmpty = password.length === 0;
-
+export const Form = ({ children }: { children: React.ReactNode }) => {
   return (
-    <form
-      className="flex flex-col items-start gap-4 self-stretch"
-      onSubmit={(e) => {
-        e.preventDefault();
-        // TODO : alert 창 모달로 변경하기
-        if (emailHasError || emailIsEmpty || passwordIsEmpty) {
-          alert("아이디 또는 비밀번호를 모두 입력해 주세요");
-          return;
-        }
-        postLoginForm(
-          { email, password, persistLogin },
-          {
-            onSuccess: (data) => {
-              const { authorization, role } = data.content;
-              setToken(authorization);
-              setRole(role);
-              // TODO 리다이렉션하기
-            },
-            onError: (error) => {
-              // TODO : alert 창 모달로 변경하기
-              alert(error.message);
-            },
-          },
-        );
-      }}
-    >
-      <EmailInput
-        id="email"
-        name="email"
-        label="이메일"
-        fullWidth
-        value={email}
-        onChange={handleChange}
-        isError={!emailIsEmpty && emailHasError}
-        statusText={emailStatusText}
-      />
-      <PasswordInput
-        id="password"
-        name="password"
-        label="비밀번호"
-        fullWidth
-        value={password}
-        onChange={handleChange}
-      />
-      <div className="flex items-center gap-1">
-        <input
-          type="checkbox"
-          id="rememberMe"
-          name="rememberMe"
-          onClick={handlePersistLogin}
-        />
-        <label htmlFor="rememberMe" className="btn-3 text-grey-700">
-          로그인 유지
-        </label>
-      </div>
-      <Button
-        colorType="primary"
-        size="large"
-        variant="filled"
-        role="submit"
-        aria-label="login-submit-button"
-        type="submit"
-      >
-        로그인
-      </Button>
+    <form className="flex flex-col items-start gap-4 self-stretch">
+      {children}
     </form>
   );
 };
 
-export default LoginForm;
+/**
+ * LoginForm.Email 컴포넌트는 이메일 입력값에 대한 에러 상태와 상태 메시지를 소모합니다.
+ * 직접적으로 email 상태를 소모하지 않음으로서 에러 상태와 상태 메시지 변경 유무에 따라서만 리렌더링이 일어납니다.
+ * 폼에서 email,  에러 상태 , 상태 메시지 상태를 변경 시킵니다.
+ */
+export const Email = () => {
+  const isEmailNotValidate = useLoginFormStore(
+    (state) => state.isEmailNotValidate,
+  );
+  const statusText = useLoginFormStore((state) => state.statusText);
+
+  const setEmail = useLoginFormStore((state) => state.setEmail);
+  const setStatusText = useLoginFormStore((state) => state.setStatusText);
+  const setIsEmailNotValidate = useLoginFormStore(
+    (state) => state.setIsEmailNotValidate,
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: email } = e.currentTarget;
+    const isEmailNotValidate = !new RegExp(
+      "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+    ).test(email);
+    const isEmailEmpty = email.length === 0;
+    const statusText = isEmailEmpty
+      ? "이메일 형식으로 입력해 주세요"
+      : isEmailNotValidate
+        ? "올바른 이메일 형식으로 입력해 주세요"
+        : "";
+
+    setEmail(email);
+    setStatusText(statusText);
+    setIsEmailNotValidate(!isEmailEmpty && isEmailNotValidate);
+  };
+
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    const isEmailEmpty = value.length === 0;
+    if (!isEmailEmpty) {
+      return;
+    }
+    setStatusText("이메일 형식으로 입력해 주세요");
+  };
+
+  return (
+    <EmailInput
+      id="email"
+      name="email"
+      label="이메일"
+      fullWidth
+      onChange={handleChange}
+      onFocus={handleFocus}
+      isError={isEmailNotValidate}
+      statusText={statusText}
+    />
+  );
+};
+
+export const Password = () => {
+  const setPassword = useLoginFormStore((state) => state.setPassword);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: password } = e.currentTarget;
+    setPassword(password);
+  };
+
+  return (
+    <PasswordInput
+      id="password"
+      name="password"
+      label="비밀번호"
+      fullWidth
+      onChange={handleChange}
+    />
+  );
+};
+
+export const PersistLogin = () => {
+  const setPersistLogin = useLoginFormStore((state) => state.setPersistLogin);
+
+  const handlePersistLogin = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { checked } = e.target;
+    setPersistLogin(checked);
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      <input
+        type="checkbox"
+        id="rememberMe"
+        name="rememberMe"
+        onChange={handlePersistLogin}
+      />
+      <label htmlFor="rememberMe" className="btn-3 text-grey-700">
+        로그인 유지
+      </label>
+    </div>
+  );
+};
+
+export const SubmitButton = () => {
+  const navigate = useNavigate();
+  const { mutate: postLoginForm } = usePostLoginForm();
+  const setToken = useAuthStore((state) => state.setToken);
+  const setRole = useAuthStore((state) => state.setRole);
+  const setUserId = useAuthStore((state) => state.setUserId);
+
+  const handleSubmit = () => {
+    const { email, password, isEmailNotValidate, persistLogin } =
+      useLoginFormStore.getState();
+    const isEmailEmpty = email.length === 0;
+    const isPasswordEmpty = password.length === 0;
+
+    if (isEmailEmpty || isPasswordEmpty || isEmailNotValidate) {
+      // TODO : alert 창 모달로 변경하기
+      alert("아이디 또는 비밀번호를 모두 입력해 주세요");
+      // TODO : 유효성을 만족하지 않는 경우의 메시지를 디자이너와 상담하여 생성하기
+      return;
+    }
+    postLoginForm(
+      { email, password, persistLogin },
+      {
+        onSuccess: (data) => {
+          const { authorization, role, userId } = data.content;
+          setToken(authorization);
+          setRole(role);
+          setUserId(userId);
+
+          const { lastNoneAuthRoute } = useRouteHistoryStore.getState();
+          navigate(lastNoneAuthRoute);
+        },
+        onError: (error) => {
+          if (error instanceof Error) {
+            // TODO : alert 창 모달로 변경하기
+            alert(error.message);
+          }
+          // 만약 alert 창이 아닌 콘솔 에러에서 에러 메시지가 표시되는 경우에는
+          // 현재 우리가 컨트롤하고 있지 않은 에러 객체가 발생한 것입니다.
+          // 에러를 보고 코드에 문제가 없는지 확인해봐야 합니다.
+          console.error(error);
+        },
+      },
+    );
+  };
+
+  return (
+    <Button
+      colorType="primary"
+      size="large"
+      variant="filled"
+      role="submit"
+      aria-label="login-submit-button"
+      type="button"
+      onClick={handleSubmit}
+    >
+      로그인
+    </Button>
+  );
+};

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -20,32 +20,28 @@ export const Form = ({ children }: { children: React.ReactNode }) => {
  * 폼에서 email,  에러 상태 , 상태 메시지 상태를 변경 시킵니다.
  */
 export const Email = () => {
-  const isEmailNotValidate = useLoginFormStore(
-    (state) => state.isNotValidEmail,
-  );
+  const isValidEmail = useLoginFormStore((state) => state.isValidEmail);
   const statusText = useLoginFormStore((state) => state.statusText);
 
   const setEmail = useLoginFormStore((state) => state.setEmail);
   const setStatusText = useLoginFormStore((state) => state.setStatusText);
-  const setIsNotValidEmail = useLoginFormStore(
-    (state) => state.setIsNotValidEmail,
-  );
+  const setIsValidEmail = useLoginFormStore((state) => state.setIsValidEmail);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value: email } = e.currentTarget;
-    const isEmailNotValidate = !new RegExp(
+    const isValidEmail = !new RegExp(
       "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
     ).test(email);
     const isEmailEmpty = email.length === 0;
     const statusText = isEmailEmpty
       ? "이메일 형식으로 입력해 주세요"
-      : isEmailNotValidate
+      : isValidEmail
         ? "올바른 이메일 형식으로 입력해 주세요"
         : "";
 
     setEmail(email);
     setStatusText(statusText);
-    setIsNotValidEmail(!isEmailEmpty && isEmailNotValidate);
+    setIsValidEmail(isEmailEmpty && isValidEmail);
   };
 
   return (
@@ -55,7 +51,7 @@ export const Email = () => {
       label="이메일"
       fullWidth
       onChange={handleChange}
-      isError={isEmailNotValidate}
+      isError={!isValidEmail}
       statusText={statusText}
     />
   );
@@ -112,12 +108,12 @@ export const SubmitButton = () => {
   const setNickname = useAuthStore((state) => state.setNickname);
 
   const handleSubmit = () => {
-    const { email, password, isNotValidEmail, persistLogin } =
+    const { email, password, isValidEmail, persistLogin } =
       useLoginFormStore.getState();
     const isEmailEmpty = email.length === 0;
     const isPasswordEmpty = password.length === 0;
 
-    if (isEmailEmpty || isPasswordEmpty || isNotValidEmail) {
+    if (isEmailEmpty || isPasswordEmpty || isValidEmail) {
       // TODO : alert 창 모달로 변경하기
       alert("아이디 또는 비밀번호를 모두 입력해 주세요");
       // TODO : 유효성을 만족하지 않는 경우의 메시지를 디자이너와 상담하여 생성하기

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -21,14 +21,14 @@ export const Form = ({ children }: { children: React.ReactNode }) => {
  */
 export const Email = () => {
   const isEmailNotValidate = useLoginFormStore(
-    (state) => state.isEmailNotValidate,
+    (state) => state.isNotValidEmail,
   );
   const statusText = useLoginFormStore((state) => state.statusText);
 
   const setEmail = useLoginFormStore((state) => state.setEmail);
   const setStatusText = useLoginFormStore((state) => state.setStatusText);
-  const setIsEmailNotValidate = useLoginFormStore(
-    (state) => state.setIsEmailNotValidate,
+  const setIsNotValidEmail = useLoginFormStore(
+    (state) => state.setIsNotValidEmail,
   );
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,7 +45,7 @@ export const Email = () => {
 
     setEmail(email);
     setStatusText(statusText);
-    setIsEmailNotValidate(!isEmailEmpty && isEmailNotValidate);
+    setIsNotValidEmail(!isEmailEmpty && isEmailNotValidate);
   };
 
   return (
@@ -112,12 +112,12 @@ export const SubmitButton = () => {
   const setNickname = useAuthStore((state) => state.setNickname);
 
   const handleSubmit = () => {
-    const { email, password, isEmailNotValidate, persistLogin } =
+    const { email, password, isNotValidEmail, persistLogin } =
       useLoginFormStore.getState();
     const isEmailEmpty = email.length === 0;
     const isPasswordEmpty = password.length === 0;
 
-    if (isEmailEmpty || isPasswordEmpty || isEmailNotValidate) {
+    if (isEmailEmpty || isPasswordEmpty || isNotValidEmail) {
       // TODO : alert 창 모달로 변경하기
       alert("아이디 또는 비밀번호를 모두 입력해 주세요");
       // TODO : 유효성을 만족하지 않는 경우의 메시지를 디자이너와 상담하여 생성하기

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -41,7 +41,7 @@ export const Email = () => {
 
     setEmail(email);
     setStatusText(statusText);
-    setIsValidEmail(isEmailEmpty && isValidEmail);
+    setIsValidEmail(isEmailEmpty || isValidEmail);
   };
 
   return (

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -48,15 +48,6 @@ export const Email = () => {
     setIsEmailNotValidate(!isEmailEmpty && isEmailNotValidate);
   };
 
-  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    const { value } = e.currentTarget;
-    const isEmailEmpty = value.length === 0;
-    if (!isEmailEmpty) {
-      return;
-    }
-    setStatusText("이메일 형식으로 입력해 주세요");
-  };
-
   return (
     <EmailInput
       id="email"
@@ -64,7 +55,6 @@ export const Email = () => {
       label="이메일"
       fullWidth
       onChange={handleChange}
-      onFocus={handleFocus}
       isError={isEmailNotValidate}
       statusText={statusText}
     />

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -119,6 +119,7 @@ export const SubmitButton = () => {
   const setToken = useAuthStore((state) => state.setToken);
   const setRole = useAuthStore((state) => state.setRole);
   const setUserId = useAuthStore((state) => state.setUserId);
+  const setNickname = useAuthStore((state) => state.setNickname);
 
   const handleSubmit = () => {
     const { email, password, isEmailNotValidate, persistLogin } =
@@ -136,10 +137,11 @@ export const SubmitButton = () => {
       { email, password, persistLogin },
       {
         onSuccess: (data) => {
-          const { authorization, role, userId } = data.content;
+          const { authorization, role, userId, nickname } = data.content;
           setToken(authorization);
           setRole(role);
           setUserId(userId);
+          setNickname(nickname);
 
           const { lastNoneAuthRoute } = useRouteHistoryStore.getState();
           navigate(lastNoneAuthRoute);

--- a/src/features/auth/ui/index.ts
+++ b/src/features/auth/ui/index.ts
@@ -1,5 +1,5 @@
 export * from "./hyperlinks";
 export { default as SignUpByEmailForm } from "./SignUpByEmailForm";
-export { default as LoginForm } from "./LoginForm";
+export * as LoginForm from "./LoginForm";
 export * from "./PetInfoForm";
 export { default as UserInfoRegistrationForm } from "./UserInfoRegistrationForm";

--- a/src/pages/login/email/page.tsx
+++ b/src/pages/login/email/page.tsx
@@ -8,7 +8,12 @@ const EmailLoginPage = () => {
       <h1 className="headline-3 self-stretch text-ellipsis text-center text-grey-900">
         이메일로 로그인
       </h1>
-      <LoginForm />
+      <LoginForm.Form>
+        <LoginForm.Email />
+        <LoginForm.Password />
+        <LoginForm.PersistLogin />
+        <LoginForm.SubmitButton />
+      </LoginForm.Form>
       <div className="flex flex-col items-center justify-center self-stretch">
         <p className="flex items-center justify-center self-stretch">
           <span className="title-3 text-center text-grey-500">


### PR DESCRIPTION
# 관련 이슈 번호
#86 
# 설명

하나의 거대한 `LoginForm` 컴포넌트를 `Form , Email , Password ...` 등으로 나눠 생성한 후 `useLoginFormStore` 의 상태값을 구독하도록 변경했습니다. 

이 때 `Form` 와 같이 동일한 컴포넌트 명을 사용하는 다른 파일에서 충돌이 일어나 다음과 같이 `index.ts` 를 수정하였습니다.

```tsx
export * as LoginForm from "./LoginForm";
```

기능상 변경된 부분은 한 가지 밖에 없습니다.

 예전엔 `useAuthStore` 에서 API 요청이 일어난 후  `nickname` 을 저장하지 않았는데 저장하도록 변경한 것 외에는 수정된 기능이 없습니다. 

# 테스트 코드 작성 

드디어 `msw` 와 `zustand` 를 이용해 테스트 코드를 작성해보았습니다 ! 

우선 스토리북 안에서 테스트코드를 사용하기 위한 컴포넌트를 생성해줬습니다.

```tsx
const ApiTestComponent = () => {
  const { token, role, nickname, userId } = useAuthStore((state) => state);
  return (
    <>
      <LoginForm.Form>
        <LoginForm.Email />
        <LoginForm.Password />
        <LoginForm.PersistLogin />
        <LoginForm.SubmitButton />
      </LoginForm.Form>
      <p data-testid="token">{token}</p>
      <p data-testid="role">{role}</p>
      <p data-testid="nickname">{nickname}</p>
      <p data-testid="userid">{userId}</p>
    </>
  );
};
```

이후 테스트 코드에서 해당 컴포넌트를 이용해 렌더링을 시행합니다. 스토리북에서 렌더링 되는 컴포넌트는 이제 `useAuthStore` 의 상태 값들을 구독하고 있는 컴포넌트입니다. 

`decorater` 에서 매번 테스트에 사용하는 스토어의 초기값들을 초기화 시켜줍니다. 

`jest` 였다면 `beforeAll , afterAll` 을 이용했겠지만 스토리북에선 존재하지 않아 `decorater` 에서 해줬습니다. (`afterAll` 같은 건 어떻게 구현 할지 , `play` 에서 마지막에 해줘야 하나 ? 싶긴 한데 찾아봐야겠습니다.)

이후 `msw` 에서 인터셉트 할 엔드포인트에 대한 `API` 주소를 적어주고 `response` 값을 적어줍니다.

> 직접 `HttpResponse` 를 사용하지 않고 콜백 함수에 존재하는 인수인 `req,res,ctx` 를 이용하는 방법도 있던데 , 우선 저는 제가 해봤던 방법으로 해봤습니다.

```tsx
export const APISuccessTest: StoryObj<typeof LoginForm> = {
  decorators: (Story) => {
    // 스토리 시작 전 스토어 초기화
    useAuthStore.setState({
      token: null,
      role: null,
      nickname: null,
      userId: null,
    });
    return <Story />;
  },
  render: () => <ApiTestComponent />,
  parameters: {
    msw: {
      handlers: [
        http.post("http://localhost/login", () => {
          return HttpResponse.json({
            code: 200,
            message: "success",
            content: {
              authorization: "Bearer token",
              role: "USER_USER",
              nickname: "뽀송이",
              userId: 1234,
            },
          });
        }),
      ],
    },
   ...
    play: async ({ canvasElement, step }) => {
    const canvas = within(canvasElement);
    const $input = canvas.getByLabelText("이메일-input");
    const $password = canvas.getByLabelText("비밀번호-input");
    const $submit = await canvas.getByRole("submit", {
      name: "login-submit-button",
    });

    const $token = canvas.getByTestId("token");
    const $role = canvas.getByTestId("role");
    const $nickname = canvas.getByTestId("nickname");
    const $userId = canvas.getByTestId("userid");

    await step("API 요청이 일어나기 전까지 토큰은 존재하지 않는다.", () => {
      expect($token).toHaveTextContent("");
      expect($role).toHaveTextContent("");
      expect($nickname).toHaveTextContent("");
      expect($userId).toHaveTextContent("");
    });

    await userEvent.type($input, "abcd123@naver.com");
    await userEvent.type($password, "password");
    await userEvent.click($submit);

    await step("API 요청이 일어난 후에는 토큰에 값이 존재한다.", async () => {
      // 목업된 API 데이터를 받기 위한 딜레이 설정
      await new Promise((resolve) => setTimeout(resolve, 1000));
      expect($token).toHaveTextContent("Bearer token");
      expect($role).toHaveTextContent("USER_USER");
      expect($nickname).toHaveTextContent("뽀송이");
      expect($userId).toHaveTextContent("1234");
    });
  },
};
  },
```

다음과 같이 인터셉트 하도록 테스트 한 후 `play` 함수에서 테스트를 시행합니다.

`msw` 를 사용하면 네트워크 창 뿐이 아니라 콘솔 로그 창에서도 이런 식으로 확인이 가능하더군요 ! 

![image](https://github.com/user-attachments/assets/e26cff8c-f334-440c-840e-788444b66874)

> 엔드포인트에선 `:80` 포트로 보내는데 스토리북에서 테스트 할 땐 포트 번호까지는 안나타더군요 ? 80번 포트라 기본 포트이기에 엔드포인트에 안적히나 싶긴 한데 `vite` 에선 엔드 포인트가 80번까지 나오던데 
>
> 잘 모르겠습니다 왠지는 

# 첨부 파일 (Optional)

![123123](https://github.com/user-attachments/assets/62c47d19-9b16-4285-a884-9584fed008c3)

# 레퍼런스 (Optional)
