### PR TITLE
[Feat] 지도에 나타날 커스텀 마커 UI 생성

### DIFF
--- a/src/entities/map/ui/CustomMarker.tsx
+++ b/src/entities/map/ui/CustomMarker.tsx
@@ -37,22 +37,22 @@ export const MultiplePin = ({
   position,
   imageUrl,
   alt,
-  amount,
-}: GooglePinProps & { amount: number }) => {
+  markerCount,
+}: GooglePinProps & { markerCount: number }) => {
   return (
     <AdvancedMarker position={position}>
-      <_Pin.Multiple imageUrl={imageUrl} alt={alt} amount={amount} />
+      <_Pin.Multiple imageUrl={imageUrl} alt={alt} markerCount={markerCount} />
     </AdvancedMarker>
   );
 };
 
 export const Cluster = ({
   position,
-  amount,
-}: MarkerProps & { amount: number }) => {
+  markerCount,
+}: MarkerProps & { markerCount: number }) => {
   return (
     <AdvancedMarker position={position}>
-      <_Pin.Cluster amount={amount} />
+      <_Pin.Cluster markerCount={markerCount} />
     </AdvancedMarker>
   );
 };

--- a/src/entities/map/ui/CustomMarker.tsx
+++ b/src/entities/map/ui/CustomMarker.tsx
@@ -1,4 +1,6 @@
 import { AdvancedMarker } from "@vis.gl/react-google-maps";
