### PR TITLE
[Fix] Select.Option에 disabled가 적용 안되는 문제 해결

### DIFF
--- a/src/shared/ui/list/List.stories.tsx
+++ b/src/shared/ui/list/List.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 
 import List, { Item } from "./List";
 
@@ -43,6 +44,10 @@ export const ListItem: ItemStory = {
     },
   },
   render: ({ disabled }) => {
-    return <List.Item disabled={disabled}>Item 1</List.Item>;
+    return (
+      <List.Item disabled={disabled} onClick={action("onClick")}>
+        Item 1
+      </List.Item>
+    );
   },
 };

--- a/src/shared/ui/list/List.tsx
+++ b/src/shared/ui/list/List.tsx
@@ -23,7 +23,11 @@ export const Item = forwardRef<HTMLLIElement, ItemProps>(
         ref={ref}
         className={`${baseStyles} ${disabled ? disabledStyles : ableStyles} ${additionalClassName}`}
         aria-disabled={disabled}
-        onClick={onClick}
+        onClick={(e) => {
+          if (disabled) return;
+
+          onClick?.(e);
+        }}
         {...props}
       >
         {children}

--- a/src/shared/ui/select/Option.tsx
+++ b/src/shared/ui/select/Option.tsx
@@ -17,6 +17,8 @@ const Option = ({
   const { onClose } = useSelectContext();
 
   const handleClick = (e: React.MouseEvent<HTMLLIElement>) => {
+    if (disabled) return;
+
     onClick?.(e);
     onClose();
   };
@@ -31,6 +33,7 @@ const Option = ({
     <List.Item
       onClick={handleClick}
       additionalClassName={textColorStyles}
+      disabled={disabled}
       {...props}
     >
       {children}

--- a/src/shared/ui/select/Select.stories.tsx
+++ b/src/shared/ui/select/Select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 
 import Select from "./Select";
 import { useState } from "react";
@@ -89,6 +90,47 @@ export const BottomSheetSelect: Story = {
                     onClick={() => setSelectedValue(value)}
                   >
                     {name}
+                  </Select.Option>
+                );
+              })}
+            </Select.OptionList>
+          </Select.BottomSheet>
+        </Select>
+      </>
+    );
+  },
+};
+
+export const WithDisabledOption: Story = {
+  render: () => {
+    const optionList = [1, 2, 3, 4, 5];
+
+    /* eslint-disable */
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const [selectedValue, setSelectedValue] = useState<number | null>(null);
+
+    return (
+      <>
+        {/* select 컴포넌트를 여는 trigger */}
+        <button onClick={() => setIsOpen(true)}>click option</button>
+        <div>value: {selectedValue}</div>
+
+        <Select isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <Select.BottomSheet>
+            <Select.OptionList>
+              {optionList.map((value) => {
+                return (
+                  <Select.Option
+                    key={value}
+                    value={value}
+                    isSelected={value === selectedValue}
+                    onClick={() => {
+                      action("onClick")(value);
+                      setSelectedValue(value);
+                    }}
+                    disabled={value === 5}
+                  >
+                    {value}
                   </Select.Option>
                 );
               })}

--- a/src/shared/ui/select/SelectBottomSheet.tsx
+++ b/src/shared/ui/select/SelectBottomSheet.tsx
@@ -19,7 +19,9 @@ const SelectBottomSheet = ({ children }: SelectBottomSheetProps) => {
     >
       <Sheet.Container>
         <Sheet.Header />
-        <Sheet.Content>{children}</Sheet.Content>
+        <Sheet.Content>
+          <Sheet.Scroller>{children}</Sheet.Scroller>
+        </Sheet.Content>
       </Sheet.Container>
       <Sheet.Backdrop onTap={onClose} />
     </Sheet>


### PR DESCRIPTION
# 관련 이슈 번호

#107

# 설명

## Select.Option의 disabled가 적용 안되는 문제

`List.Item`에 `disabled`를 넘겨주지 않아서였습니다 😢 

`Select.Option`과 `List.Item`에 `disabled`가 true이면, click handler가 실행되지 못하도록 하였습니다.

## SelectBottomSheet 내부에 컨텐츠가 많을 때, 스크롤이 되지 않는 문제

children에 `Sheet.Scroller`를 감싸서 스크롤이 가능하게 하였습니다.

```javascript
const SelectBottomSheet = ({ children }: SelectBottomSheetProps) => {
  const { id, isOpen, onClose } = useSelectContext();

  return (
    <Sheet
      id={id}
      isOpen={isOpen}
      onClose={onClose}
      detent="content-height"
      mountPoint={document.querySelector("#root")!}
    >
      <Sheet.Container>
        <Sheet.Header />
        <Sheet.Content>
          <Sheet.Scroller>{children}</Sheet.Scroller>
        </Sheet.Content>
      </Sheet.Container>
      <Sheet.Backdrop onTap={onClose} />
    </Sheet>
  );
};
```

## storybook의 actions 설정

List와 Select 스토리북에서 disabled인 옵션의 click handler가 실행되는지 테스트 해보실 수 있어요!

https://github.com/user-attachments/assets/4837b1d0-b2c4-40a7-bba6-b75ead88d1ab


https://github.com/user-attachments/assets/c52be336-2fb9-48cb-b264-c25047346c58


