### PR TITLE
[Feat] auth 도메인에서 사용할 SelectOpener 컴포넌트 수정

### DIFF
--- a/src/entities/auth/ui/SelectOpener.stories.tsx
+++ b/src/entities/auth/ui/SelectOpener.stories.tsx
@@ -1,0 +1,124 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { SelectOpener } from "./SelectOpener";
+import { useState } from "react";
+import { Select } from "@/shared/ui/select";
+import { expect, fireEvent, waitFor, within, fn } from "@storybook/test";
+
+const meta: Meta = {
+  title: "entities/auth/SelectOpener",
+  component: SelectOpener,
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      description: "label을 나타냅니다.",
+      control: {
+        type: "text",
+      },
+    },
+    essential: {
+      description: "필수 여부를 나타냅니다.",
+      control: {
+        type: "boolean",
+      },
+    },
+    placeholder: {
+      description: "placeholder를 나타냅니다.",
+      control: {
+        type: "text",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SelectOpener>;
+
+export const Default: Story = {
+  args: {
+    label: "label",
+    essential: false,
+    placeholder: "placeholder",
+    value: "",
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    const $label = canvas.getByText("label");
+    const $opener = canvas.getByRole("button", {
+      name: /placeholder/i,
+    });
+
+    // 오프너 클릭 이벤트 핸들러 모킹
+    const handleOpenerClick = fn();
+    $opener.onclick = handleOpenerClick;
+
+    await step("label을 클릭하면, button이 포커스되고 클릭된다.", async () => {
+      fireEvent.click($label);
+
+      await waitFor(() => {
+        expect($opener).toHaveFocus();
+        expect(handleOpenerClick).toHaveBeenCalled();
+      });
+    });
+  },
+};
+
+export const Example: Story = {
+  render: () => {
+    const genderOptionList = [
+      {
+        value: "MALE",
+        name: "남자",
+      },
+      {
+        value: "FEMALE",
+        name: "여자",
+      },
+    ] as const;
+
+    /* eslint-disable */
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const [selectedValue, setSelectedValue] = useState<
+      "FEMALE" | "MALE" | null
+    >(null);
+
+    const selectedName = genderOptionList.find(
+      (option) => option.value === selectedValue,
+    )?.name;
+
+    return (
+      <div>
+        <SelectOpener
+          label="성별"
+          essential={true}
+          placeholder="성별을 선택해 주세요"
+          value={selectedName ?? ""}
+          disabled={false}
+          onClick={() => setIsOpen(!isOpen)}
+        />
+
+        <Select isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <Select.BottomSheet>
+            <Select.OptionList>
+              {genderOptionList.map(({ value, name }) => {
+                return (
+                  <Select.Option
+                    key={value}
+                    value={value}
+                    isSelected={value === selectedValue}
+                    onClick={() => {
+                      setSelectedValue(value);
+                    }}
+                  >
+                    {name}
+                  </Select.Option>
+                );
+              })}
+            </Select.OptionList>
+          </Select.BottomSheet>
+        </Select>
+      </div>
+    );
+  },
+};

--- a/src/entities/auth/ui/SelectOpener.tsx
+++ b/src/entities/auth/ui/SelectOpener.tsx
@@ -1,19 +1,57 @@
+import { Badge } from "@/shared/ui/badge";
 import { ArrowDropDownIcon } from "@/shared/ui/icon";
-import { Input, InputProps } from "@/shared/ui/input/Input";
+import { ButtonHTMLAttributes, useRef } from "react";
 
-type FixedInputProps = "type" | "componentType" | "readOnly" | "trailingNode";
+interface SelectOpenerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  essential?: boolean;
+  placeholder?: string;
+}
 
 export const SelectOpener = ({
+  label,
+  essential = false,
+  placeholder = "",
+  value,
+  disabled,
   ...props
-}: Omit<InputProps, FixedInputProps>) => {
+}: SelectOpenerProps) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const handleLabelClick = () => {
+    buttonRef.current?.focus();
+    buttonRef.current?.click();
+  };
+
+  const isValueEmpty = value === undefined || value === "";
+
+  const baseStyles =
+    "body-2 flex h-12 w-full items-center justify-between gap-1 rounded-2xl border px-3 py-2 ";
+  const colorStyles =
+    "border-grey-300 bg-grey-0 hover:border-grey-500 hover:bg-grey-100 focus:border-tangerine-500 focus:bg-grey-0 focus-visible:outline-none disabled:border-grey-100 disabled:bg-grey-0";
+  const textStyles = `body-2 ${disabled ? "text-grey-300" : !isValueEmpty ? "text-grey-700" : "text-grey-500"}`;
+
   return (
-    <Input
-      type="text"
-      trailingNode={<ArrowDropDownIcon />}
-      componentType="outlinedText"
-      readOnly
-      style={{ cursor: "pointer" }}
-      {...props}
-    />
+    <div>
+      {/* label */}
+      <div
+        className="flex w-fit cursor-pointer gap-1 pb-2"
+        onClick={handleLabelClick}
+      >
+        <p className="title-3 text-grey-700">{label}</p>
+        {essential && <Badge colorType="primary" />}
+      </div>
+
+      {/* trigger */}
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`${baseStyles} ${colorStyles} ${textStyles}`}
+        {...props}
+      >
+        <span>{isValueEmpty ? placeholder : value}</span>
+        <ArrowDropDownIcon />
+      </button>
+    </div>
   );
 };


### PR DESCRIPTION
# 관련 이슈 번호

#66 

# 설명

## 변경된 점

이전에는 **Input 컴포넌트**를 이용하여 만들었으나, 클릭 범위가 제한되어 있어 아이콘을 클릭해도 Select 컴포넌트가 열리지 않는 문제가 있었습니다. (#113 참고)

![image](https://github.com/user-attachments/assets/f321791b-dfa2-41ae-90eb-a5b04a40e6a7)

기존의 Input 컴포넌트를 이용하지 않고, 새로운 컴포넌트를 만들기로 하였습니다.

## 구성

### ui

크게 2가지로 구성되어 있어요. 사진에서 위에는 label, 밑에는 button입니다.

<img width="620" alt="스크린샷 2024-09-07 오후 6 10 46" src="https://github.com/user-attachments/assets/094d762a-5aea-4e30-b6f7-54a7d774e057">


#### 1. label
  - label 부분을 클릭하면 button에 focus되고 클릭됩니다.

https://github.com/user-attachments/assets/cc96d9d9-d830-45ce-a5c7-b3e85e233ef2

#### 2. button: Select 컴포넌트를 여는 trigger


### props

props는 button 태그의 attributes를 기반으로 하고 있습니다.

- label: label에 표시할 텍스트 (필수)
- essential: 필수로 옵션을 선택해야하는지
- placeholder: 맨 처음 button에 표시할 설명 문구
- value: button에 표시할 선택한 옵션 텍스트
- disabled: 비활성화 여부




