### PR TITLE
[Feat] /sign-up/pet-info 페이지 API 기능 추가 

### DIFF
--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -56,6 +56,6 @@ const postPetInfo = async (formObject: PetInfoFormData) => {
 
 export const usePostPetInfo = () => {
   return useMutation<PetInfoResponse, Error, PetInfoFormData>({
-    mutationFn: (formData) => postPetInfo(formData),
+    mutationFn: postPetInfo,
   });
 };

--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -1,9 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
+import { SIGN_UP_END_POINT } from "../constants";
 
-export interface PetInfoReeponse {
+export interface PetInfoResponse {
   code: number;
   message: string;
-  contetn: {
+  content: {
     role: string;
   };
 }
@@ -11,6 +12,7 @@ export interface PetInfoReeponse {
 export interface PetInfoFormData {
   userId: number;
   name: string;
+  breed: string;
   personalities: string[];
   description: string;
   profile: File | null;
@@ -34,7 +36,7 @@ const postPetInfo = async (formObject: PetInfoFormData) => {
   formData.append("personalities", JSON.stringify(personalities));
   formData.append("description", description);
 
-  const response = await fetch("http://localhost:3000/pet", {
+  const response = await fetch(SIGN_UP_END_POINT.PET_INFO, {
     method: "POST",
     headers: {
       "Content-Type": "multipart/form-data",
@@ -53,7 +55,7 @@ const postPetInfo = async (formObject: PetInfoFormData) => {
 };
 
 export const usePostPetInfo = () => {
-  return useMutation<PetInfoReeponse, Error, PetInfoFormData>({
+  return useMutation<PetInfoResponse, Error, PetInfoFormData>({
     mutationFn: (formData) => postPetInfo(formData),
   });
 };

--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -13,14 +13,22 @@ interface PetInfoFormData {
   name: string;
   personalities: string[];
   description: string;
-  profile: File;
+  profile: File | null;
 }
 
 const postPetInfo = async (formObject: PetInfoFormData) => {
   const { userId, name, personalities, description, profile } = formObject;
 
   const formData = new FormData();
-  formData.append("profile", profile, `${name}-profile`);
+
+  // 이미지 파일은 파일 이름과 확장자를 붙혀 보내야 합니다.
+  if (profile) {
+    const profileExtension = profile.type.split("/")[1];
+    formData.append("profile", profile, `${name}-profile.${profileExtension}`);
+  } else {
+    formData.append("profile", "");
+  }
+
   formData.append("userid", userId.toString());
   formData.append("name", name);
   formData.append("personalities", JSON.stringify(personalities));

--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 
-interface PetInfoReeponse {
+export interface PetInfoReeponse {
   code: number;
   message: string;
   contetn: {
@@ -8,7 +8,7 @@ interface PetInfoReeponse {
   };
 }
 
-interface PetInfoFormData {
+export interface PetInfoFormData {
   userId: number;
   name: string;
   personalities: string[];

--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -1,0 +1,51 @@
+import { useMutation } from "@tanstack/react-query";
+
+interface PetInfoReeponse {
+  code: number;
+  message: string;
+  contetn: {
+    role: string;
+  };
+}
+
+interface PetInfoFormData {
+  userId: number;
+  name: string;
+  personalities: string[];
+  description: string;
+  profile: File;
+}
+
+const postPetInfo = async (formObject: PetInfoFormData) => {
+  const { userId, name, personalities, description, profile } = formObject;
+
+  const formData = new FormData();
+  formData.append("profile", profile, `${name}-profile`);
+  formData.append("userid", userId.toString());
+  formData.append("name", name);
+  formData.append("personalities", JSON.stringify(personalities));
+  formData.append("description", description);
+
+  const response = await fetch("http://localhost:3000/pet", {
+    method: "POST",
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      "예기치 못한 에러가 발생했습니다.잠시 후 다시 시도해주세요.",
+    );
+  }
+
+  const data = await response.json();
+  return data;
+};
+
+export const usePostPetInfo = () => {
+  return useMutation<PetInfoReeponse, Error, PetInfoFormData>({
+    mutationFn: (formData) => postPetInfo(formData),
+  });
+};

--- a/src/features/auth/constants/endpoint.ts
+++ b/src/features/auth/constants/endpoint.ts
@@ -8,4 +8,5 @@ export const LOGIN_END_POINT = {
 export const SIGN_UP_END_POINT = {
   EMAIL: "http://localhost:80/users",
   USER_INFO: (userId: number) => `/users/${userId}/additional-info`,
+  PET_INFO: "http://localhost:80/pet",
 };

--- a/src/features/auth/constants/endpoint.ts
+++ b/src/features/auth/constants/endpoint.ts
@@ -8,5 +8,5 @@ export const LOGIN_END_POINT = {
 export const SIGN_UP_END_POINT = {
   EMAIL: "http://localhost:80/users",
   USER_INFO: (userId: number) => `/users/${userId}/additional-info`,
-  PET_INFO: "http://localhost:80/pet",
+  PET_INFO: "http://localhost:80/pets",
 };

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -1,16 +1,14 @@
 import { create } from "zustand";
 
-const DEFAULT_PROFILE_IMAGE = "default-profile.svg";
-
 interface PetInfoStore {
-  profileImage: string;
+  profileImage: File | null;
   name: string;
   isValidName: boolean;
   breed: string;
   characterList: string[];
   introduce: string;
 
-  setProfileImage: (profileImage: string) => void;
+  setProfileImage: (profileImage: File | null) => void;
   setName: (name: string) => void;
   setIsValidName: (name: string) => void;
   setBreed: (greed: string) => void;
@@ -23,14 +21,14 @@ interface PetInfoStore {
  * origin/{파일명} 을 통해 public 폴더에 접근하는 파일에 접근 할 수 있습니다.
  */
 export const usePetInfoStore = create<PetInfoStore>((set) => ({
-  profileImage: `${window.location.origin}/${DEFAULT_PROFILE_IMAGE}`,
+  profileImage: null,
   name: "",
   isValidName: true,
   breed: "",
   characterList: [],
   introduce: "",
 
-  setProfileImage: (profileImage: string) => set({ profileImage }),
+  setProfileImage: (profileImage: File | null) => set({ profileImage }),
   setName: (name: string) => set({ name }),
   setIsValidName: (name: string) =>
     set(() => {

--- a/src/features/auth/ui/PetInfoForm.stories.tsx
+++ b/src/features/auth/ui/PetInfoForm.stories.tsx
@@ -30,7 +30,7 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
     msw: {
       // TODO 공식문서 보고 타입 선언 하기
       handlers: [
-        http.post("http://localhost/pet", async () => {
+        http.post("http://localhost/pets", async () => {
           return HttpResponse.json({
             code: 200,
             message: "success",

--- a/src/features/auth/ui/PetInfoForm.stories.tsx
+++ b/src/features/auth/ui/PetInfoForm.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import * as PetInfoForm from "./PetInfoForm";
-import { expect, userEvent, within } from "@storybook/test";
+import { expect, userEvent, waitFor, within } from "@storybook/test";
 import { usePetInfoStore } from "../store";
 import { useAuthStore } from "@/shared/store/auth";
 
@@ -181,6 +181,9 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
     });
 
     await step("submit 버튼 유효성 테스트", async () => {
+      // submit 하기 위해선 userId 가 필요하기 때문에 userId를 설정해줍니다.
+      useAuthStore.setState({ userId: 123 });
+
       const clearAll = async () => {
         await userEvent.clear($name);
         await userEvent.clear($textarea);
@@ -194,19 +197,16 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       window.alert = (message: string) => {
         alertMessage = message;
       };
-
       // 모든 입력 내용 지우기
-      await userEvent.clear($name);
-      await userEvent.clear($textarea);
-      await userEvent.clear($breed);
+      await clearAll();
 
       // 아무 내용도 입력하지 않고 submit 버튼을 누른 경우
       await step(
         "아무내용도 입력하지 않고 submit 버튼을 누르면 alert 창이 뜬다.",
         async () => {
+          alertMessage = "";
           await userEvent.click($submit);
           expect(alertMessage).toBe("필수 항목을 모두 입력해 주세요");
-          alertMessage = "";
         },
       );
 
@@ -214,10 +214,10 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       await step(
         "이름만 입력하고 submit 버튼을 누르면 alert 창이 뜬다.",
         async () => {
+          alertMessage = "";
           await userEvent.type($name, "초코");
           await userEvent.click($submit);
           expect(alertMessage).toBe("필수 항목을 모두 입력해 주세요");
-          alertMessage = "";
         },
       );
 
@@ -227,18 +227,20 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       await step(
         "이름이 유효성을 만족하지 않은 채로 submit 버튼을 누르면 alert 창이 뜬다.",
         async () => {
+          alertMessage = "";
           await userEvent.type($name, "123");
           await userEvent.click($submit);
           // TODO 유효성을 만족하지 않는 경우의 메시지 디자이너에게 확인
           expect(alertMessage).toBe("필수 항목을 모두 입력해 주세요");
-          alertMessage = "";
         },
       );
+
+      await clearAll();
 
       await step(
         "이름과 종을 유효성에 맞게 입력하고 submit 버튼을 누르면 alert 창이 뜨지 않는다.",
         async () => {
-          await userEvent.clear($name);
+          alertMessage = "";
           await userEvent.type($name, "초코");
           await userEvent.type($breed, "푸들");
           await userEvent.click($submit);
@@ -251,6 +253,7 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       await step(
         "이름을 유효성에 맞게 입력하고 breed 를 mix로 선택하고 submit 버튼을 누르면 alert 창이 뜨지 않는다.",
         async () => {
+          alertMessage = "";
           await userEvent.type($name, "초코");
           // breed를 mix 로 하였을 경우
           await userEvent.click($mix!);

--- a/src/features/auth/ui/PetInfoForm.stories.tsx
+++ b/src/features/auth/ui/PetInfoForm.stories.tsx
@@ -1,0 +1,175 @@
+import { Meta, StoryObj } from "@storybook/react";
+import * as PetInfoForm from "./PetInfoForm";
+import { http, HttpResponse } from "msw";
+import { expect, userEvent, within } from "@storybook/test";
+import { usePetInfoStore } from "../store";
+
+const _PetInfoForm = () => (
+  <PetInfoForm.Form>
+    <PetInfoForm.ProfileInput />
+    <PetInfoForm.NameInput />
+    <PetInfoForm.BreedInput />
+    <PetInfoForm.CharacterInput />
+    <PetInfoForm.IntroduceTextArea />
+    <PetInfoForm.SubmitButton />
+  </PetInfoForm.Form>
+);
+
+const meta: Meta<typeof _PetInfoForm> = {
+  title: "features/auth/PetInfoForm",
+  tags: ["autodocs"],
+  component: _PetInfoForm,
+};
+
+export default meta;
+
+// TODO 사진 업로드 기능은 어떻게 테스트 할 수 있을까?
+export const Default: StoryObj<typeof _PetInfoForm> = {
+  parameters: {
+    msw: {
+      handlers: async (req, res, ctx) => {
+        // request 를 가로채서 특정 url 일 때만 처리하도록 설정
+        if (req.url.pathname !== "/api/pet") {
+          return;
+        }
+        // 보낼 request의 형태 생성
+        const formData = new FormData();
+        formData.append("profile", new File([""], "profile.png"));
+        formData.append("userid", "123");
+        formData.append("name", "초코");
+        formData.append(
+          "personalities",
+          JSON.stringify(["호기심 많은", "애착이 강한"]),
+        );
+        formData.append("description", "안녕하세요");
+
+        await fetch("http://localhost:3000/pet", {
+          method: "POST",
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
+          body: formData,
+        });
+        const response = await res(
+          ctx.json({
+            code: 200,
+            message: "success",
+            content: {
+              role: "USER_USER",
+            },
+          }),
+        );
+        return response;
+      },
+    },
+  },
+
+  decorators: (Story) => {
+    usePetInfoStore.setState({
+      name: "",
+      isValidName: true,
+      breed: "",
+      characterList: [],
+      introduce: "",
+    });
+    return <Story />;
+  },
+
+  render: () => (
+    <div className="mx-auto w-96">
+      <PetInfoForm.Form>
+        <PetInfoForm.ProfileInput />
+        <PetInfoForm.NameInput />
+        <PetInfoForm.BreedInput />
+        <PetInfoForm.CharacterInput />
+        <PetInfoForm.IntroduceTextArea />
+        <PetInfoForm.SubmitButton />
+      </PetInfoForm.Form>
+    </div>
+  ),
+
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const $name = await canvas.getByLabelText("이름이 어떻게 되나요?-input");
+    const $statusText = await canvas.getAllByLabelText("status-text")[0];
+    const $breed = await canvas.getByLabelText("어떤 종의 아이인가요?-input");
+    const $mix = await canvasElement.querySelector("#isMixDog");
+    const $characterButton1 = canvas.queryByText("호기심 많은");
+    const $characterButton2 = canvas.queryByText("애착이 강한");
+    const $textarea = await canvas.getByLabelText(
+      "간단히 소개해 주세요-textarea",
+    );
+    const $submit = await canvas.getByText("등록하기");
+
+    step("모든 컴포넌트들이 Actual DOM에 존재한다.", () => {
+      expect($name).toBeInTheDocument();
+      expect($breed).toBeInTheDocument();
+      expect($mix).toBeInTheDocument();
+      expect($characterButton1).toBeInTheDocument();
+      expect($characterButton2).toBeInTheDocument();
+      expect($textarea).toBeInTheDocument();
+      expect($submit).toBeInTheDocument();
+    });
+
+    await step(
+      "한글 혹은 영문이 아닌 문자를 입력하면 에러 메시지가 나타난다.",
+      async () => {
+        await userEvent.type($name, "123");
+        await expect($statusText).toHaveClass("text-pink-500");
+        await userEvent.clear($name);
+        await userEvent.type($name, "ㄱㄴㄷ");
+        await expect($statusText).toHaveClass("text-pink-500");
+        await userEvent.clear($name);
+      },
+    );
+
+    await step(
+      "이름에 특수 문자를 입력하면 문자가 입력되지 않는다.",
+      async () => {
+        await userEvent.type($name, "abc!");
+        await expect($name).toHaveValue("abc");
+        await userEvent.clear($name);
+      },
+    );
+
+    await step("이름은 최대 글자는 20글자만 입력 된다.", async () => {
+      const maxName = "가".repeat(20);
+      const extraName = "나";
+      await userEvent.type($name, maxName + extraName);
+      await expect($name).toHaveValue(maxName);
+      await userEvent.clear($name);
+    });
+
+    // TODO : 바텀 시트 도입 시 테스트 코드 추가하기
+    await step(
+      "종 입력란에 모르겠어요를 체크하면 입력란이 비활성화 된다.",
+      async () => {
+        await userEvent.click($mix!);
+        expect($breed).toBeDisabled();
+        await userEvent.click($mix!);
+        expect($breed).not.toBeDisabled();
+      },
+    );
+
+    // 종 입력
+    await userEvent.type($breed, "푸들");
+
+    /**
+     * 단위테스트를 시행한 셀레트 칩에 대한 테스트 코드는 진행하지 않습니다.
+     */
+
+    // 캐릭터 버튼 클릭
+    await userEvent.click($characterButton1!);
+    await userEvent.click($characterButton2!);
+
+    step(
+      "간단히 소개해주세요 란은 최대 150자의 글을 입력 할 수 있다.",
+      async () => {
+        const maxIntroduce = "안녕하세요".repeat(30);
+        const extraIntroduce = "나";
+        await userEvent.type($textarea, maxIntroduce + extraIntroduce);
+        await expect($textarea).toHaveValue(maxIntroduce);
+      },
+    );
+  },
+};

--- a/src/features/auth/ui/PetInfoForm.stories.tsx
+++ b/src/features/auth/ui/PetInfoForm.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
 import * as PetInfoForm from "./PetInfoForm";
-import { http, HttpResponse } from "msw";
 import { expect, userEvent, within } from "@storybook/test";
 import { usePetInfoStore } from "../store";
+import { useAuthStore } from "@/shared/store/auth";
 
 const _PetInfoForm = () => (
   <PetInfoForm.Form>
@@ -27,6 +27,7 @@ export default meta;
 export const Default: StoryObj<typeof _PetInfoForm> = {
   parameters: {
     msw: {
+      // TODO 공식문서 보고 타입 선언 하기
       handlers: async (req, res, ctx) => {
         // request 를 가로채서 특정 url 일 때만 처리하도록 설정
         if (req.url.pathname !== "/api/pet") {
@@ -72,6 +73,11 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       characterList: [],
       introduce: "",
     });
+
+    useAuthStore.setState({
+      userId: 1,
+    });
+
     return <Story />;
   },
 
@@ -111,65 +117,224 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       expect($submit).toBeInTheDocument();
     });
 
-    await step(
-      "한글 혹은 영문이 아닌 문자를 입력하면 에러 메시지가 나타난다.",
-      async () => {
-        await userEvent.type($name, "123");
-        await expect($statusText).toHaveClass("text-pink-500");
-        await userEvent.clear($name);
-        await userEvent.type($name, "ㄱㄴㄷ");
-        await expect($statusText).toHaveClass("text-pink-500");
-        await userEvent.clear($name);
-      },
-    );
+    await step("기본 기능 테스트", async () => {
+      await step(
+        "한글 혹은 영문이 아닌 문자를 입력하면 에러 메시지가 나타난다.",
+        async () => {
+          await userEvent.type($name, "123");
+          await expect($statusText).toHaveClass("text-pink-500");
+          await userEvent.clear($name);
+          await userEvent.type($name, "ㄱㄴㄷ");
+          await expect($statusText).toHaveClass("text-pink-500");
+          await userEvent.clear($name);
+        },
+      );
 
-    await step(
-      "이름에 특수 문자를 입력하면 문자가 입력되지 않는다.",
-      async () => {
-        await userEvent.type($name, "abc!");
-        await expect($name).toHaveValue("abc");
-        await userEvent.clear($name);
-      },
-    );
+      await step(
+        "이름에 특수 문자를 입력하면 문자가 입력되지 않는다.",
+        async () => {
+          await userEvent.type($name, "abc!");
+          await expect($name).toHaveValue("abc");
+          await userEvent.clear($name);
+        },
+      );
 
-    await step("이름은 최대 글자는 20글자만 입력 된다.", async () => {
-      const maxName = "가".repeat(20);
-      const extraName = "나";
-      await userEvent.type($name, maxName + extraName);
-      await expect($name).toHaveValue(maxName);
-      await userEvent.clear($name);
+      await step("이름은 최대 글자는 20글자만 입력 된다.", async () => {
+        const maxName = "가".repeat(20);
+        const extraName = "나";
+        await userEvent.type($name, maxName + extraName);
+        await expect($name).toHaveValue(maxName);
+        await userEvent.clear($name);
+      });
+
+      // TODO : 바텀 시트 도입 시 테스트 코드 추가하기
+      await step(
+        "종 입력란에 모르겠어요를 체크하면 입력란이 비활성화 된다.",
+        async () => {
+          await userEvent.click($mix!);
+          expect($breed).toBeDisabled();
+          await userEvent.click($mix!);
+          expect($breed).not.toBeDisabled();
+        },
+      );
+
+      // 종 입력
+      await userEvent.type($breed, "푸들");
+
+      /**
+       * 단위테스트를 시행한 셀레트 칩에 대한 테스트 코드는 진행하지 않습니다.
+       */
+
+      // 캐릭터 버튼 클릭
+      await userEvent.click($characterButton1!);
+      await userEvent.click($characterButton2!);
+
+      await step(
+        "간단히 소개해주세요 란은 최대 150자의 글을 입력 할 수 있다.",
+        async () => {
+          const maxIntroduce = "안녕하세요".repeat(30);
+          const extraIntroduce = "나";
+          await userEvent.type($textarea, maxIntroduce + extraIntroduce);
+          await expect($textarea).toHaveValue(maxIntroduce);
+        },
+      );
     });
 
-    // TODO : 바텀 시트 도입 시 테스트 코드 추가하기
-    await step(
-      "종 입력란에 모르겠어요를 체크하면 입력란이 비활성화 된다.",
-      async () => {
+    await step("submit 버튼 유효성 테스트", async () => {
+      const clearAll = async () => {
+        await userEvent.clear($name);
+        await userEvent.clear($textarea);
+        await userEvent.clear($breed);
+      };
+
+      // TODO 스낵바 생성되면 테스트 코드 변경하기
+      // alert 창 목업
+      let alertMessage = "";
+      const originalAlert = window.alert;
+      window.alert = (message: string) => {
+        alertMessage = message;
+      };
+
+      // 모든 입력 내용 지우기
+      await userEvent.clear($name);
+      await userEvent.clear($textarea);
+      await userEvent.clear($breed);
+
+      // 아무 내용도 입력하지 않고 submit 버튼을 누른 경우
+      await step(
+        "아무내용도 입력하지 않고 submit 버튼을 누르면 alert 창이 뜬다.",
+        async () => {
+          await userEvent.click($submit);
+          expect(alertMessage).toBe("필수 항목을 모두 입력해 주세요");
+          alertMessage = "";
+        },
+      );
+
+      // 이름만 입력 한 경우
+      await step(
+        "이름만 입력하고 submit 버튼을 누르면 alert 창이 뜬다.",
+        async () => {
+          await userEvent.type($name, "초코");
+          await userEvent.click($submit);
+          expect(alertMessage).toBe("필수 항목을 모두 입력해 주세요");
+          alertMessage = "";
+        },
+      );
+
+      await clearAll();
+
+      // 이름이 유효성을 만족하지 않는 경우
+      await step(
+        "이름이 유효성을 만족하지 않은 채로 submit 버튼을 누르면 alert 창이 뜬다.",
+        async () => {
+          await userEvent.type($name, "123");
+          await userEvent.click($submit);
+          // TODO 유효성을 만족하지 않는 경우의 메시지 디자이너에게 확인
+          expect(alertMessage).toBe("필수 항목을 모두 입력해 주세요");
+          alertMessage = "";
+        },
+      );
+
+      await step(
+        "이름과 종을 유효성에 맞게 입력하고 submit 버튼을 누르면 alert 창이 뜨지 않는다.",
+        async () => {
+          await userEvent.clear($name);
+          await userEvent.type($name, "초코");
+          await userEvent.type($breed, "푸들");
+          await userEvent.click($submit);
+          expect(alertMessage).toBe("");
+        },
+      );
+
+      await clearAll();
+
+      await step(
+        "이름을 유효성에 맞게 입력하고 breed 를 mix로 선택하고 submit 버튼을 누르면 alert 창이 뜨지 않는다.",
+        async () => {
+          await userEvent.type($name, "초코");
+          // breed를 mix 로 하였을 경우
+          await userEvent.click($mix!);
+          await userEvent.click($submit);
+          expect(alertMessage).toBe("");
+          await userEvent.click($mix!);
+        },
+      );
+
+      window.alert = originalAlert;
+    });
+
+    await step("폼 데이터가 상태에 잘 저장되는지 테스트", async () => {
+      const clearAll = async () => {
+        await userEvent.clear($name);
+        await userEvent.clear($textarea);
+        await userEvent.clear($breed);
+
+        const { characterList } = usePetInfoStore.getState();
+        characterList.forEach((character) => {
+          if (character === "호기심 많은") {
+            userEvent.click($characterButton1!);
+          }
+          if (character === "애착이 강한") {
+            userEvent.click($characterButton2!);
+          }
+        });
+      };
+
+      await clearAll();
+
+      await step(
+        "input , textarea 에 적은 내용은 상태에 잘 저장된다.",
+        async () => {
+          await userEvent.type($name, "초코");
+          await userEvent.type($breed, "푸들");
+          await userEvent.type(
+            $textarea,
+            "안녕하세요 너무 귀여운 강아지 입니다.",
+          );
+          await userEvent.click($submit);
+          const { name, breed, introduce } = usePetInfoStore.getState();
+          expect(name).toBe("초코");
+          expect(breed).toBe("푸들");
+          expect(introduce).toBe("안녕하세요 너무 귀여운 강아지 입니다.");
+        },
+      );
+
+      await step("mix 를 선택 했을 때 상태에 mix로 잘 저장된다.", async () => {
         await userEvent.click($mix!);
-        expect($breed).toBeDisabled();
+        const { breed } = usePetInfoStore.getState();
+        expect(breed).toBe("mix");
         await userEvent.click($mix!);
-        expect($breed).not.toBeDisabled();
-      },
-    );
+      });
 
-    // 종 입력
-    await userEvent.type($breed, "푸들");
+      await step(
+        "성격란을 클릭하지 않았을 때 상태에는 아무런 값도 저장되지 않는다.",
+        async () => {
+          const { characterList } = usePetInfoStore.getState();
+          expect(characterList).toEqual([]);
+        },
+      );
 
-    /**
-     * 단위테스트를 시행한 셀레트 칩에 대한 테스트 코드는 진행하지 않습니다.
-     */
+      await step("성격란을 클릭하면 상태엔 값이 적절히 저장된다.", async () => {
+        await userEvent.click($characterButton1!);
 
-    // 캐릭터 버튼 클릭
-    await userEvent.click($characterButton1!);
-    await userEvent.click($characterButton2!);
+        await expect(usePetInfoStore.getState().characterList[0]).toEqual(
+          "호기심 많은",
+        );
 
-    step(
-      "간단히 소개해주세요 란은 최대 150자의 글을 입력 할 수 있다.",
-      async () => {
-        const maxIntroduce = "안녕하세요".repeat(30);
-        const extraIntroduce = "나";
-        await userEvent.type($textarea, maxIntroduce + extraIntroduce);
-        await expect($textarea).toHaveValue(maxIntroduce);
-      },
-    );
+        await userEvent.click($characterButton2!);
+        await expect(usePetInfoStore.getState().characterList[1]).toEqual(
+          "애착이 강한",
+        );
+
+        // 이미 있는 것을 클릭 한 경우엔 폼에서 해당 값이 사라진다.
+        await userEvent.click($characterButton1!);
+        await expect(usePetInfoStore.getState().characterList).toEqual([
+          "애착이 강한",
+        ]);
+
+        // 선택한 버튼 초기화
+        await userEvent.click($characterButton2!);
+      });
+    });
   },
 };

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -218,7 +218,7 @@ export const SubmitButton = () => {
     const isNameEmpty = name.length === 0;
     const isBreedEmpty = breed.length === 0;
 
-    if (isValidName && isNameEmpty && isBreedEmpty) {
+    if (!isValidName || isNameEmpty || isBreedEmpty) {
       alert("필수 항목을 모두 입력해 주세요");
       return;
     }

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -47,25 +47,29 @@ export const ProfileInput = () => {
   const setProfileImage = usePetInfoStore((state) => state.setProfileImage);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
+  // 상태에 저장된 파일 객체가 존재하는 경우엔 파일 객체를 URL로 변경하여 사용합니다.
+  // 만약 파일 객체가 존재하지 않는 경우 기본 이미지를 제공합니다.
+  const profileUrl = profileImage
+    ? URL.createObjectURL(profileImage)
+    : `${window.location.origin}/${DEFAULT_PROFILE_IMAGE}`;
+
   const handleInputClick = () => {
     inputRef.current?.click();
   };
 
   // type이 file인 input에게 파일이 존재하는 경우엔 Blob URL을 생성하여 프로필 이미지로 설정합니다.
   // 만약 사진이 존재하지 않는 경우 기본 이미지를 제공합니다.
+  // TODO 바텀 시트가 생성되고 사진 선택하기 , 삭제 기능이 추가되면 로직을 변경해야 합니다.
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    const profileImage = file
-      ? URL.createObjectURL(file)
-      : `${window.location.origin}${DEFAULT_PROFILE_IMAGE}`;
-    setProfileImage(profileImage);
+    setProfileImage(file || null);
   };
 
   return (
     <div
       className="flex h-20 w-20 flex-shrink items-end justify-end rounded-[28px] bg-tangerine-500 bg-cover bg-center bg-no-repeat"
       style={{
-        backgroundImage: `url(${profileImage})`,
+        backgroundImage: `url(${profileUrl})`,
       }}
     >
       <input

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -93,6 +93,15 @@ export const NameInput = () => {
 
   const MAX_LENGTH = 20;
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    // 한글,영문,숫자가 아닌 경우 true 를 반환하는 정규식
+    const regex = /[^가-힣a-zA-Z0-9ㄱ-ㅎ\s]/g;
+    const filteredName = value.replace(regex, "");
+    setName(filteredName);
+    setIsValidName(filteredName);
+  };
+
   return (
     <Input
       componentType="outlinedText"
@@ -102,11 +111,7 @@ export const NameInput = () => {
       maxLength={MAX_LENGTH}
       trailingNode={<TextCounter text={name} maxLength={MAX_LENGTH} />}
       value={name}
-      onChange={(e) => {
-        const { value } = e.target;
-        setName(value);
-        setIsValidName(value);
-      }}
+      onChange={handleChange}
       isError={!isNameEmpty && !isValidName}
       statusText="20자 이내의 한글 영문의 이름을 입력해 주세요"
       essential

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -8,6 +8,8 @@ import { useAuthStore } from "@/shared/store/auth";
 import { usePetInfoStore } from "../store";
 import { characterList } from "../constants/form";
 import { usePostPetInfo } from "../api/petinfo";
+import { useNavigate } from "react-router-dom";
+import { useRouteHistoryStore } from "@/shared/store/history";
 
 // TODO svg 경로를 문자열로 가져오는 방법 찾아보기
 const DEFAULT_PROFILE_IMAGE = "default-profile.svg";
@@ -204,7 +206,7 @@ export const SubmitButton = () => {
    * getState() 는 호출 시점의 store 를 가져오기 떄문에 클릭이 일어난 시점의 상태 값들을 가져 올 수 있습니다.
    * getState() 로 인해 반환되는 store 자체는 불변하기 때문에 store 내부 상태들이 변경되어도 리렌더링이 일어나지 않습니다.
    */
-
+  const navigate = useNavigate();
   const userId = useAuthStore((state) => state.userId);
   const setRole = useAuthStore((state) => state.setRole);
   const { mutate: postPetInfo } = usePostPetInfo();
@@ -242,7 +244,10 @@ export const SubmitButton = () => {
       {
         onSuccess: (data) => {
           const { role } = data.content;
+          const { lastNoneAuthRoute } = useRouteHistoryStore.getState();
+
           setRole(role);
+          navigate(lastNoneAuthRoute);
         },
         // TODO 에러 바운더리 생성되면 로직 변경하기
         onError: (error) => {

--- a/src/features/auth/ui/index.ts
+++ b/src/features/auth/ui/index.ts
@@ -1,5 +1,5 @@
 export * from "./hyperlinks";
 export { default as SignUpByEmailForm } from "./SignUpByEmailForm";
 export * as LoginForm from "./LoginForm";
-export * from "./PetInfoForm";
+export * as PetInfoForm from "./PetInfoForm";
 export { default as UserInfoRegistrationForm } from "./UserInfoRegistrationForm";

--- a/src/pages/sign-up/pet-info/page.tsx
+++ b/src/pages/sign-up/pet-info/page.tsx
@@ -1,5 +1,5 @@
 import { CloseNavigationBar } from "@/widgets/navigationbar/ui";
-import * as PetInfoForm from "@/features/auth/ui";
+import { PetInfoForm } from "@/features/auth/ui";
 
 const PetInfoPage = () => {
   return (

--- a/src/shared/ui/chip/SelectChip.tsx
+++ b/src/shared/ui/chip/SelectChip.tsx
@@ -18,7 +18,6 @@ export const SelectChip = ({
 
   // 제어컴포넌트와 비제어컴포넌트를 구분하는 boolean 변수를 선언합니다.
   const isUncontrolled = typeof controlledIsSelected === "undefined";
-
   // 제어 컴포넌트와 비제어컴포넌트의 경우를 구분하여 내부에서 스타일에 사용할 state인 chipState를 결정합니다.
   const isSelected = isUncontrolled
     ? unControlledIsSelected
@@ -30,7 +29,6 @@ export const SelectChip = ({
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (isUncontrolled) {
       setIsUnControlledIsSelected((prev) => !prev);
-      return;
     }
     onClick?.(e);
   };


### PR DESCRIPTION
# 관련 이슈 번호
#89
# 설명
### 테스트 코드
작성한 테스트 코드 목록은 다음과 같습니다.
- 기본 기능 테스트
  - [x] 한글 혹은 영문이 아닌 문자를 입력하면 에러 메시지가 나타난다.
  - [x] 이름에 특수 문자를 입력하면 문자가 입력되지 않는다.
  - [x] 이름은 최대 글자는 20글자만 입력 된다.
  - [x] 종 입력란에 모르겠어요를 체크하면 입력란이 비활성화 된다.
  - [x] 간단히 소개해주세요 란은 최대 150자의 글을 입력 할 수 있다.

- submit 버튼 유효성 테스트
  - [x] 아무내용도 입력하지 않고 submit 버튼을 누르면 alert 창이 뜬다.
  - [x] 이름만 입력하고 submit 버튼을 누르면 alert 창이 뜬다.
  - [x] 이름이 유효성을 만족하지 않은 채로 submit 버튼을 누르면 alert 창이 뜬다.
  - [x] 이름과 종을 유효성에 맞게 입력하고 submit 버튼을 누르면 alert 창이 뜨지 않는다.
  - [x] 이름을 유효성에 맞게 입력하고 breed 를 mix로 선택하고 submit 버튼을 누르면 alert 창이 뜨지 않는다.

- 폼 데이터가 상태에 잘 저장되는지 테스트
  - [x] input, textarea에 적은 내용은 상태에 잘 저장된다.
  - [x] mix를 선택했을 때 상태에 mix로 잘 저장된다.
  - [x] 성격란을 클릭하지 않았을 때 상태에는 아무런 값도 저장되지 않는다.
  - [x] 성격란을 클릭하면 상태엔 값이 적절히 저장된다.

- 올바른 API 요청이 전송되면 role에 값이 저장된다.
  - [x] 올바른 API 요청이 전송되면 role에 값이 저장된다.

### 기능상 변경점 

![image](https://github.com/user-attachments/assets/9cd76ebc-087b-4baf-b7b2-d2036bfd6901)

테스트 코드를 작성하다보니 유효성 검사 부분의 로직이 잘못된 것을 확인하여 수정하였습니다.

![image](https://github.com/user-attachments/assets/791de74a-096a-4d8b-b3f7-a8e302a69af9)

기본 `shared` 내부에 존재하던 `SelectChip` 컴포넌트에서 `unControlled` 일 경우 `props` 로 전달받은 `onClick` 메소드를 실행하지 못하고 있어서 해당 부분을 수정했습니다.

![image](https://github.com/user-attachments/assets/811a2e3e-146e-4032-af01-04c3125465b4)

`usePetInfoForm` 부분에서 `ProfileImage` 를 `url` 형태의 `string` 으로 저장하던 부분에서 `File` 객체 혹은 삭제 하였을 떄를 대비하여 `null` 타입을 받도록 수정했습니다.

이를 통해 `usePostPetInfo` 부분에서 `mutationFn` 에 해당하는 부분에서 `File` 객체를 올바르게 전송 할 수 있도록 다음과 같이 수정했습니다.

![image](https://github.com/user-attachments/assets/76a19265-bd37-4ce0-9972-83014469e028)
![image](https://github.com/user-attachments/assets/f6529470-e027-4bb4-998c-dc72a764086b)
![image](https://github.com/user-attachments/assets/026e7ca9-f7fd-4f55-909c-ccc439ecc0c8)

`PetInfoForm` 에서 해당 부분을 렌더링 하는 방식에서도 `File` 형태의 상태를 받아 `url` 형태로 변경하여 백그라운드에 렌더링 하도록 수정하였습니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