+import * as _Pin from "./Pin";
+import type { PinProps } from "./Pin";
 
 interface MarkerProps {
   position: {
@@ -6,6 +8,8 @@ interface MarkerProps {
     lng: number;
   };
 }
+
+interface GooglePinProps extends MarkerProps, PinProps {}
 
 /**
  * 해당 컴포넌트는 지도 중심에 존재하는 사용자의 위치를 표시하기 위한 컴포넌트 입니다.
@@ -17,6 +21,38 @@ export const User = ({ position }: MarkerProps) => {
         <div className="h-12 w-12 animate-radar rounded-full bg-tangerine-500 opacity-25"></div>
         <div className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 transform rounded-full bg-tangerine-500 opacity-100"></div>
       </div>
+    </AdvancedMarker>
+  );
+};
+
+export const Pin = ({ position, imageUrl, alt }: GooglePinProps) => {
+  return (
+    <AdvancedMarker position={position}>
+      <_Pin.Default imageUrl={imageUrl} alt={alt} />
+    </AdvancedMarker>
+  );
+};
+
+export const MultiplePin = ({
+  position,
+  imageUrl,
+  alt,
+  amount,
+}: GooglePinProps & { amount: number }) => {
+  return (
+    <AdvancedMarker position={position}>
+      <_Pin.Multiple imageUrl={imageUrl} alt={alt} amount={amount} />
+    </AdvancedMarker>
+  );
+};
+
+export const Cluster = ({
+  position,
+  amount,
+}: MarkerProps & { amount: number }) => {
+  return (
+    <AdvancedMarker position={position}>
+      <_Pin.Cluster amount={amount} />
     </AdvancedMarker>
   );
 };

--- a/src/entities/map/ui/Pin.stories.tsx
+++ b/src/entities/map/ui/Pin.stories.tsx
@@ -25,19 +25,27 @@ export const Default: Story = {
     <>
       <div>
         <h1>Default Pin</h1>
-        <Pin.Default imageUrl="/public/default-profile.svg" />
+        <Pin.Default imageUrl="/public/default-profile.svg" alt="기본 이미지" />
       </div>
       <div>
         <h1>Multiple Pin</h1>
-        <p>MultiplePin 에서 amount의 최대값은 99입니다.</p>
+        <p>MultiplePin 에서 markerCount의 최대값은 99입니다.</p>
         <div className="flex gap-4">
-          <Pin.Multiple imageUrl="/public/default-profile.svg" amount={2} />
-          <Pin.Multiple imageUrl="/public/default-profile.svg" amount={5000} />
+          <Pin.Multiple
+            imageUrl="/public/default-profile.svg"
+            markerCount={2}
+            alt="기본 이미지"
+          />
+          <Pin.Multiple
+            imageUrl="/public/default-profile.svg"
+            markerCount={5000}
+            alt="기본 이미지"
+          />
         </div>
       </div>
       <div>
         <h1>Cluster Pin</h1>
-        <Pin.Cluster amount={16} />
+        <Pin.Cluster markerCount={16} />
       </div>
     </>
   ),

--- a/src/entities/map/ui/Pin.stories.tsx
+++ b/src/entities/map/ui/Pin.stories.tsx
@@ -1,0 +1,44 @@
+import { Meta, StoryObj } from "@storybook/react";
+import * as Pin from "./Pin";
+
+const meta: Meta<typeof Pin.Default> = {
+  title: "entities/map/Pin",
+  component: Pin.Default,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Pin.Default>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => {
+      return (
+        <div className="flex flex-col gap-2">
+          <Story />
+        </div>
+      );
+    },
+  ],
+
+  render: () => (
+    <>
+      <div>
+        <h1>Default Pin</h1>
+        <Pin.Default imageUrl="/public/default-profile.svg" />
+      </div>
+      <div>
+        <h1>Multiple Pin</h1>
+        <p>MultiplePin 에서 amount의 최대값은 99입니다.</p>
+        <div className="flex gap-4">
+          <Pin.Multiple imageUrl="/public/default-profile.svg" amount={2} />
+          <Pin.Multiple imageUrl="/public/default-profile.svg" amount={5000} />
+        </div>
+      </div>
+      <div>
+        <h1>Cluster Pin</h1>
+        <Pin.Cluster amount={16} />
+      </div>
+    </>
+  ),
+};

--- a/src/entities/map/ui/Pin.tsx
+++ b/src/entities/map/ui/Pin.tsx
@@ -3,7 +3,7 @@ import { PinShadowIcon } from "@/shared/ui/icon";
 
 export interface PinProps {
   imageUrl: string;
-  alt?: string;
+  alt: string;
 }
 
 const Pin = ({ imageUrl, alt }: PinProps) => (
@@ -30,22 +30,22 @@ export const Default = ({ imageUrl, alt }: PinProps) => {
 export const Multiple = ({
   imageUrl,
   alt,
-  amount,
-}: PinProps & { amount: number }) => {
+  markerCount,
+}: PinProps & { markerCount: number }) => {
   return (
     <div className="relative">
       <Pin imageUrl={imageUrl} alt={alt} />
       <div className="absolute left-[0.75rem] top-[0.7rem]">
-        <Badge colorType="secondary">{`+${Math.min(amount, 99)}`}</Badge>
+        <Badge colorType="secondary">{`+${Math.min(markerCount, 99)}`}</Badge>
       </div>
     </div>
   );
 };
 
-export const Cluster = ({ amount }: { amount: number }) => {
+export const Cluster = ({ markerCount }: { markerCount: number }) => {
   return (
-    <span className="btn-2 flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full bg-translucent-tangerine text-center text-tangerine-900">
-      {amount}
+    <span className="btn-2 bg-translucent-tangerine flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full text-center text-tangerine-900">
+      {markerCount}
     </span>
   );
 };

--- a/src/entities/map/ui/Pin.tsx
+++ b/src/entities/map/ui/Pin.tsx
@@ -6,17 +6,23 @@ export interface PinProps {
   alt?: string;
 }
 
+const Pin = ({ imageUrl, alt }: PinProps) => (
+  <>
+    <div className="pin relative flex h-[2.75rem] w-8 items-center justify-center bg-tangerine-500">
+      <div className="h-[1.625rem] w-[1.625rem] translate-y-[-0.375rem] rounded-full bg-grey-0">
+        <img src={imageUrl} alt={alt} className="h-full w-full rounded-2xl" />
+      </div>
+    </div>
+    <span className="absolute translate-x-[0.25rem] translate-y-[-0.5rem]">
+      <PinShadowIcon fill="tangerine-900" />
+    </span>
+  </>
+);
+
 export const Default = ({ imageUrl, alt }: PinProps) => {
   return (
-    <div className="pin-wrapper">
-      <div className="pin">
-        <div className="pin-inner">
-          <img src={imageUrl} alt={alt} className="h-full w-full rounded-2xl" />
-        </div>
-      </div>
-      <span className="pin-shadow">
-        <PinShadowIcon fill="#BB370C" />
-      </span>
+    <div className="relative">
+      <Pin imageUrl={imageUrl} alt={alt} />
     </div>
   );
 };
@@ -27,16 +33,9 @@ export const Multiple = ({
   amount,
 }: PinProps & { amount: number }) => {
   return (
-    <div className="pin-wrapper">
-      <div className="pin">
-        <div className="pin-inner">
-          <img src={imageUrl} alt={alt} className="h-full w-full rounded-2xl" />
-        </div>
-      </div>
-      <div className="pin-shadow">
-        <PinShadowIcon fill="#BB370C" />
-      </div>
-      <div className="pin-amount">
+    <div className="relative">
+      <Pin imageUrl={imageUrl} alt={alt} />
+      <div className="absolute left-[0.75rem] top-[0.7rem]">
         <Badge colorType="secondary">{`+${Math.min(amount, 99)}`}</Badge>
       </div>
     </div>

--- a/src/entities/map/ui/Pin.tsx
+++ b/src/entities/map/ui/Pin.tsx
@@ -1,0 +1,52 @@
+import { Badge } from "@/shared/ui/badge";
+import { PinShadowIcon } from "@/shared/ui/icon";
+
+export interface PinProps {
+  imageUrl: string;
+  alt?: string;
+}
+
+export const Default = ({ imageUrl, alt }: PinProps) => {
+  return (
+    <div className="pin-wrapper">
+      <div className="pin">
+        <div className="pin-inner">
+          <img src={imageUrl} alt={alt} className="h-full w-full rounded-2xl" />
+        </div>
+      </div>
+      <span className="pin-shadow">
+        <PinShadowIcon fill="#BB370C" />
+      </span>
+    </div>
+  );
+};
+
+export const Multiple = ({
+  imageUrl,
+  alt,
+  amount,
+}: PinProps & { amount: number }) => {
+  return (
+    <div className="pin-wrapper">
+      <div className="pin">
+        <div className="pin-inner">
+          <img src={imageUrl} alt={alt} className="h-full w-full rounded-2xl" />
+        </div>
+      </div>
+      <div className="pin-shadow">
+        <PinShadowIcon fill="#BB370C" />
+      </div>
+      <div className="pin-amount">
+        <Badge colorType="secondary">{`+${Math.min(amount, 99)}`}</Badge>
+      </div>
+    </div>
+  );
+};
+
+export const Cluster = ({ amount }: { amount: number }) => {
+  return (
+    <span className="btn-2 flex h-[3.75rem] w-[3.75rem] items-center justify-center rounded-full bg-translucent-tangerine text-center text-tangerine-900">
+      {amount}
+    </span>
+  );
+};

--- a/src/entities/map/ui/index.ts
+++ b/src/entities/map/ui/index.ts
@@ -1,2 +1,2 @@
-export * as CustomMarker from "./CustomMarker";
+export * from "./CustomMarker";
 export * from "./FloatingButton";

--- a/src/features/map/ui/GoogleMaps.tsx
+++ b/src/features/map/ui/GoogleMaps.tsx
@@ -38,22 +38,25 @@ export const GoogleMaps = () => {
     >
       <CustomMarker.User position={{ lat: 37.5665, lng: 126.978 }} />
       <CustomMarker.Pin
+        alt="test"
         position={{ lat: 37.56651, lng: 126.977 }}
         imageUrl="/public/default-profile.svg"
       />
       <CustomMarker.MultiplePin
         position={{ lat: 37.5664, lng: 126.976 }}
         imageUrl="/public/default-profile.svg"
-        amount={2}
+        alt="test"
+        markerCount={2}
       />
       <CustomMarker.MultiplePin
         position={{ lat: 37.5663, lng: 126.9765 }}
         imageUrl="/public/default-profile.svg"
-        amount={500}
+        alt="test"
+        markerCount={500}
       />
       <CustomMarker.Cluster
         position={{ lat: 37.5662, lng: 126.976 }}
-        amount={16}
+        markerCount={16}
       />
     </Map>
   );

--- a/src/features/map/ui/GoogleMaps.tsx
+++ b/src/features/map/ui/GoogleMaps.tsx
@@ -1,6 +1,6 @@
 import { Map } from "@vis.gl/react-google-maps";
 import { useEffect } from "react";
-import { CustomMarker } from "@/entities/map/ui";
+import { User, Pin, MultiplePin, Cluster } from "@/entities/map/ui";
 import { mapOptions } from "../constants";
 const GOOGLE_MAPS_MAP_ID = import.meta.env.VITE_GOOGLE_MAPS_ID;
 
@@ -36,28 +36,25 @@ export const GoogleMaps = () => {
       defaultZoom={16}
       reuseMaps // Map 컴포넌트가 unmount 되었다가 다시 mount 될 때 기존의 map instance 를 재사용 하여 memory leak을 방지합니다.
     >
-      <CustomMarker.User position={{ lat: 37.5665, lng: 126.978 }} />
-      <CustomMarker.Pin
+      <User position={{ lat: 37.5665, lng: 126.978 }} />
+      <Pin
         alt="test"
         position={{ lat: 37.56651, lng: 126.977 }}
         imageUrl="/public/default-profile.svg"
       />
-      <CustomMarker.MultiplePin
+      <MultiplePin
         position={{ lat: 37.5664, lng: 126.976 }}
         imageUrl="/public/default-profile.svg"
         alt="test"
         markerCount={2}
       />
-      <CustomMarker.MultiplePin
+      <MultiplePin
         position={{ lat: 37.5663, lng: 126.9765 }}
         imageUrl="/public/default-profile.svg"
         alt="test"
         markerCount={500}
       />
-      <CustomMarker.Cluster
-        position={{ lat: 37.5662, lng: 126.976 }}
-        markerCount={16}
-      />
+      <Cluster position={{ lat: 37.5662, lng: 126.976 }} markerCount={16} />
     </Map>
   );
 };

--- a/src/features/map/ui/GoogleMaps.tsx
+++ b/src/features/map/ui/GoogleMaps.tsx
@@ -37,6 +37,24 @@ export const GoogleMaps = () => {
       reuseMaps // Map 컴포넌트가 unmount 되었다가 다시 mount 될 때 기존의 map instance 를 재사용 하여 memory leak을 방지합니다.
     >
       <CustomMarker.User position={{ lat: 37.5665, lng: 126.978 }} />
+      <CustomMarker.Pin
+        position={{ lat: 37.56651, lng: 126.977 }}
+        imageUrl="/public/default-profile.svg"
+      />
+      <CustomMarker.MultiplePin
+        position={{ lat: 37.5664, lng: 126.976 }}
+        imageUrl="/public/default-profile.svg"
+        amount={2}
+      />
+      <CustomMarker.MultiplePin
+        position={{ lat: 37.5663, lng: 126.9765 }}
+        imageUrl="/public/default-profile.svg"
+        amount={500}
+      />
+      <CustomMarker.Cluster
+        position={{ lat: 37.5662, lng: 126.976 }}
+        amount={16}
+      />
     </Map>
   );
 };

--- a/src/global.css
+++ b/src/global.css
@@ -146,3 +146,39 @@ img[alt="Google"] {
 .gm-style-cc a {
   display: none !important;
 }
+
+.pin {
+  width: 2rem;
+  height: 2.75rem;
+  background-color: #fb5821;
+  clip-path: path(
+    "M32 16C32 7.16344 24.8366 0 16 0C7.16344 0 0 7.16344 0 16C0 18.25 0.5 21.75 3.84215 27.375L12.2859 42C13.8255 44.6667 17.6745 44.6667 19.2141 42C19.2141 42 24.5494 32.5 27.6579 27.375C30.7663 22.25 32 19.8 32 16Z"
+  );
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.pin-inner {
+  width: 1.625rem;
+  height: 1.625rem;
+  border-radius: 100%;
+  background-size: cover;
+  transform: translateY(-0.375rem);
+  background-color: #fff;
+}
+
+.pin-wrapper {
+  position: relative;
+}
+
+.pin-shadow {
+  transform: translateY(-0.5rem) translateX(0.2rem);
+}
+
+.pin-amount {
+  position: absolute;
+  top: 0.7rem;
+  left: 0.75rem;
+}

--- a/src/global.css
+++ b/src/global.css
@@ -148,37 +148,7 @@ img[alt="Google"] {
 }
 
 .pin {
-  width: 2rem;
-  height: 2.75rem;
-  background-color: #fb5821;
   clip-path: path(
     "M32 16C32 7.16344 24.8366 0 16 0C7.16344 0 0 7.16344 0 16C0 18.25 0.5 21.75 3.84215 27.375L12.2859 42C13.8255 44.6667 17.6745 44.6667 19.2141 42C19.2141 42 24.5494 32.5 27.6579 27.375C30.7663 22.25 32 19.8 32 16Z"
   );
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-}
-
-.pin-inner {
-  width: 1.625rem;
-  height: 1.625rem;
-  border-radius: 100%;
-  background-size: cover;
-  transform: translateY(-0.375rem);
-  background-color: #fff;
-}
-
-.pin-wrapper {
-  position: relative;
-}
-
-.pin-shadow {
-  transform: translateY(-0.5rem) translateX(0.2rem);
-}
-
-.pin-amount {
-  position: absolute;
-  top: 0.7rem;
-  left: 0.75rem;
 }

--- a/src/shared/assets/pin-shadow.svg
+++ b/src/shared/assets/pin-shadow.svg
@@ -1,4 +1,4 @@
-118<svg xmlns="http://www.w3.org/2000/svg" width="current" height="current" viewBox="0 0 24 12" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="current" height="current" viewBox="0 0 24 12" fill="none">
 <g filter="url(#filter0_f_122_9665)">
 <ellipse cx="12" cy="6" rx="7.5" ry="2" fill="current"/>
 </g>

--- a/src/shared/assets/pin-shadow.svg
+++ b/src/shared/assets/pin-shadow.svg
@@ -1,0 +1,12 @@
+118<svg xmlns="http://www.w3.org/2000/svg" width="current" height="current" viewBox="0 0 24 12" fill="none">
+<g filter="url(#filter0_f_122_9665)">
+<ellipse cx="12" cy="6" rx="7.5" ry="2" fill="current"/>
+</g>
+<defs>
+<filter id="filter0_f_122_9665" x="0.5" y="2.38419e-07" width="23" height="12" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="2" result="effect1_foregroundBlur_122_9665"/>
+</filter>
+</defs>
+</svg>

--- a/src/shared/ui/icon/index.ts
+++ b/src/shared/ui/icon/index.ts
@@ -19,6 +19,7 @@ import NotificationSVG from "@/shared/assets/notification.svg";
 import CompassSVG from "@/shared/assets/compass.svg";
 import MapSVG from "@/shared/assets/map.svg";
 import CommunitySVG from "@/shared/assets/community.svg";
+import PinShadowSVG from "@/shared/assets/pin-shadow.svg";
 // Icon 컴포넌트 생성
 export const EmailIcon = withIcon(EmailSvg);
 export const VisibilityOnIcon = withIcon(VisibilityOnSvg);
@@ -38,3 +39,4 @@ export const NotificationIcon = withIcon(NotificationSVG);
 export const CompassIcon = withIcon(CompassSVG);
 export const MapIcon = withIcon(MapSVG);
 export const CommunityIcon = withIcon(CommunitySVG);
+export const PinShadowIcon = withIcon(PinShadowSVG);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,7 @@ export default {
       },
       backgroundColor: {
         "translucent-gray": "rgba(33,33,33,0.25)",
+        "translucent-tangerine": "rgba(251,88,33,0.5)",
       },
       keyframes: {
         radar: {


### PR DESCRIPTION
# 관련 이슈 번호
close #118 
# 설명

![image](https://github.com/user-attachments/assets/9a32634c-75ff-447b-875d-c979e1901e5d)

`AdvancedMarker` 의 `children` 에 들어갈 컴포넌트들을 `entities/map/ui/Pin.tsx` 에 정의해봤습니다. 

`Pin.tsx` 에서 정의하고 `CustomMarker` 에서 불러와 `AdvancedMakrer` 컴포넌트로 감싸줍니다. 

> 이렇게 만든 이유는 스토리북에 커스텀 핀들을 업로드 하기 위함이였습니다
> 스토리북엔 `Pin.tsx` 에 정의된 컴포넌트를 업로드 했습니다. 

`Pin.tsx` 에서는 외부로 export 되지 않는 기본이 되는 `Pin` 컴포넌트을 기본으로 하여 `Default , Multiple` 컴포넌트가 만들어집니다.

```tsx
export const Default = ({ imageUrl, alt }: PinProps) => {
  return (
    <div className="relative">
      <Pin imageUrl={imageUrl} alt={alt} />
    </div>
  );
};

export const Multiple = ({
  imageUrl,
  alt,
  amount,
}: PinProps & { amount: number }) => {
  return (
    <div className="relative">
      <Pin imageUrl={imageUrl} alt={alt} />
      <div className="absolute left-[0.75rem] top-[0.7rem]">
        <Badge colorType="secondary">{`+${Math.min(amount, 99)}`}</Badge>
      </div>
    </div>
  );
};
```

`Pin` 컴포넌트는 `tailwindCSS` 를 이용하여 매우 지저분합니다. 

맨 처음에는 클래식하게 `global.css` 에서 클래스명을 만들어서 스타일링 했었는데 이렇게 되면 테일윈드의 장점인 클래스명 캐싱 기능을 사용하지 못하게 되는 거 같아 지저분하더라도 테일윈드를 이용하여 `Pin` 컴포넌트를 생성했습니다.

클러스터 컴포넌트는 단순한 `CSS` 만 존재하는 `span` 태그이기 때문에 설명을 줄이겠습니다.

---

### 실제 사용 예시

```tsx
// features/map/GoogleMaps.tsx
    <Map
      mapId={GOOGLE_MAPS_MAP_ID}
      options={mapOptions}
      // TODO 상태 붙혀서 default Center 이동시키기
      defaultCenter={{ lat: 37.5665, lng: 126.978 }}
      defaultZoom={16}
      reuseMaps // Map 컴포넌트가 unmount 되었다가 다시 mount 될 때 기존의 map instance 를 재사용 하여 memory leak을 방지합니다.
    >
      <CustomMarker.User position={{ lat: 37.5665, lng: 126.978 }} />
      <CustomMarker.Pin
        position={{ lat: 37.56651, lng: 126.977 }}
        imageUrl="/public/default-profile.svg"
      />
      <CustomMarker.MultiplePin
        position={{ lat: 37.5664, lng: 126.976 }}
        imageUrl="/public/default-profile.svg"
        amount={2}
      />
      <CustomMarker.MultiplePin
        position={{ lat: 37.5663, lng: 126.9765 }}
        imageUrl="/public/default-profile.svg"
        amount={500}
      />
      <CustomMarker.Cluster
        position={{ lat: 37.5662, lng: 126.976 }}
        amount={16}
      />
    </Map>
```

다음과 같이 이용합니다. 감사합니다. 


# 첨부 파일 (Optional)

![44](https://github.com/user-attachments/assets/4a04de3d-dc20-426e-8826-a6c53222edf9)

현재 예시는 줌 레벨에 따라 모든 마커들이 나타나있어서 겹치지만 추후 실사용 할 땐 줌 레벨에 따라 다른 마커를 보여주면 될 거 같습니다.

# PS

아마 클릭하거나 했을 때 크기가 커지는 `ClickPin` 의 경우에는 나중에 라우팅 기능 집어넣었을 때 `NavLink` 로 한 번 핀들을 감싸 활성화 된 경우 (현재 경로와 NavLink 의 to 가 동일 한 경우) 에 `transform : scale(2)` 을 집어 넣으면 될 거 같습니다.



# 레퍼런스 (Optional)
