### PR TITLE
[Refactor] 기본 정보 입력 폼 리팩토링

### DIFF
--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -49,7 +49,6 @@ export const usePostSignUpByEmail = () => {
 
 interface UserInfoRegistrationRequest {
   token: string;
-  userId: number;
   nickname: string;
   gender: "FEMALE" | "MALE";
   age: number;
@@ -68,10 +67,9 @@ interface UserInfoRegistrationResponse {
 
 const putUserInfoRegister = async ({
   token,
-  userId,
   ...userInfo
 }: UserInfoRegistrationRequest) => {
-  const response = await fetch(SIGN_UP_END_POINT.USER_INFO(userId), {
+  const response = await fetch(SIGN_UP_END_POINT.USER_INFO, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",

--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -51,7 +51,7 @@ interface UserInfoRegistrationRequest {
   token: string;
   nickname: string;
   gender: "FEMALE" | "MALE";
-  ageRange: 10 | 20 | 30 | 40 | 50;
+  age: 10 | 20 | 30 | 40 | 50;
   region: string;
   marketingYn: boolean;
 }

--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -51,7 +51,7 @@ interface UserInfoRegistrationRequest {
   token: string;
   nickname: string;
   gender: "FEMALE" | "MALE";
-  age: number;
+  ageRange: 10 | 20 | 30 | 40 | 50;
   region: string;
   marketingYn: boolean;
 }

--- a/src/features/auth/constants/endpoint.ts
+++ b/src/features/auth/constants/endpoint.ts
@@ -7,7 +7,6 @@ export const LOGIN_END_POINT = {
 
 export const SIGN_UP_END_POINT = {
   EMAIL: "http://localhost:80/users",
-  USER_INFO: (userId: number) =>
-    `http://localhost:80/users/${userId}/additional-info`,
+  USER_INFO: "http://localhost:80/users/additional-info",
   PET_INFO: "http://localhost:80/pets",
 };

--- a/src/features/auth/constants/form.ts
+++ b/src/features/auth/constants/form.ts
@@ -12,3 +12,37 @@ export const characterList = [
   "애교있는",
   "까칠한",
 ] as const;
+
+export const genderOptionList = [
+  {
+    value: "MALE",
+    name: "남자",
+  },
+  {
+    value: "FEMALE",
+    name: "여자",
+  },
+] as const;
+
+export const ageRangeOptionList = [
+  {
+    value: 10,
+    name: "10대",
+  },
+  {
+    value: 20,
+    name: "20~30대",
+  },
+  {
+    value: 30,
+    name: "30~40대",
+  },
+  {
+    value: 40,
+    name: "50~60대",
+  },
+  {
+    value: 50,
+    name: "60대 이상",
+  },
+] as const;

--- a/src/features/auth/lib/index.ts
+++ b/src/features/auth/lib/index.ts
@@ -1,0 +1,1 @@
+export * from "./validate";

--- a/src/features/auth/lib/validate.ts
+++ b/src/features/auth/lib/validate.ts
@@ -1,0 +1,4 @@
+export const validateNickname = (nickName: string) => {
+  const regExp = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{1,20}$/;
+  return regExp.test(nickName);
+};

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -84,12 +84,14 @@ type CheckedList = boolean[];
 
 interface UserInfoRegistrationFormStore {
   nickname: string;
+  isValidNickname: boolean;
   gender: Gender;
   ageRange: AgeRange;
   region: Region;
   checkList: CheckedList;
 
   setNickname: (email: string) => void;
+  setIsValidNickname: (isValidNickname: boolean) => void;
   setGender: (gender: Gender) => void;
   setAgeRange: (birth: AgeRange) => void;
   setRegion: (region: Region) => void;
@@ -99,12 +101,14 @@ interface UserInfoRegistrationFormStore {
 export const useUserInfoRegistrationFormStore =
   create<UserInfoRegistrationFormStore>((set) => ({
     nickname: "",
+    isValidNickname: true,
     gender: null,
     ageRange: null,
     region: null,
     checkList: [false, false, false],
 
     setNickname: (nickname) => set({ nickname }),
+    setIsValidNickname: (isValidNickname) => set({ isValidNickname }),
     setGender: (gender) => set({ gender }),
     setAgeRange: (birth) => set({ ageRange: birth }),
     setRegion: (region) => set({ region }),

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -76,3 +76,37 @@ export const useLoginFormStore = create<LoginFormStore>((set) => ({
   setIsValidEmail: (isValidEmail: boolean) => set({ isValidEmail }),
   setStatusText: (statusText: string) => set({ statusText }),
 }));
+
+type Gender = "FEMALE" | "MALE" | null;
+type AgeRange = 10 | 20 | 30 | 40 | 50 | null;
+type Region = string | null;
+type CheckedList = boolean[];
+
+interface UserInfoRegistrationFormStore {
+  nickname: string;
+  gender: Gender;
+  ageRange: AgeRange;
+  region: Region;
+  checkList: CheckedList;
+
+  setNickname: (email: string) => void;
+  setGender: (gender: Gender) => void;
+  setAgeRange: (birth: AgeRange) => void;
+  setRegion: (region: Region) => void;
+  setCheckList: (checkList: CheckedList) => void;
+}
+
+export const useUserInfoRegistrationFormStore =
+  create<UserInfoRegistrationFormStore>((set) => ({
+    nickname: "",
+    gender: null,
+    ageRange: null,
+    region: null,
+    checkList: [false, false, false],
+
+    setNickname: (nickname) => set({ nickname }),
+    setGender: (gender) => set({ gender }),
+    setAgeRange: (birth) => set({ ageRange: birth }),
+    setRegion: (region) => set({ region }),
+    setCheckList: (checkList) => set({ checkList }),
+  }));

--- a/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
@@ -4,6 +4,7 @@ import UserInfoRegistrationForm from "./UserInfoRegistrationForm";
 import { expect, userEvent, within } from "@storybook/test";
 import { useUserInfoRegistrationFormStore } from "../store";
 import { useAuthStore } from "@/shared/store/auth";
+import { OverlayPortal } from "@/app/OverlayPortal";
 
 const meta: Meta<typeof UserInfoRegistrationForm> = {
   title: "features/auth/UserInfoRegistrationForm",
@@ -33,6 +34,7 @@ export const Default: Story = {
 
     return (
       <div id="root">
+        <OverlayPortal />
         <Story />
       </div>
     );
@@ -50,6 +52,10 @@ export const Default: Story = {
     const $nicknameInput = canvasElement.querySelector(
       'input[name="nickname"]',
     ) as HTMLInputElement;
+    const validNickname = "hihihi";
+    const invalidNickname = "!!@#$@";
+
+    const $submitButton = canvas.getByText("회원가입");
 
     await step("nickname input 검사", async () => {
       const STATUS_TEXT = "20자 이내의 한글 영어 숫자만 사용 가능합니다.";
@@ -72,7 +78,7 @@ export const Default: Story = {
       await step(
         "닉네임 형식에 맞지 않게 입력할 경우, 안내 문구가 핑크색으로 표시된다.",
         async () => {
-          await userEvent.type($nicknameInput, "!!@#$@");
+          await userEvent.type($nicknameInput, invalidNickname);
           // outfocus되도 statusText를 pink-500 색상으로 표시
           await userEvent.tab();
 
@@ -80,8 +86,6 @@ export const Default: Story = {
           expect($statusText).toHaveClass(textColor.error);
         },
       );
-
-      const validNickname = "hihihi";
 
       await step(
         "닉네임 형식에 맞게 입력한 경우, 안내 문구는 기본 색상으로 표시된다.",
@@ -115,6 +119,23 @@ export const Default: Story = {
     await step("gender select 검사", async () => {
       const $genderLabel = canvas.getByText("성별");
       const $genderTriggerButton = canvasElement.querySelector("#gender");
+
+      await step(
+        "성별을 선택하지 않은 상태에서 [회원가입] 버튼을 누르면, snackbar가 뜬다.",
+        async () => {
+          await userEvent.click($submitButton);
+
+          const $snackbar = canvas.getByText("필수 항목을 모두 입력해 주세요");
+          expect($snackbar).toBeInTheDocument();
+
+          const $snackBarCloseButton = canvas.getByLabelText(
+            "info-snackbar-close-button",
+          );
+
+          await userEvent.click($snackBarCloseButton);
+          await expect($snackBarCloseButton).not.toBeInTheDocument();
+        },
+      );
 
       await step("성별 라벨을 클릭하면, 바텀 시트가 열린다.", async () => {
         await userEvent.click($genderLabel);
@@ -182,6 +203,23 @@ export const Default: Story = {
       const $ageRangeLabel = canvas.getByText("연령대");
       const $ageRangeTriggerButton = canvasElement.querySelector("#age-range");
 
+      await step(
+        "연령대를 선택하지 않은 상태에서 [회원가입] 버튼을 누르면, snackbar가 뜬다.",
+        async () => {
+          await userEvent.click($submitButton);
+
+          const $snackbar = canvas.getByText("필수 항목을 모두 입력해 주세요");
+          expect($snackbar).toBeInTheDocument();
+
+          const $snackBarCloseButton = canvas.getByLabelText(
+            "info-snackbar-close-button",
+          );
+
+          await userEvent.click($snackBarCloseButton);
+          await expect($snackBarCloseButton).not.toBeInTheDocument();
+        },
+      );
+
       await step("연령대 라벨을 클릭하면, 바텀 시트가 열린다.", async () => {
         await userEvent.click($ageRangeLabel);
 
@@ -244,5 +282,47 @@ export const Default: Story = {
     });
 
     // todo: 동네 설정 검사
+
+    await step(
+      "form을 다 입력했지만 이메일 형식에 맞지 않은 상태에서 [회원가입] 버튼을 누르면, snackbar가 뜬다.",
+      async () => {
+        await userEvent.clear($nicknameInput);
+
+        await userEvent.type($nicknameInput, invalidNickname);
+        await userEvent.click($submitButton);
+
+        const $snackbar = canvas.getByText("올바른 닉네임을 입력해 주세요");
+        expect($snackbar).toBeInTheDocument();
+
+        const $snackBarCloseButton = canvas.getByLabelText(
+          "info-snackbar-close-button",
+        );
+
+        await userEvent.click($snackBarCloseButton);
+        await expect($snackBarCloseButton).not.toBeInTheDocument();
+      },
+    );
+
+    await userEvent.clear($nicknameInput);
+    await userEvent.type($nicknameInput, validNickname);
+
+    // todo: 유저 중복 snackbar 검사
+
+    await step(
+      "필수 약관에 동의하지 않은 상태에서 [회원가입] 버튼을 누르면, snackbar가 뜬다.",
+      async () => {
+        await userEvent.click($submitButton);
+
+        const $snackbar = canvas.getByText("필수 약관에 모두 동의해 주세요");
+        expect($snackbar).toBeInTheDocument();
+
+        const $snackBarCloseButton = canvas.getByLabelText(
+          "info-snackbar-close-button",
+        );
+
+        await userEvent.click($snackBarCloseButton);
+        await expect($snackBarCloseButton).not.toBeInTheDocument();
+      },
+    );
   },
 };

--- a/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
@@ -82,5 +82,64 @@ export const Default: Story = {
         },
       );
     });
+
+    await step("gender select 검사", async () => {
+      const $genderLabel = canvas.getByText("성별");
+      const $genderTriggerButton = canvasElement.querySelector("#gender");
+
+      await step("성별 라벨을 클릭하면, 바텀 시트가 열린다.", async () => {
+        await userEvent.click($genderLabel);
+
+        expect($genderTriggerButton).toHaveFocus();
+
+        const $bottomSheet = document.querySelector("#gender-select");
+
+        expect($bottomSheet).toBeInTheDocument();
+      });
+
+      if (!$genderTriggerButton) return;
+
+      await step(
+        "성별 바텀시트의 trigger 버튼을 클릭하면, 바텀 시트가 열린다.",
+        async () => {
+          await userEvent.click($genderTriggerButton);
+
+          const $bottomSheet = document.querySelector("#gender-select");
+
+          expect($bottomSheet).toBeInTheDocument();
+        },
+      );
+
+      await step(
+        "바텀 시트에 '남자'를 선택하면, trigger 버튼에 '남자'가 표시된다.",
+        async () => {
+          const $bottomSheet = document.querySelector("#gender-select");
+          const $optionList = $bottomSheet?.querySelectorAll("li");
+          const $maleOption = $optionList?.[0];
+
+          if (!$maleOption) return;
+          await userEvent.click($maleOption);
+
+          expect($genderTriggerButton).toHaveTextContent("남자");
+        },
+      );
+
+      await step(
+        "'남자'를 선택한 상태에서 바텀 시트를 다시 열면, '남자' 옵션이 빨간색으로 표시되어 있다.",
+        async () => {
+          await userEvent.click($genderTriggerButton);
+
+          const $bottomSheet = document.querySelector("#gender-select");
+          expect($bottomSheet).toBeInTheDocument();
+
+          const $optionList = $bottomSheet?.querySelectorAll("li");
+          const $maleOption = $optionList?.[0];
+
+          if (!$maleOption) return;
+
+          expect($maleOption).toHaveClass("text-tangerine-500");
+        },
+      );
+    });
   },
 };

--- a/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
@@ -167,8 +167,7 @@ export const Default: Story = {
           const $optionList = $bottomSheet?.querySelectorAll("li");
           const $maleOption = $optionList?.[0];
 
-          if (!$maleOption) return;
-          await userEvent.click($maleOption);
+          await userEvent.click($maleOption!);
 
           expect($genderTriggerButton).toHaveTextContent("남자");
         },
@@ -185,11 +184,9 @@ export const Default: Story = {
           const $optionList = $bottomSheet?.querySelectorAll("li");
           const $maleOption = $optionList?.[0];
 
-          if (!$maleOption) return;
-
           expect($maleOption).toHaveClass("text-tangerine-500");
 
-          await userEvent.click($maleOption);
+          await userEvent.click($maleOption!);
         },
       );
 
@@ -230,12 +227,10 @@ export const Default: Story = {
         expect($bottomSheet).toBeInTheDocument();
       });
 
-      if (!$ageRangeTriggerButton) return;
-
       await step(
         "연령대 바텀시트의 trigger 버튼을 클릭하면, 바텀 시트가 열린다.",
         async () => {
-          await userEvent.click($ageRangeTriggerButton);
+          await userEvent.click($ageRangeTriggerButton!);
 
           const $bottomSheet = document.querySelector("#age-range-select");
 
@@ -250,8 +245,7 @@ export const Default: Story = {
           const $optionList = $bottomSheet?.querySelectorAll("li");
           const $teenagerOption = $optionList?.[0];
 
-          if (!$teenagerOption) return;
-          await userEvent.click($teenagerOption);
+          await userEvent.click($teenagerOption!);
 
           expect($ageRangeTriggerButton).toHaveTextContent("10대");
         },
@@ -260,7 +254,7 @@ export const Default: Story = {
       await step(
         "'10대'를 선택한 상태에서 바텀 시트를 다시 열면, '10대' 옵션이 빨간색으로 표시되어 있다.",
         async () => {
-          await userEvent.click($ageRangeTriggerButton);
+          await userEvent.click($ageRangeTriggerButton!);
 
           const $bottomSheet = document.querySelector("#age-range-select");
           expect($bottomSheet).toBeInTheDocument();

--- a/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import UserInfoRegistrationForm from "./UserInfoRegistrationForm";
 import { expect, userEvent, within } from "@storybook/test";
+import { useUserInfoRegistrationFormStore } from "../store";
+import { useAuthStore } from "@/shared/store/auth";
 
 const meta: Meta<typeof UserInfoRegistrationForm> = {
   title: "features/auth/UserInfoRegistrationForm",
@@ -16,6 +18,26 @@ export default meta;
 type Story = StoryObj<typeof UserInfoRegistrationForm>;
 
 export const Default: Story = {
+  decorators: (Story) => {
+    useUserInfoRegistrationFormStore.setState({
+      nickname: "",
+      gender: null,
+      ageRange: null,
+      region: null,
+      checkList: [false, false, false],
+    });
+
+    useAuthStore.setState({
+      token: "Bearer token",
+    });
+
+    return (
+      <div id="root">
+        <Story />
+      </div>
+    );
+  },
+
   render: () => (
     <div className="w-96">
       <UserInfoRegistrationForm />
@@ -59,12 +81,14 @@ export const Default: Story = {
         },
       );
 
+      const validNickname = "hihihi";
+
       await step(
         "닉네임 형식에 맞게 입력한 경우, 안내 문구는 기본 색상으로 표시된다.",
         async () => {
           // 이메일 입력 필드의 값을 초기화합니다.
           await userEvent.clear($nicknameInput);
-          await userEvent.type($nicknameInput, "hihihi");
+          await userEvent.type($nicknameInput, validNickname);
 
           const $statusText = canvas.getByText(STATUS_TEXT);
 
@@ -81,6 +105,11 @@ export const Default: Story = {
           expect($statusText).not.toBeInTheDocument();
         },
       );
+
+      await step("닉네임이 store에 저장된다.", async () => {
+        const { nickname } = useUserInfoRegistrationFormStore.getState();
+        expect(nickname).toEqual(validNickname);
+      });
     });
 
     await step("gender select 검사", async () => {
@@ -142,6 +171,11 @@ export const Default: Story = {
           await userEvent.click($maleOption);
         },
       );
+
+      await step("성별이 store에 저장된다.", async () => {
+        const { gender } = useUserInfoRegistrationFormStore.getState();
+        expect(gender).toEqual("MALE");
+      });
     });
 
     await step("age range select 검사", async () => {
@@ -202,6 +236,13 @@ export const Default: Story = {
           await userEvent.click($teenagerOption);
         },
       );
+
+      await step("연령대가 store에 저장된다.", async () => {
+        const { ageRange } = useUserInfoRegistrationFormStore.getState();
+        expect(ageRange).toEqual(10);
+      });
     });
+
+    // todo: 동네 설정 검사
   },
 };

--- a/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
@@ -24,62 +24,63 @@ export const Default: Story = {
 
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+
     const $nicknameInput = canvasElement.querySelector(
       'input[name="nickname"]',
     ) as HTMLInputElement;
 
-    await step(
-      'focus된 상태에서 입력값의 길이가 0일때, "20자 이내의 한글 영어 숫자만 사용 가능합니다." 안내문구가 뜬다.',
-      async () => {
-        await userEvent.click($nicknameInput);
+    await step("nickname input 검사", async () => {
+      const STATUS_TEXT = "20자 이내의 한글 영어 숫자만 사용 가능합니다.";
+      const textColor = {
+        base: "text-grey-500",
+        error: "text-pink-500",
+      };
 
-        const $statusText = canvas.getByText(
-          "20자 이내의 한글 영어 숫자만 사용 가능합니다.",
-        );
-        expect($statusText).toBeInTheDocument();
-        expect($statusText).toHaveClass("text-grey-500");
-      },
-    );
+      await step(
+        "focus된 상태에서 입력값의 길이가 0일때, 안내 문구가 뜬다.",
+        async () => {
+          await userEvent.click($nicknameInput);
 
-    await step(
-      '닉네임 형식에 맞지 않게 입력할 경우, "20자 이내의 한글 영어 숫자만 사용 가능합니다." 색상이 pink-500으로 표시된다.',
-      async () => {
-        await userEvent.type($nicknameInput, "!!@#$@");
-        // outfocus되도 statusText를 pink-500 색상으로 표시
-        await userEvent.tab();
+          const $statusText = canvas.getByText(STATUS_TEXT);
+          expect($statusText).toBeInTheDocument();
+          expect($statusText).toHaveClass(textColor.base);
+        },
+      );
 
-        const $statusText = canvas.getByText(
-          "20자 이내의 한글 영어 숫자만 사용 가능합니다.",
-        );
-        expect($statusText).toHaveClass("text-pink-500");
-      },
-    );
+      await step(
+        "닉네임 형식에 맞지 않게 입력할 경우, 안내 문구가 핑크색으로 표시된다.",
+        async () => {
+          await userEvent.type($nicknameInput, "!!@#$@");
+          // outfocus되도 statusText를 pink-500 색상으로 표시
+          await userEvent.tab();
 
-    await step(
-      '닉네임 형식에 맞게 입력한 경우, "20자 이내의 한글 영어 숫자만 사용 가능합니다." 색상이 grey-500으로 표시된다.',
-      async () => {
-        // 이메일 입력 필드의 값을 초기화합니다.
-        await userEvent.clear($nicknameInput);
-        await userEvent.type($nicknameInput, "hihihi");
+          const $statusText = canvas.getByText(STATUS_TEXT);
+          expect($statusText).toHaveClass(textColor.error);
+        },
+      );
 
-        const $statusText = canvas.getByText(
-          "20자 이내의 한글 영어 숫자만 사용 가능합니다.",
-        );
+      await step(
+        "닉네임 형식에 맞게 입력한 경우, 안내 문구는 기본 색상으로 표시된다.",
+        async () => {
+          // 이메일 입력 필드의 값을 초기화합니다.
+          await userEvent.clear($nicknameInput);
+          await userEvent.type($nicknameInput, "hihihi");
 
-        expect($statusText).toHaveClass("text-grey-500");
-      },
-    );
+          const $statusText = canvas.getByText(STATUS_TEXT);
 
-    await step(
-      '닉네임 형식에 맞게 입력한 상태에서 outfocus되면, "20자 이내의 한글 영어 숫자만 사용 가능합니다." 문구가 사라진다.',
-      async () => {
-        await userEvent.tab();
+          expect($statusText).toHaveClass(textColor.base);
+        },
+      );
 
-        const $statusText = canvas.queryByText(
-          "20자 이내의 한글 영어 숫자만 사용 가능합니다.",
-        );
-        expect($statusText).not.toBeInTheDocument();
-      },
-    );
+      await step(
+        "닉네임 형식에 맞게 입력한 상태에서 outfocus되면, 안내 문구가 사라진다.",
+        async () => {
+          await userEvent.tab();
+
+          const $statusText = canvas.queryByText(STATUS_TEXT);
+          expect($statusText).not.toBeInTheDocument();
+        },
+      );
+    });
   },
 };

--- a/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.stories.tsx
@@ -138,6 +138,68 @@ export const Default: Story = {
           if (!$maleOption) return;
 
           expect($maleOption).toHaveClass("text-tangerine-500");
+
+          await userEvent.click($maleOption);
+        },
+      );
+    });
+
+    await step("age range select 검사", async () => {
+      const $ageRangeLabel = canvas.getByText("연령대");
+      const $ageRangeTriggerButton = canvasElement.querySelector("#age-range");
+
+      await step("연령대 라벨을 클릭하면, 바텀 시트가 열린다.", async () => {
+        await userEvent.click($ageRangeLabel);
+
+        expect($ageRangeTriggerButton).toHaveFocus();
+
+        const $bottomSheet = document.querySelector("#age-range-select");
+
+        expect($bottomSheet).toBeInTheDocument();
+      });
+
+      if (!$ageRangeTriggerButton) return;
+
+      await step(
+        "연령대 바텀시트의 trigger 버튼을 클릭하면, 바텀 시트가 열린다.",
+        async () => {
+          await userEvent.click($ageRangeTriggerButton);
+
+          const $bottomSheet = document.querySelector("#age-range-select");
+
+          expect($bottomSheet).toBeInTheDocument();
+        },
+      );
+
+      await step(
+        "바텀 시트에 '10대'를 선택하면, trigger 버튼에 '10대'가 표시된다.",
+        async () => {
+          const $bottomSheet = document.querySelector("#age-range-select");
+          const $optionList = $bottomSheet?.querySelectorAll("li");
+          const $teenagerOption = $optionList?.[0];
+
+          if (!$teenagerOption) return;
+          await userEvent.click($teenagerOption);
+
+          expect($ageRangeTriggerButton).toHaveTextContent("10대");
+        },
+      );
+
+      await step(
+        "'10대'를 선택한 상태에서 바텀 시트를 다시 열면, '10대' 옵션이 빨간색으로 표시되어 있다.",
+        async () => {
+          await userEvent.click($ageRangeTriggerButton);
+
+          const $bottomSheet = document.querySelector("#age-range-select");
+          expect($bottomSheet).toBeInTheDocument();
+
+          const $optionList = $bottomSheet?.querySelectorAll("li");
+          const $teenagerOption = $optionList?.[0];
+
+          if (!$teenagerOption) return;
+
+          expect($teenagerOption).toHaveClass("text-tangerine-500");
+          await userEvent.click($teenagerOption);
         },
       );
     });

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -8,6 +8,8 @@ import { usePutUserInfoRegistration } from "../api";
 import { useAuthStore } from "@/shared/store/auth";
 import { Select } from "@/shared/ui/select";
 import { useUserInfoRegistrationFormStore } from "../store";
+import { useSnackBar } from "@/shared/lib/overlay";
+import { Snackbar } from "@/shared/ui/snackbar";
 
 const validateNickname = (nickName: string) => {
   const regExp = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{1,20}$/;
@@ -258,6 +260,15 @@ const AgreementCheckboxList = () => {
 };
 
 const UserInfoRegistrationForm = () => {
+  const {
+    handleOpen: openRequiredFieldsAlert,
+    onClose: closeRequiredFieldsAlert,
+  } = useSnackBar(() => (
+    <Snackbar onClose={closeRequiredFieldsAlert}>
+      필수 항목을 모두 입력해 주세요
+    </Snackbar>
+  ));
+
   const token = useAuthStore((state) => state.token);
   const setNickname = useAuthStore((state) => state.setNickname);
   const setRole = useAuthStore((state) => state.setRole);
@@ -281,7 +292,8 @@ const UserInfoRegistrationForm = () => {
       !isNicknameEmpty && ageRange !== null && gender !== null;
 
     if (!areEssentialFieldsFilled) {
-      throw new Error("필수 항목을 모두 입력해 주세요");
+      openRequiredFieldsAlert();
+      return;
     }
 
     const isValidNickname = validateNickname(nickname);

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -6,37 +6,263 @@ import { Input } from "@/shared/ui/input";
 import { useState } from "react";
 import { usePutUserInfoRegistration } from "../api";
 import { useAuthStore } from "@/shared/store/auth";
+import { Select } from "@/shared/ui/select";
+import { useUserInfoRegistrationFormStore } from "../store";
 
-const UserInfoRegistrationForm = () => {
-  // todo: input 상태 리팩토링 필요
-  const [nickname, setNickname] = useState<string>("");
-  const [checkedItems, setCheckedItems] = useState<boolean[]>([
-    false,
-    false,
-    false,
-  ]);
+const validateNickname = (nickName: string) => {
+  const regExp = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{1,20}$/;
+  return regExp.test(nickName);
+};
 
-  // 전체 선택되어 있는 경우
-  const allChecked = checkedItems.every(Boolean);
-  // 전체 선택되어 있지 않고 하나 이상 선택되어 있는 경우
-  const isIndeterminate = checkedItems.some(Boolean) && !allChecked;
-
-  // nickname 제한
-  // 20자 이내의 한글 영어 숫자만 사용 가능합니다.
-  // 특수문자 입력 x
-  // 공백 입력 x
-
-  const validateNickname = (nickName: string) => {
-    const regExp = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{1,20}$/;
-    return regExp.test(nickName);
-  };
+const NicknameInput = () => {
+  const nickname = useUserInfoRegistrationFormStore((state) => state.nickname);
+  const setNickname = useUserInfoRegistrationFormStore(
+    (state) => state.setNickname,
+  );
 
   const isValidNickname = validateNickname(nickname);
 
+  return (
+    <Input
+      type="text"
+      id="nickname"
+      name="nickname"
+      label="닉네임"
+      placeholder="닉네임을 입력해 주세요"
+      statusText="20자 이내의 한글 영어 숫자만 사용 가능합니다."
+      essential
+      componentType="outlinedText"
+      isError={!isValidNickname && nickname.length > 0}
+      value={nickname}
+      onChange={(e) => setNickname(e.target.value)}
+      maxLength={20}
+    />
+  );
+};
+
+const GenderSelect = () => {
+  const genderOptionList = [
+    {
+      value: "MALE",
+      name: "남자",
+    },
+    {
+      value: "FEMALE",
+      name: "여자",
+    },
+  ] as const;
+
+  const gender = useUserInfoRegistrationFormStore((state) => state.gender);
+  const setGender = useUserInfoRegistrationFormStore(
+    (state) => state.setGender,
+  );
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const selectedName = genderOptionList.find((e) => e.value === gender)?.name;
+
+  return (
+    <>
+      <div className="pb-5">
+        <SelectOpener
+          id="gender"
+          name="gender"
+          label="성별"
+          essential
+          placeholder="성별을 선택해 주세요"
+          value={selectedName ?? ""}
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        />
+      </div>
+
+      <Select isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        <Select.BottomSheet>
+          <Select.OptionList>
+            {genderOptionList.map(({ value, name }) => {
+              return (
+                <Select.Option
+                  key={value}
+                  value={value}
+                  isSelected={value === gender}
+                  onClick={() => setGender(value)}
+                >
+                  {name}
+                </Select.Option>
+              );
+            })}
+          </Select.OptionList>
+        </Select.BottomSheet>
+      </Select>
+    </>
+  );
+};
+
+const AgeRangeSelect = () => {
+  const ageRangeOptionList = [
+    {
+      value: 10,
+      name: "10대",
+    },
+    {
+      value: 20,
+      name: "20~30대",
+    },
+    {
+      value: 30,
+      name: "30~40대",
+    },
+    {
+      value: 40,
+      name: "50~60대",
+    },
+    {
+      value: 50,
+      name: "60대 이상",
+    },
+  ] as const;
+
+  const ageRange = useUserInfoRegistrationFormStore((state) => state.ageRange);
+  const setAgeRange = useUserInfoRegistrationFormStore(
+    (state) => state.setAgeRange,
+  );
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const selectedName = ageRangeOptionList.find(
+    (e) => e.value === ageRange,
+  )?.name;
+
+  return (
+    <>
+      <div className="pb-5">
+        <SelectOpener
+          id="age"
+          name="age"
+          label="연령대"
+          essential
+          value={selectedName ?? ""}
+          onClick={() => setIsOpen(true)}
+          placeholder="연령대를 선택해 주세요"
+        />
+      </div>
+
+      <Select isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        <Select.BottomSheet>
+          <Select.OptionList>
+            {ageRangeOptionList.map(({ value, name }) => {
+              return (
+                <Select.Option
+                  key={value}
+                  value={value}
+                  isSelected={value === ageRange}
+                  onClick={() => setAgeRange(value)}
+                >
+                  {name}
+                </Select.Option>
+              );
+            })}
+          </Select.OptionList>
+        </Select.BottomSheet>
+      </Select>
+    </>
+  );
+};
+
+const RegionSetting = () => {
+  return (
+    <div>
+      <div className="flex items-start gap-1 pb-2">
+        <span className="title-3 text-grey-700">동네설정</span>
+        <Badge colorType="primary" />
+      </div>
+
+      <Button
+        type="button"
+        variant="outlined"
+        colorType="tertiary"
+        size="medium"
+      >
+        <MapLocationSearchingIcon />
+        <span>동네 설정하기</span>
+      </Button>
+    </div>
+  );
+};
+
+const AgreementCheckboxList = () => {
+  const agreementList = [
+    {
+      id: "terms-of-service-agreement",
+      label: "이용약관 동의 (필수)",
+      link: "/",
+    },
+    {
+      id: "privacy-policy-agreement",
+      label: "개인정보 수집 및 이용 동의 (필수)",
+      link: "/",
+    },
+    {
+      id: "marketing-information-agreement",
+      label: "마케팅 정보 수신 동의 (선택)",
+      link: "/",
+    },
+  ];
+
+  const checkList = useUserInfoRegistrationFormStore(
+    (state) => state.checkList,
+  );
+  const setCheckList = useUserInfoRegistrationFormStore(
+    (state) => state.setCheckList,
+  );
+
+  // 전체 선택되어 있는 경우
+  const allChecked = checkList.every(Boolean);
+  // 전체 선택되어 있지 않고 하나 이상 선택되어 있는 경우
+  const isIndeterminate = checkList.some(Boolean) && !allChecked;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <AgreementCheckbox
+        id="agree-to-all-terms"
+        checked={allChecked}
+        isIndeterminate={isIndeterminate}
+        label="전체 동의합니다."
+        onChange={(e) => {
+          const { checked } = e.target;
+
+          setCheckList([checked, checked, checked]);
+        }}
+      />
+
+      {agreementList.map(({ id, label, link }, idx) => {
+        return (
+          <AgreementCheckbox
+            key={id}
+            id={id}
+            checked={checkList[idx]}
+            label={label}
+            onChange={() => {
+              const newCheckList = [...checkList];
+              newCheckList[idx] = !newCheckList[idx];
+
+              setCheckList(newCheckList);
+            }}
+            agreementLink={link}
+          />
+        );
+      })}
+    </section>
+  );
+};
+
+const UserInfoRegistrationForm = () => {
+  const { nickname, checkList } = useUserInfoRegistrationFormStore.getState();
+  const isValidNickname = validateNickname(nickname);
+
   const token = useAuthStore((state) => state.token);
-  const userId = useAuthStore((state) => state.userId);
-  // todo: setNickname으로 변경 (set 설정자 함수와 이름이 중복되어 임시방편으로 설정)
-  const setUserNickname = useAuthStore((state) => state.setNickname);
+  const setNickname = useAuthStore((state) => state.setNickname);
   const setRole = useAuthStore((state) => state.setRole);
 
   const { mutate: putUserInfoRegistration } = usePutUserInfoRegistration();
@@ -44,7 +270,7 @@ const UserInfoRegistrationForm = () => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!token || !userId) {
+    if (!token) {
       throw new Error("로그인 정보가 없습니다");
     }
 
@@ -61,7 +287,7 @@ const UserInfoRegistrationForm = () => {
       throw new Error("올바른 닉네임을 입력해 주세요");
     }
 
-    const areRequiredAgreementsChecked = checkedItems[0] && checkedItems[1];
+    const areRequiredAgreementsChecked = checkList[0] && checkList[1];
 
     if (!areRequiredAgreementsChecked) {
       throw new Error("필수 약관에 모두 동의해 주세요");
@@ -70,7 +296,6 @@ const UserInfoRegistrationForm = () => {
     putUserInfoRegistration(
       {
         token,
-        userId,
         nickname,
         gender: "MALE",
         age: 10,
@@ -83,7 +308,7 @@ const UserInfoRegistrationForm = () => {
             content: { nickname, role },
           } = data;
 
-          setUserNickname(nickname);
+          setNickname(nickname);
           setRole(role);
 
           // todo: 회원가입 완료 페이지로 이동
@@ -97,114 +322,16 @@ const UserInfoRegistrationForm = () => {
 
   return (
     <form className="flex flex-col gap-8 self-stretch" onSubmit={handleSubmit}>
-      <section className="flex flex-col gap-8 self-stretch">
-        <Input
-          type="text"
-          id="nickname"
-          name="nickname"
-          label="닉네임"
-          placeholder="닉네임을 입력해 주세요"
-          statusText="20자 이내의 한글 영어 숫자만 사용 가능합니다."
-          essential
-          componentType="outlinedText"
-          isError={!isValidNickname && nickname.length > 0}
-          value={nickname}
-          onChange={(e) => setNickname(e.target.value)}
-        />
-        <SelectOpener
-          id="sex"
-          name="sex"
-          label="성별"
-          essential
-          value={"남자"}
-          placeholder="성별을 선택해 주세요"
-        />
-        <SelectOpener
-          id="age"
-          name="age"
-          label="연령대"
-          essential
-          value={"10대"}
-          placeholder="연령대를 선택해 주세요"
-        />
-
-        <div>
-          <div className="flex items-start gap-1 pb-2">
-            <span className="title-3 text-grey-700">동네설정</span>
-            <Badge colorType="primary" />
-          </div>
-
-          <Button
-            type="button"
-            variant="outlined"
-            colorType="tertiary"
-            size="medium"
-          >
-            <MapLocationSearchingIcon />
-            <span>동네 설정하기</span>
-          </Button>
-        </div>
+      <section className="flex flex-col gap-4 self-stretch">
+        <NicknameInput />
+        <GenderSelect />
+        <AgeRangeSelect />
+        <RegionSetting />
       </section>
 
       <hr className="text-grey-200" />
 
-      <section className="flex flex-col gap-4">
-        <AgreementCheckbox
-          id="agree-to-all-terms"
-          checked={allChecked}
-          isIndeterminate={isIndeterminate}
-          label="전체 동의합니다."
-          onChange={(e) =>
-            setCheckedItems([
-              e.target.checked,
-              e.target.checked,
-              e.target.checked,
-            ])
-          }
-        />
-
-        <AgreementCheckbox
-          id="terms-of-service-agreement"
-          checked={checkedItems[0]}
-          label="이용약관 동의 (필수)"
-          onChange={(e) =>
-            setCheckedItems([
-              e.target.checked,
-              checkedItems[1],
-              checkedItems[2],
-            ])
-          }
-          agreementLink="/"
-        />
-
-        <AgreementCheckbox
-          id="privacy-policy-agreement"
-          label="개인정보 수집 및 이용 동의 (필수)"
-          checked={checkedItems[1]}
-          onChange={(e) =>
-            setCheckedItems([
-              checkedItems[0],
-              e.target.checked,
-              checkedItems[2],
-            ])
-          }
-          agreementLink="/"
-        />
-
-        <AgreementCheckbox
-          id="marketing-information-agreement"
-          label="마케팅 정보 수신 동의 (선택)"
-          checked={checkedItems[2]}
-          onChange={(e) =>
-            setCheckedItems([
-              checkedItems[0],
-              checkedItems[1],
-              e.target.checked,
-            ])
-          }
-          agreementLink="/"
-        />
-      </section>
+      <AgreementCheckboxList />
 
       <Button type="submit" colorType="primary" variant="filled" size="large">
         회원가입

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -11,11 +11,7 @@ import { useUserInfoRegistrationFormStore } from "../store";
 import { useSnackBar } from "@/shared/lib/overlay";
 import { Snackbar } from "@/shared/ui/snackbar";
 import { ageRangeOptionList, genderOptionList } from "../constants/form";
-
-const validateNickname = (nickName: string) => {
-  const regExp = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{1,20}$/;
-  return regExp.test(nickName);
-};
+import { validateNickname } from "../lib";
 
 const NicknameInput = () => {
   const nickname = useUserInfoRegistrationFormStore((state) => state.nickname);

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -268,6 +268,12 @@ const UserInfoRegistrationForm = () => {
       필수 항목을 모두 입력해 주세요
     </Snackbar>
   ));
+  const { handleOpen: openNicknameAlert, onClose: closeNicknameAlert } =
+    useSnackBar(() => (
+      <Snackbar onClose={closeNicknameAlert}>
+        올바른 닉네임을 입력해 주세요
+      </Snackbar>
+    ));
 
   const token = useAuthStore((state) => state.token);
   const setNickname = useAuthStore((state) => state.setNickname);
@@ -299,7 +305,8 @@ const UserInfoRegistrationForm = () => {
     const isValidNickname = validateNickname(nickname);
 
     if (!isValidNickname) {
-      throw new Error("올바른 닉네임을 입력해 주세요");
+      openNicknameAlert();
+      return;
     }
 
     const areRequiredAgreementsChecked = checkList[0] && checkList[1];

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -14,12 +14,25 @@ import { ageRangeOptionList, genderOptionList } from "../constants/form";
 import { validateNickname } from "../lib";
 
 const NicknameInput = () => {
-  const nickname = useUserInfoRegistrationFormStore((state) => state.nickname);
+  const isValidNickname = useUserInfoRegistrationFormStore(
+    (state) => state.isValidNickname,
+  );
   const setNickname = useUserInfoRegistrationFormStore(
     (state) => state.setNickname,
   );
+  const setIsValidNickname = useUserInfoRegistrationFormStore(
+    (state) => state.setIsValidNickname,
+  );
 
-  const isValidNickname = validateNickname(nickname);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: nickname } = e.target;
+    const isValidNickname = validateNickname(nickname);
+
+    const isNicknameEmpty = nickname.length === 0;
+
+    setNickname(nickname);
+    setIsValidNickname(isValidNickname || isNicknameEmpty);
+  };
 
   return (
     <Input
@@ -31,9 +44,8 @@ const NicknameInput = () => {
       statusText="20자 이내의 한글 영어 숫자만 사용 가능합니다."
       essential
       componentType="outlinedText"
-      isError={!isValidNickname && nickname.length > 0}
-      value={nickname}
-      onChange={(e) => setNickname(e.target.value)}
+      isError={!isValidNickname}
+      onChange={handleChange}
       maxLength={20}
     />
   );

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -64,10 +64,15 @@ const GenderSelect = () => {
           onClick={() => {
             setIsOpen(true);
           }}
+          aria-controls="gender-select"
         />
       </div>
 
-      <Select isOpen={isOpen} onClose={() => setIsOpen(false)}>
+      <Select
+        id="gender-select"
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      >
         <Select.BottomSheet>
           <Select.OptionList>
             {genderOptionList.map(({ value, name }) => {
@@ -112,10 +117,11 @@ const AgeRangeSelect = () => {
           value={selectedName ?? ""}
           onClick={() => setIsOpen(true)}
           placeholder="연령대를 선택해 주세요"
+          aria-controls="age-select"
         />
       </div>
 
-      <Select isOpen={isOpen} onClose={() => setIsOpen(false)}>
+      <Select id="age-select" isOpen={isOpen} onClose={() => setIsOpen(false)}>
         <Select.BottomSheet>
           <Select.OptionList>
             {ageRangeOptionList.map(({ value, name }) => {

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -10,6 +10,7 @@ import { Select } from "@/shared/ui/select";
 import { useUserInfoRegistrationFormStore } from "../store";
 import { useSnackBar } from "@/shared/lib/overlay";
 import { Snackbar } from "@/shared/ui/snackbar";
+import { ageRangeOptionList, genderOptionList } from "../constants/form";
 
 const validateNickname = (nickName: string) => {
   const regExp = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{1,20}$/;
@@ -43,17 +44,6 @@ const NicknameInput = () => {
 };
 
 const GenderSelect = () => {
-  const genderOptionList = [
-    {
-      value: "MALE",
-      name: "남자",
-    },
-    {
-      value: "FEMALE",
-      name: "여자",
-    },
-  ] as const;
-
   const gender = useUserInfoRegistrationFormStore((state) => state.gender);
   const setGender = useUserInfoRegistrationFormStore(
     (state) => state.setGender,
@@ -61,7 +51,9 @@ const GenderSelect = () => {
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const selectedName = genderOptionList.find((e) => e.value === gender)?.name;
+  const selectedName = genderOptionList.find(
+    ({ value }) => value === gender,
+  )?.name;
 
   return (
     <>
@@ -102,29 +94,6 @@ const GenderSelect = () => {
 };
 
 const AgeRangeSelect = () => {
-  const ageRangeOptionList = [
-    {
-      value: 10,
-      name: "10대",
-    },
-    {
-      value: 20,
-      name: "20~30대",
-    },
-    {
-      value: 30,
-      name: "30~40대",
-    },
-    {
-      value: 40,
-      name: "50~60대",
-    },
-    {
-      value: 50,
-      name: "60대 이상",
-    },
-  ] as const;
-
   const ageRange = useUserInfoRegistrationFormStore((state) => state.ageRange);
   const setAgeRange = useUserInfoRegistrationFormStore(
     (state) => state.setAgeRange,
@@ -133,7 +102,7 @@ const AgeRangeSelect = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const selectedName = ageRangeOptionList.find(
-    (e) => e.value === ageRange,
+    ({ value }) => value === ageRange,
   )?.name;
 
   return (

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -110,18 +110,22 @@ const AgeRangeSelect = () => {
     <>
       <div className="pb-5">
         <SelectOpener
-          id="age"
-          name="age"
+          id="age-range"
+          name="age-range"
           label="연령대"
           essential
           value={selectedName ?? ""}
           onClick={() => setIsOpen(true)}
           placeholder="연령대를 선택해 주세요"
-          aria-controls="age-select"
+          aria-controls="age-range-select"
         />
       </div>
 
-      <Select id="age-select" isOpen={isOpen} onClose={() => setIsOpen(false)}>
+      <Select
+        id="age-range-select"
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      >
         <Select.BottomSheet>
           <Select.OptionList>
             {ageRangeOptionList.map(({ value, name }) => {

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -274,6 +274,12 @@ const UserInfoRegistrationForm = () => {
         올바른 닉네임을 입력해 주세요
       </Snackbar>
     ));
+  const { handleOpen: openAgreementAlert, onClose: closeAgreementAlert } =
+    useSnackBar(() => (
+      <Snackbar onClose={closeAgreementAlert}>
+        필수 약관에 모두 동의해 주세요
+      </Snackbar>
+    ));
 
   const token = useAuthStore((state) => state.token);
   const setNickname = useAuthStore((state) => state.setNickname);
@@ -312,7 +318,8 @@ const UserInfoRegistrationForm = () => {
     const areRequiredAgreementsChecked = checkList[0] && checkList[1];
 
     if (!areRequiredAgreementsChecked) {
-      throw new Error("필수 약관에 모두 동의해 주세요");
+      openAgreementAlert();
+      return;
     }
 
     // todo: region 수정

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -303,7 +303,7 @@ const UserInfoRegistrationForm = () => {
         token,
         nickname,
         gender,
-        ageRange,
+        age: ageRange,
         region: "서울 강남구",
         marketingYn: checkList[2],
       },

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -258,9 +258,6 @@ const AgreementCheckboxList = () => {
 };
 
 const UserInfoRegistrationForm = () => {
-  const { nickname, checkList } = useUserInfoRegistrationFormStore.getState();
-  const isValidNickname = validateNickname(nickname);
-
   const token = useAuthStore((state) => state.token);
   const setNickname = useAuthStore((state) => state.setNickname);
   const setRole = useAuthStore((state) => state.setRole);
@@ -270,20 +267,26 @@ const UserInfoRegistrationForm = () => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    const { nickname, ageRange, gender, checkList } =
+      useUserInfoRegistrationFormStore.getState();
+
     if (!token) {
       throw new Error("로그인 정보가 없습니다");
     }
 
     const isNicknameEmpty = nickname.length === 0;
 
-    // todo: 조건문 수정 필요
-    // 닉네임, 성별, 연령대, 동네설정 중 하나라도 입력하지 않은 경우
-    if (isNicknameEmpty) {
+    // todo: 조건에 region !== null인 경우 추가하기
+    const areEssentialFieldsFilled =
+      !isNicknameEmpty && ageRange !== null && gender !== null;
+
+    if (!areEssentialFieldsFilled) {
       throw new Error("필수 항목을 모두 입력해 주세요");
     }
 
-    // 닉네임이 유효하지 않은 경우
-    if (!isValidNickname && !isNicknameEmpty) {
+    const isValidNickname = validateNickname(nickname);
+
+    if (!isValidNickname) {
       throw new Error("올바른 닉네임을 입력해 주세요");
     }
 
@@ -293,14 +296,15 @@ const UserInfoRegistrationForm = () => {
       throw new Error("필수 약관에 모두 동의해 주세요");
     }
 
+    // todo: region 수정
     putUserInfoRegistration(
       {
         token,
         nickname,
-        gender: "MALE",
-        age: 10,
+        gender,
+        ageRange,
         region: "서울 강남구",
-        marketingYn: true,
+        marketingYn: checkList[2],
       },
       {
         onSuccess: (data) => {

--- a/src/shared/ui/select/Select.tsx
+++ b/src/shared/ui/select/Select.tsx
@@ -5,10 +5,12 @@ import OptionList from "./OptionList";
 import Option from "./Option";
 
 const SelectMain = ({
+  id,
   isOpen,
   onClose,
   children,
 }: SelectContextType & {
+  id?: string;
   children: ReactNode;
 }) => {
   useEffect(() => {
@@ -22,7 +24,7 @@ const SelectMain = ({
   }, [isOpen]);
 
   return (
-    <SelectContext.Provider value={{ isOpen, onClose }}>
+    <SelectContext.Provider value={{ id, isOpen, onClose }}>
       {children}
     </SelectContext.Provider>
   );

--- a/src/shared/ui/select/Select.tsx
+++ b/src/shared/ui/select/Select.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { SelectContext, SelectContextType } from "./select.context";
 import SelectBottomSheet from "./SelectBottomSheet";
 import OptionList from "./OptionList";
@@ -11,6 +11,16 @@ const SelectMain = ({
 }: SelectContextType & {
   children: ReactNode;
 }) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, [isOpen]);
+
   return (
     <SelectContext.Provider value={{ isOpen, onClose }}>
       {children}

--- a/src/shared/ui/select/SelectBottomSheet.tsx
+++ b/src/shared/ui/select/SelectBottomSheet.tsx
@@ -7,10 +7,10 @@ interface SelectBottomSheetProps {
 }
 
 const SelectBottomSheet = ({ children }: SelectBottomSheetProps) => {
-  const { isOpen, onClose } = useSelectContext();
+  const { id, isOpen, onClose } = useSelectContext();
 
   return (
-    <Sheet isOpen={isOpen} onClose={onClose} detent="content-height">
+    <Sheet id={id} isOpen={isOpen} onClose={onClose} detent="content-height">
       <Sheet.Container>
         <Sheet.Header />
         <Sheet.Content>{children}</Sheet.Content>

--- a/src/shared/ui/select/SelectBottomSheet.tsx
+++ b/src/shared/ui/select/SelectBottomSheet.tsx
@@ -10,7 +10,13 @@ const SelectBottomSheet = ({ children }: SelectBottomSheetProps) => {
   const { id, isOpen, onClose } = useSelectContext();
 
   return (
-    <Sheet id={id} isOpen={isOpen} onClose={onClose} detent="content-height">
+    <Sheet
+      id={id}
+      isOpen={isOpen}
+      onClose={onClose}
+      detent="content-height"
+      mountPoint={document.querySelector("#root")!}
+    >
       <Sheet.Container>
         <Sheet.Header />
         <Sheet.Content>{children}</Sheet.Content>

--- a/src/shared/ui/select/select.context.tsx
+++ b/src/shared/ui/select/select.context.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "react";
 
 export interface SelectContextType {
+  id?: string;
   isOpen: boolean;
   onClose: () => void;
 }


### PR DESCRIPTION
# 관련 이슈 번호

#66

# 설명

## store 생성

form에 대한 store를 생성하였습니다.

```typescript
// store 초기값
nickname: "",
gender: null,
ageRange: null,
region: null,
checkList: [false, false, false],

// store type
type Gender = "FEMALE" | "MALE" | null;
type AgeRange = 10 | 20 | 30 | 40 | 50 | null;
type Region = string | null;
type CheckedList = boolean[];

nickname: string;
gender: Gender;
ageRange: AgeRange;
region: Region;
checkList: CheckedList;
```
회원가입 폼에서 필수 입력 항목(닉네임, 성별, 연령대, 동네)을 처리하기 위해 각 항목마다 컴포넌트를 따로 만들어서, 컴포넌트 내에서 개별적으로 상태를 관리하도록 구현했습니다.

## Select 컴포넌트 수정

### 1. props에 id 추가

select을 여는 요소(`SelectOpener`)에 `aria-controls` 속성 값을 주는 경우를 위해, Select의 props에 id를 추가하였습니다.

```javascript
// select trigger 컴포넌트
<SelectOpener
  aria-controls="gender-select"
  // ...
/>

<Select id="gender-select" {...} >
// ...
</Select>
```

이렇게 설정해두면, "`SelectOpener`는 id가 `gender-select`인 요소를 제어한다."라는 의미를 가지더라구요!
그리고, id 타입이 optional이라 설정 안해주셔도 됩니다.

### 2. body 스크롤 제어

Select이 렌더링 되었을 때, `body.style.overflow`를 `hidden`으로 안바꿨더라구요!
그래서 아래 사진처럼, body 스크롤이 보이는 문제가 발생했습니다.

<img width="1031" alt="스크린샷 2024-09-08 오후 2 21 16" src="https://github.com/user-attachments/assets/20e3a9af-4b6e-44e3-8d18-86408c61e9a0">

isOpen이 true일 경우에는 body의 `overflow`를 `hidden`으로, false일 경우엔 `auto`로 설정했습니다.