### PR TITLE
[Feat] Authorization 기능 변화에 따른 userId걷어내기

### DIFF
--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { SIGN_UP_END_POINT } from "../constants";
+import type { AuthStore } from "@/shared/store/auth";
 
 export interface PetInfoResponse {
   code: number;
@@ -10,7 +11,6 @@ export interface PetInfoResponse {
 }
 
 export interface PetInfoFormData {
-  token: string;
   name: string;
   breed: string;
   personalities: string[];
@@ -18,8 +18,16 @@ export interface PetInfoFormData {
   profile: File | null;
 }
 
-const postPetInfo = async (formObject: PetInfoFormData) => {
-  const { token, name, personalities, description, profile } = formObject;
+interface PostPetInfoArgs {
+  token: NonNullable<AuthStore["token"]>;
+  formObject: PetInfoFormData;
+}
+
+const postPetInfo = async ({
+  token,
+  formObject,
+}: PostPetInfoArgs): Promise<PetInfoResponse> => {
+  const { name, personalities, description, profile } = formObject;
 
   const formData = new FormData();
 
@@ -55,7 +63,7 @@ const postPetInfo = async (formObject: PetInfoFormData) => {
 };
 
 export const usePostPetInfo = () => {
-  return useMutation<PetInfoResponse, Error, PetInfoFormData>({
+  return useMutation<PetInfoResponse, Error, PostPetInfoArgs>({
     mutationFn: postPetInfo,
   });
 };

--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -11,7 +11,6 @@ export interface PetInfoResponse {
 
 export interface PetInfoFormData {
   token: string;
-  userId: number;
   name: string;
   breed: string;
   personalities: string[];
@@ -20,8 +19,7 @@ export interface PetInfoFormData {
 }
 
 const postPetInfo = async (formObject: PetInfoFormData) => {
-  const { token, userId, name, personalities, description, profile } =
-    formObject;
+  const { token, name, personalities, description, profile } = formObject;
 
   const formData = new FormData();
 
@@ -33,7 +31,6 @@ const postPetInfo = async (formObject: PetInfoFormData) => {
     formData.append("profile", "");
   }
 
-  formData.append("userid", userId.toString());
   formData.append("name", name);
   formData.append("personalities", JSON.stringify(personalities));
   formData.append("description", description);

--- a/src/features/auth/ui/LoginForm.stories.tsx
+++ b/src/features/auth/ui/LoginForm.stories.tsx
@@ -119,7 +119,6 @@ export const APISuccessTest: StoryObj<typeof LoginForm> = {
       token: null,
       role: null,
       nickname: null,
-      userId: null,
     });
     return <Story />;
   },
@@ -151,11 +150,10 @@ export const APISuccessTest: StoryObj<typeof LoginForm> = {
     });
 
     await step("API 요청이 일어나기 전까지 토큰은 존재하지 않는다.", () => {
-      const { token, role, nickname, userId } = useAuthStore.getState();
+      const { token, role, nickname } = useAuthStore.getState();
       expect(token).toBe(null);
       expect(role).toBe(null);
       expect(nickname).toBe(null);
-      expect(userId).toBe(null);
     });
 
     await userEvent.type($input, "abcd123@naver.com");
@@ -165,11 +163,10 @@ export const APISuccessTest: StoryObj<typeof LoginForm> = {
     await step("API 요청이 일어난 후에는 토큰에 값이 존재한다.", async () => {
       // 목업된 API 데이터를 받기 위한 딜레이 설정
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      const { token, role, nickname, userId } = useAuthStore.getState();
+      const { token, role, nickname } = useAuthStore.getState();
       expect(token).toBe("Bearer token");
       expect(role).toBe("USER_USER");
       expect(nickname).toBe("뽀송이");
-      expect(userId).toBe(1234);
     });
   },
 };
@@ -181,7 +178,6 @@ export const APIFailedTest: StoryObj<typeof LoginForm> = {
       token: null,
       role: null,
       nickname: null,
-      userId: null,
     });
     return <Story />;
   },
@@ -213,11 +209,10 @@ export const APIFailedTest: StoryObj<typeof LoginForm> = {
     });
 
     await step("API 요청이 일어나기 전까지 토큰은 존재하지 않는다.", () => {
-      const { token, role, nickname, userId } = useAuthStore.getState();
+      const { token, role, nickname } = useAuthStore.getState();
       expect(token).toBe(null);
       expect(role).toBe(null);
       expect(nickname).toBe(null);
-      expect(userId).toBe(null);
     });
 
     await step("API 요청이 실패한 경우엔 상태가 변경되지 않는다.", async () => {
@@ -234,11 +229,10 @@ export const APIFailedTest: StoryObj<typeof LoginForm> = {
       // 목업된 API 데이터를 받기 위한 딜레이 설정
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      const { token, role, nickname, userId } = useAuthStore.getState();
+      const { token, role, nickname } = useAuthStore.getState();
       expect(token).toBe(null);
       expect(role).toBe(null);
       expect(nickname).toBe(null);
-      expect(userId).toBe(null);
 
       expect(alertMessage).toEqual("아이디 또는 비밀번호를 다시 확인해 주세요");
       window.alert = originalAlert;

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -104,7 +104,6 @@ export const SubmitButton = () => {
   const { mutate: postLoginForm } = usePostLoginForm();
   const setToken = useAuthStore((state) => state.setToken);
   const setRole = useAuthStore((state) => state.setRole);
-  const setUserId = useAuthStore((state) => state.setUserId);
   const setNickname = useAuthStore((state) => state.setNickname);
 
   const handleSubmit = () => {
@@ -123,10 +122,9 @@ export const SubmitButton = () => {
       { email, password, persistLogin },
       {
         onSuccess: (data) => {
-          const { authorization, role, userId, nickname } = data.content;
+          const { authorization, role, nickname } = data.content;
           setToken(authorization);
           setRole(role);
-          setUserId(userId);
           setNickname(nickname);
 
           const { lastNoneAuthRoute } = useRouteHistoryStore.getState();

--- a/src/features/auth/ui/PetInfoForm.stories.tsx
+++ b/src/features/auth/ui/PetInfoForm.stories.tsx
@@ -53,7 +53,6 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
     });
 
     useAuthStore.setState({
-      userId: 1,
       token: "Bearer token",
     });
 
@@ -178,9 +177,6 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
     });
 
     await step("submit 버튼 유효성 테스트", async () => {
-      // submit 하기 위해선 userId 가 필요하기 때문에 userId를 설정해줍니다.
-      useAuthStore.setState({ userId: 123 });
-
       const clearAll = async () => {
         await userEvent.clear($name);
         await userEvent.clear($textarea);

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -235,11 +235,13 @@ export const SubmitButton = () => {
     postPetInfo(
       {
         token,
-        name,
-        breed,
-        personalities: characterList,
-        description: introduce,
-        profile: profileImage,
+        formObject: {
+          name,
+          breed,
+          personalities: characterList,
+          description: introduce,
+          profile: profileImage,
+        },
       },
       {
         onSuccess: (data) => {

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -215,7 +215,7 @@ export const SubmitButton = () => {
     // TODO refactor : 유효성 검사 메소드 만들어 사용하기
     const { isValidName, name, breed, characterList, introduce, profileImage } =
       petInfoForm;
-    const { userId, token } = useAuthStore.getState();
+    const { token } = useAuthStore.getState();
 
     const isNameEmpty = name.length === 0;
     const isBreedEmpty = breed.length === 0;
@@ -226,16 +226,15 @@ export const SubmitButton = () => {
     }
     // TODO 엔드포인트 양식 정해지면 API 요청 기능 추가하기
 
-    if (!userId || !token) {
+    if (!token) {
       throw new Error(
-        "userId가 없거나 token이 존재하지 않는다면 해당 페이지에 접속 할 수 없습니다. 페이지에 접속 할 수 있는 권한의 범위를 확인하세요",
+        "토큰이 없다면 해당 페이지에 접근할 수 없습니다. 토큰이 존재하는지 확인해주세요",
       );
     }
 
     postPetInfo(
       {
         token,
-        userId,
         name,
         breed,
         personalities: characterList,

--- a/src/shared/store/auth.ts
+++ b/src/shared/store/auth.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-type AuthStore = {
+export type AuthStore = {
   token: string | null;
   role: string | null;
   nickname: string | null;

--- a/src/shared/store/auth.ts
+++ b/src/shared/store/auth.ts
@@ -3,12 +3,10 @@ import { create } from "zustand";
 type AuthStore = {
   token: string | null;
   role: string | null;
-  userId: number | null;
   nickname: string | null;
 
   setToken: (token: string | null) => void;
   setRole: (role: string | null) => void;
-  setUserId: (userId: number | null) => void;
   setNickname: (nickname: string | null) => void;
 };
 
@@ -20,11 +18,9 @@ type AuthStore = {
 export const useAuthStore = create<AuthStore>((set) => ({
   token: null,
   role: null,
-  userId: null,
   nickname: null,
 
   setToken: (token: string | null) => set({ token }),
   setRole: (role: string | null) => set({ role }),
-  setUserId: (userId: number | null) => set({ userId }),
   setNickname: (nickname: string | null) => set({ nickname }),
 }));


### PR DESCRIPTION
# 관련 이슈 번호
#109 

# 설명
2024/09/05 에 결정된 API 명세서 변경에 따라 다음과 같은 사항들이 변경되었습니다.

1. `useAuthStore` 에서 `userId , setUserId`  부분이 제거 되었습니다.
2. `/login` 경로에서 사용되는 `LoginForm` 컴포넌트에서 더 이상 `userId` 를 스토어에 저장하지 않습니다.
3. `/sign-up/pet-info` 에서 `POST` 요청을 보낼 때 더 이상 `userId` 를 이용해 유효성 검증을 하지 않습니다.
4. `/sign-up/pet-info` 에서 `POST` 요청을 보낼 때 더 이상 `userId` 를 전송하지 않습니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
