### PR TITLE
[Feat] 페이지 라우팅 경로 수정

### DIFF
--- a/src/app/MobileLayout.tsx
+++ b/src/app/MobileLayout.tsx
@@ -1,0 +1,7 @@
+export const MobileLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="mx-auto my-0 min-h-[3.25rem] w-full min-w-80 max-w-[37.5rem]">
+      {children}
+    </div>
+  );
+};

--- a/src/app/QueryClient.tsx
+++ b/src/app/QueryClient.tsx
@@ -3,7 +3,11 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const queryClient = new QueryClient();
 
-const ReactQueryProvider = ({ children }: { children: React.ReactNode }) => {
+export const ReactQueryProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
@@ -11,5 +15,3 @@ const ReactQueryProvider = ({ children }: { children: React.ReactNode }) => {
     </QueryClientProvider>
   );
 };
-
-export default ReactQueryProvider;

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,0 +1,4 @@
+export * from "./HistoryTracker";
+export * from "./MobileLayout";
+export * from "./QueryClient";
+export * from "./router";

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -6,6 +6,7 @@ import { SignUpPage } from "@/pages/sign-up";
 import { EmailLoginPage } from "@/pages/login/email";
 import PetInfoPage from "@/pages/sign-up/pet-info/page";
 import { UserInfoRegistrationPage } from "@/pages/sign-up/user-info";
+import { HistoryTracker } from "./HistoryTracker";
 
 export const router = createBrowserRouter([
   {
@@ -16,43 +17,46 @@ export const router = createBrowserRouter([
         index: true,
         element: <MainPage />,
       },
-
+    ],
+  },
+  {
+    path: ROUTER_PATH.LOGIN,
+    element: <LoginLayout />,
+    children: [
       {
-        path: ROUTER_PATH.LOGIN,
-        element: <LoginLayout />,
-        children: [
-          {
-            index: true,
-            element: <LoginPage />,
-          },
-          {
-            path: "email",
-            element: <EmailLoginPage />,
-          },
-          {
-            path: "forgot-password",
-            element: <div>forgot-password</div>,
-          },
-        ],
+        index: true,
+        element: <LoginPage />,
       },
-
       {
-        path: ROUTER_PATH.SIGN_UP,
-        element: <Outlet />,
-        children: [
-          {
-            index: true,
-            element: <SignUpPage />,
-          },
-          {
-            path: "user-info",
-            element: <UserInfoRegistrationPage />,
-          },
-          {
-            path: ROUTER_PATH.SIGN_UP_PET_INFO,
-            element: <PetInfoPage />,
-          },
-        ],
+        path: "email",
+        element: <EmailLoginPage />,
+      },
+      {
+        path: "forgot-password",
+        element: <div>forgot-password</div>,
+      },
+    ],
+  },
+  {
+    path: ROUTER_PATH.SIGN_UP,
+    element: (
+      <>
+        <HistoryTracker />
+        <Outlet />
+      </>
+    ),
+    children: [
+      {
+        index: true,
+        element: <SignUpPage />,
+      },
+      {
+        path: "user-info",
+        element: <UserInfoRegistrationPage />,
+      },
+      {
+        path: ROUTER_PATH.SIGN_UP_PET_INFO,
+        element: <PetInfoPage />,
       },
     ],
   },

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -28,11 +28,11 @@ export const router = createBrowserRouter([
         element: <LoginPage />,
       },
       {
-        path: "email",
+        path: ROUTER_PATH.LOGIN_BY_EMAIL,
         element: <EmailLoginPage />,
       },
       {
-        path: "forgot-password",
+        path: ROUTER_PATH.FORGET_PASSWORD,
         element: <div>forgot-password</div>,
       },
     ],
@@ -51,7 +51,7 @@ export const router = createBrowserRouter([
         element: <SignUpPage />,
       },
       {
-        path: "user-info",
+        path: ROUTER_PATH.SIGN_UP_USER_INFO,
         element: <UserInfoRegistrationPage />,
       },
       {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,13 +2,14 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./global.css";
 import { RouterProvider } from "react-router-dom";
-import { router } from "./app/router";
-import ReactQueryProvider from "./app/QueryClient";
+import { ReactQueryProvider, MobileLayout, router } from "./app";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ReactQueryProvider>
-      <RouterProvider router={router} />
+      <MobileLayout>
+        <RouterProvider router={router} />
+      </MobileLayout>
     </ReactQueryProvider>
   </StrictMode>,
 );

--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -1,10 +1,8 @@
 import { Outlet } from "react-router-dom";
-import { HistoryTracker } from "@/app/HistoryTracker";
 const MainLayout = () => {
   return (
     // TODO 레이아웃 범위 디자이너와 상의 후 픽스하기
-    <div className="mx-auto my-0 min-h-[3.25rem] w-full min-w-80 max-w-[37.5rem]">
-      <HistoryTracker />
+    <div>
       <Outlet />
     </div>
   );

--- a/src/pages/login/email/email.stories.tsx
+++ b/src/pages/login/email/email.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
 import MainLayout from "@/pages/layout";
-import LoginLayout from "../layout";
 import { Routes, Route } from "react-router-dom";
 
 import EmailLoginPage from "./page";

--- a/src/pages/login/email/email.stories.tsx
+++ b/src/pages/login/email/email.stories.tsx
@@ -26,9 +26,7 @@ export const Default: Story = {
   render: () => (
     <Routes>
       <Route element={<MainLayout />}>
-        <Route element={<LoginLayout />}>
-          <Route index element={<EmailLoginPage />} />
-        </Route>
+        <Route index element={<EmailLoginPage />} />
       </Route>
     </Routes>
   ),

--- a/src/pages/login/layout.tsx
+++ b/src/pages/login/layout.tsx
@@ -1,6 +1,12 @@
+import { HistoryTracker } from "@/app";
+import { BackwardNavigationBar } from "@/widgets/navigationbar/ui";
 import { Outlet } from "react-router-dom";
 const LoginLayout = () => (
   <>
+    <HistoryTracker />
+    <header>
+      <BackwardNavigationBar />
+    </header>
     <main className="flex flex-col items-start gap-8 self-stretch px-4 pb-32 pt-8">
       <Outlet />
     </main>

--- a/src/pages/login/login.stories.tsx
+++ b/src/pages/login/login.stories.tsx
@@ -1,8 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
-import LoginLayout from "./layout";
 import LoginPage from "./page";
 import { Routes, Route } from "react-router-dom";
-import MainLayout from "../layout";
 
 const meta: Meta = {
   title: "Pages/login",
@@ -17,7 +15,9 @@ const meta: Meta = {
   decorators: [
     (Story) => (
       <div className="w-96 border border-grey-300">
-        <Story />
+        <main className="flex flex-col items-start gap-8 self-stretch px-4 pb-32 pt-8">
+          <Story />
+        </main>
       </div>
     ),
   ],
@@ -28,11 +28,7 @@ export default meta;
 export const Default: StoryObj = {
   render: () => (
     <Routes>
-      <Route element={<MainLayout />}>
-        <Route element={<LoginLayout />}>
-          <Route index element={<LoginPage />} />
-        </Route>
-      </Route>
+      <Route index element={<LoginPage />} />
     </Routes>
   ),
 };

--- a/src/pages/login/page.tsx
+++ b/src/pages/login/page.tsx
@@ -3,7 +3,7 @@ import { OAuthLoginHyperLinks, EmailLoginHyperLink } from "@/features/auth/ui";
 
 const LoginPage = () => (
   <>
-    <header className="flex flex-col items-center justify-center gap-2 self-stretch">
+    <section className="flex flex-col items-center justify-center gap-2 self-stretch">
       <h1 className="headline-3 overflow-ellipsis text-center text-grey-900">
         로그인 및 회원가입
       </h1>
@@ -11,7 +11,7 @@ const LoginPage = () => (
         <span>반려동물과 함께한 특별한 장소를</span>
         <span>마킹하고 공유하세요</span>
       </p>
-    </header>
+    </section>
     <div className="flex flex-col items-start gap-4 self-stretch">
       <OAuthLoginHyperLinks />
       <EmailLoginHyperLink />

--- a/src/widgets/navigationbar/ui/BackwardNavigationBar.tsx
+++ b/src/widgets/navigationbar/ui/BackwardNavigationBar.tsx
@@ -9,7 +9,7 @@ const BackWardButton = (props: React.HTMLAttributes<HTMLButtonElement>) => {
 
   return (
     <Button
-      size="large"
+      size="medium"
       variant="text"
       colorType="tertiary"
       onClick={onClick || (() => navigate(-1))}


### PR DESCRIPTION
# 관련 이슈 번호
#93 
# 설명
![image](https://github.com/user-attachments/assets/1dae8a70-7251-41f6-a620-0f6dbffd7e4d)
![image](https://github.com/user-attachments/assets/d3fd50a0-996f-4dcc-9497-1c2206b94814)
![image](https://github.com/user-attachments/assets/a3781a08-50b0-4981-b2d9-f8591447e67a)

메인 페이지와 , 로그인 , 로그아웃 경로들이 공유해야 하는 레이아웃이 다르기 때문이 `/` 경로의 `children` 으로 `/ , /login , /sign-up` 주소들을 담는 현재의 상황에서 수정이 필요했습니다.

그래서 다음과 같이 수정했습니다.

```tsx
// main.tsx
createRoot(document.getElementById("root")!).render(
  <StrictMode>
    <ReactQueryProvider>
      <MobileLayout> // 전체 화면을 모바일 크기로 만드는 레이아웃 (이전의 div 태그)
        <RouterProvider router={router} />
      </MobileLayout>
    </ReactQueryProvider>
  </StrictMode>,
);
```

모든 레이아웃이 공유해야 하는 내용들은 `main.tsx` 에서 정의해주었습니다.

`router.ts` 파일에서 파일들은 다음과 같은 모습을 갖습니다.

```
- /
  - [발견 , 지도 , 커뮤니티, 기록 ]
- /login
- /sign-up
```


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
