### PR TITLE
[Feat] Modal 컴포넌트 생성

### DIFF
--- a/src/entities/map/ui/FloatingButton.styles.ts
+++ b/src/entities/map/ui/FloatingButton.styles.ts
@@ -1,5 +1,5 @@
 export const floatingButtonStyles = {
-  base: "shadow-floating-button relative flex h-12 w-12 items-center justify-center gap-[10px] rounded-2xl bg-grey-0 px-3 disabled:text-grey-300",
+  base: "shadow-custom-1 relative flex h-12 w-12 items-center justify-center gap-[10px] rounded-2xl bg-grey-0 px-3 disabled:text-grey-300",
   active: "text-tangerine-500",
   inactive: "text-grey-500",
 };

--- a/src/shared/lib/overlay.ts
+++ b/src/shared/lib/overlay.ts
@@ -48,6 +48,9 @@ export const useSnackBar: UseOverlay = (createOverlayComponent, options) => {
   });
 };
 
+/**
+ * useModal 의 경우엔 모달간 상호작용을 막기 위해 disableInteraction 을 true 로 설정합니다.
+ */
 export const useModal: UseOverlay = (createOverlayComponent, options) => {
   return useOverlay(createOverlayComponent, {
     disableInteraction: true,

--- a/src/shared/lib/overlay.ts
+++ b/src/shared/lib/overlay.ts
@@ -1,10 +1,18 @@
 import { useState } from "react";
 import { OverlayOptions, useOverlayStore } from "../store/overlay";
 
-// TODO overlay 를 사용하는 훅이 대체 되면 export 하지 않기
-export const useOverlay = (
+type UseOverlay = (
   createOverlayComponent: (onClose: () => Promise<void>) => JSX.Element,
-  options: OverlayOptions = {},
+  options?: OverlayOptions,
+) => {
+  handleOpen: () => Promise<void>;
+  onClose: () => Promise<void>;
+  isOpen: boolean;
+};
+
+export const useOverlay: UseOverlay = (
+  createOverlayComponent,
+  options = {},
 ) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const { disableInteraction = true, beforeClose, afterClose } = options;
@@ -33,12 +41,16 @@ export const useOverlay = (
   return { handleOpen, onClose, isOpen };
 };
 
-export const useSnackBar = (
-  createOverlayComponent: (onClose: () => Promise<void>) => JSX.Element,
-  options?: OverlayOptions,
-) => {
+export const useSnackBar: UseOverlay = (createOverlayComponent, options) => {
   return useOverlay(createOverlayComponent, {
     disableInteraction: false,
+    ...options,
+  });
+};
+
+export const useModal: UseOverlay = (createOverlayComponent, options) => {
+  return useOverlay(createOverlayComponent, {
+    disableInteraction: true,
     ...options,
   });
 };

--- a/src/shared/lib/overlay.ts
+++ b/src/shared/lib/overlay.ts
@@ -48,9 +48,6 @@ export const useSnackBar: UseOverlay = (createOverlayComponent, options) => {
   });
 };
 
-/**
- * useModal 의 경우엔 모달간 상호작용을 막기 위해 disableInteraction 을 true 로 설정합니다.
- */
 export const useModal: UseOverlay = (createOverlayComponent, options) => {
   return useOverlay(createOverlayComponent, {
     disableInteraction: true,

--- a/src/shared/ui/modal/Modal.mocks.tsx
+++ b/src/shared/ui/modal/Modal.mocks.tsx
@@ -1,0 +1,55 @@
+import { Modal } from "./Modal";
+
+/**
+ * 만약 특별한 애니메이션이나 beforeClose를 사용하고 싶다면 마운트 된 모달을 찾을 수 있는 식별자를 추가해주세요
+ */
+export const CenterModal = ({
+  onClose,
+  id,
+}: {
+  onClose: () => Promise<void>;
+  id: string;
+}) => {
+  return (
+    <Modal modalType="center" id={id}>
+      <h1>Center Modal 입니다.</h1>
+      <p>Modal Content</p>
+      <div className="flex justify-end px-2 py-2">
+        <button
+          onClick={onClose}
+          className="rounded-xl border px-2 py-2 text-tangerine-500"
+        >
+          모달 닫기
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export const FullPageModal = ({
+  onClose,
+}: {
+  onClose: () => Promise<void>;
+}) => {
+  return (
+    <Modal modalType="fullPage">
+      <h1 className="text-center">FullPage Modal 입니다.</h1>
+      <p className="mx-4 my-4">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Nostrum
+        dignissimos tenetur laboriosam commodi. Ducimus facilis cum autem
+        consequatur, accusantium animi velit corporis minima nihil quia aliquid
+        sapiente neque cumque dolore?
+      </p>
+      <div className="h-full">
+        <div className="flex justify-end px-2 py-2">
+          <button
+            onClick={onClose}
+            className="rounded-xl border px-2 py-2 text-tangerine-500"
+          >
+            모달 닫기
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/src/shared/ui/modal/Modal.stories.tsx
+++ b/src/shared/ui/modal/Modal.stories.tsx
@@ -1,0 +1,71 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Modal } from "./Modal";
+import { OverlayPortal } from "@/app/OverlayPortal";
+import { useModal } from "@/shared/lib/overlay";
+import { CenterModal, FullPageModal } from "./Modal.mocks";
+
+const meta: Meta<typeof Modal> = {
+  title: "shared/Modal",
+  component: Modal,
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof Modal> = {
+  decorators: [
+    (Story) => (
+      <div id="root">
+        <OverlayPortal />
+        <Story />
+      </div>
+    ),
+  ],
+
+  render: () => {
+    /*eslint-disable*/
+    const { handleOpen: handleOpenCenterModal, onClose: onCloseCenterModal } =
+      useModal(
+        () => <CenterModal onClose={onCloseCenterModal} id="animation" />,
+        {
+          beforeClose: async () => {
+            const $modal = document.getElementById("animation")!;
+            $modal.style.transition = "opacity 0.2s";
+            $modal.style.opacity = "0";
+            await new Promise((resolve) => setTimeout(resolve, 200));
+          },
+        },
+      );
+
+    const {
+      handleOpen: handleOpenFullPageModal,
+      onClose: onCloseFullPageModal,
+    } = useModal(() => <FullPageModal onClose={onCloseFullPageModal} />);
+
+    return (
+      <div className="flex h-96 flex-col justify-between rounded-2xl border px-2 py-2">
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa aliquid
+          nostrum odit. Quam veritatis, illo aut perferendis ea modi culpa,
+          necessitatibus officiis laboriosam beatae, exercitationem aliquid
+          vitae id non. Reiciendis!
+        </p>
+        <div className="flex items-end justify-end">
+          <div className="flex gap-2 py-2">
+            <button
+              className="rounded-xl border px-2 py-2 text-tangerine-500"
+              onClick={handleOpenCenterModal}
+            >
+              Center Modal 열기
+            </button>
+            <button
+              className="rounded-xl border px-2 py-2 text-tangerine-500"
+              onClick={handleOpenFullPageModal}
+            >
+              FullPage Modal 열기
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/shared/ui/modal/Modal.styles.ts
+++ b/src/shared/ui/modal/Modal.styles.ts
@@ -1,6 +1,3 @@
-/**
- *
- */
 export const modalStyles = {
   fullPage: "fixed left-0 top-0 h-full w-full flex-col gap-8 bg-grey-0",
   center:

--- a/src/shared/ui/modal/Modal.styles.ts
+++ b/src/shared/ui/modal/Modal.styles.ts
@@ -1,0 +1,8 @@
+/**
+ *
+ */
+export const modalStyles = {
+  fullPage: "fixed left-0 top-0 h-full w-full flex-col gap-8 bg-grey-0",
+  center:
+    "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 flex w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 bg-grey-0",
+} as const;

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -1,0 +1,24 @@
+import { modalStyles } from "./Modal.styles";
+
+type ModalType = keyof typeof modalStyles;
+
+interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  modalType: ModalType;
+  className?: string;
+}
+
+export const Modal = ({
+  modalType,
+  className = "",
+  children,
+  ...props
+}: ModalProps) => {
+  const modalBaseClassName = modalStyles[modalType];
+
+  return (
+    <section className={`${modalBaseClassName} ${className}`} {...props}>
+      {children}
+    </section>
+  );
+};

--- a/src/shared/ui/modal/index.ts
+++ b/src/shared/ui/modal/index.ts
@@ -1,0 +1,1 @@
+export * from "./Modal";

--- a/src/shared/ui/snackbar/Snackbar.tsx
+++ b/src/shared/ui/snackbar/Snackbar.tsx
@@ -35,7 +35,7 @@ export const Snackbar = ({
   }, [autoHideDuration, onClose]);
 
   const baseClassName =
-    "shadow-info-snackbar inline-flex min-w-[328px] max-w-96 items-center justify-between rounded-2xl bg-grey-0 py-1 pl-4 pr-3";
+    "shadow-custom-2 inline-flex min-w-[328px] max-w-96 items-center justify-between rounded-2xl bg-grey-0 py-1 pl-4 pr-3";
 
   return (
     <div className={`${baseClassName} ${positionClassName}`} {...props}>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,9 +13,9 @@ export default {
     colors,
     extend: {
       boxShadow: {
-        "floating-button":
+        "custom-1":
           "0px 4px 8px 3px rgba(0, 0, 0, 0.15), 0px 1px 3px 0px rgba(0, 0, 0, 0.30)",
-        "info-snackbar":
+        "custom-2":
           "0px 1px 3px 0px rgba(0, 0, 0, 0.30), 0px 4px 8px 3px rgba(0, 0, 0, 0.15)",
       },
       backgroundColor: {


### PR DESCRIPTION
# 관련 이슈 번호
close #128 

# 설명
![image](https://github.com/user-attachments/assets/b756a5ae-cb92-45e1-9203-fd8e8d0cd139)
![image](https://github.com/user-attachments/assets/be65703e-f427-4d1b-8dbd-959de9a76a91)

중심에 생성되는 모달과 풀페이지 모달을 생성했습니다.

### Modal 컴포넌트

```tsx
// Modal.tsx
import { modalStyles } from "./Modal.styles";

type ModalType = keyof typeof modalStyles;

interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
  children: React.ReactNode;
  modalType: ModalType;
  className?: string;
}

export const Modal = ({
  modalType,
  className = "",
  children,
  ...props
}: ModalProps) => {
  const modalBaseClassName = modalStyles[modalType];

  return (
    <section className={`${modalBaseClassName} ${className}`} {...props}>
      {children}
    </section>
  );
};
```

모달 컴포넌트는 정말 단순하게 `Wrapper` 컴포넌트 그 이상, 이하의 작업도 하지 않습니다. 

만약 디자인 시스템 상 `Modal` 컴포넌트에서 추가적인 스타일을 적용해주고 싶다면 `className` 을 통해 추가해주면 됩니다. 

기본적인 모달의 스타일은 다음과 같습니다.

```tsx
// Modal.styles.ts
export const modalStyles = {
  fullPage: "fixed left-0 top-0 h-full w-full flex-col gap-8 bg-grey-0",
  center:
    "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 flex w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 bg-grey-0",
} as const;
```

`fullPage` 의 경우엔 뷰포트 전체를 채우며 `center` 인 경우엔 피그마에 나와있는 기준의 너비를 가진 모달 레이아웃이 생성됩니다. 

### useModal 훅 

```tsx
/**
 * useModal 의 경우엔 모달간 상호작용을 막기 위해 disableInteraction 을 true 로 설정합니다.
 */
export const useModal: UseOverlay = (createOverlayComponent, options) => {
  return useOverlay(createOverlayComponent, {
    disableInteraction: true,
    ...options,
  });
};
```

모달을 사용하기 위한 `useModal` 훅을 생성했습니다. 

추후 모달이 닫힐 때의 애니메이션이 결정된다면 `useModal` 내부에서 `options` 부분에 `beforeClose` 부분을 추가해주면 됩니다. 

> `beforeClose` 에서 애니메이션을 위해 마운트 된 모달들을 찾기 위한 식별자가 필요합니다.
> 애니메이션 기능이 추가되면   `beforeClose` 메소드 내부에서 모달에 `document.querySelector('.modal')` 등으로 접근하기 위해 `Modal` 컴포넌트에서도 식별자를 추가해줘야 합니다.

 `useModal` 훅을 생성하며 `shared/lib/overlay.ts` 에서 훅들의 타입을 타입 앨리어스 형태로 리팩토링해줬습니다.
 ```tsx
type UseOverlay = (
  createOverlayComponent: (onClose: () => Promise<void>) => JSX.Element,
  options?: OverlayOptions,
) => {
  handleOpen: () => Promise<void>;
  onClose: () => Promise<void>;
  isOpen: boolean;
};
```

다음과 같이 오버레이 훅들의 타입을 앨리어스로 정의하고 `useOverlay` 를 호출하는 훅의 타입 선언 방식을 단순화 했습니다.
```tsx
export const useSnackBar: UseOverlay = (createOverlayComponent, options) => {
  return useOverlay(createOverlayComponent, {
    disableInteraction: false,
    ...options,
  });
};

/**
 * useModal 의 경우엔 모달간 상호작용을 막기 위해 disableInteraction 을 true 로 설정합니다.
 */
export const useModal: UseOverlay = (createOverlayComponent, options) => {
  return useOverlay(createOverlayComponent, {
    disableInteraction: true,
    ...options,
  });
};
```

### 사용 예시 

```tsx
/**
 * 만약 특별한 애니메이션이나 beforeClose를 사용하고 싶다면 마운트 된 모달을 찾을 수 있는 식별자를 추가해주세요
 */
export const CenterModal = ({
  onClose,
  id,
}: {
  onClose: () => Promise<void>;
  id: string;
}) => {
  return (
    <Modal modalType="center" id={id}>
      <h1>Center Modal 입니다.</h1>
      <p>Modal Content</p>
      <div className="flex justify-end px-2 py-2">
        <button
          onClick={onClose}
          className="rounded-xl border px-2 py-2 text-tangerine-500"
        >
          모달 닫기
        </button>
      </div>
    </Modal>
  );
};
```
> 현재는 애니메이션 작동 유무를 확인하기 위해 `CenterModal` 에서 `id` 를 `props` 로 받았습니다.

`Modal` 은 이미 `FlexBox` 이면서 `gap, padding` 등의 스타일이 적용되어 있습니다. 그렇기에 `Modal` 컴포넌트 내에 컴포넌트들을 만들어 사용해주세요 

```tsx
() => {
    /*eslint-disable*/
    const { handleOpen: handleOpenCenterModal, onClose: onCloseCenterModal } =
      useModal(
        () => <CenterModal onClose={onCloseCenterModal} id="animation" />,
        {
          beforeClose: async () => {
            const $modal = document.getElementById("animation")!;
            $modal.style.transition = "opacity 0.2s";
            $modal.style.opacity = "0";
            await new Promise((resolve) => setTimeout(resolve, 200));
          },
        },
      );

    const {
      handleOpen: handleOpenFullPageModal,
      onClose: onCloseFullPageModal,
    } = useModal(() => <FullPageModal onClose={onCloseFullPageModal} />);

    return (
      <div className="flex h-96 flex-col justify-between rounded-2xl border px-2 py-2">
        <p>
          Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa aliquid
          nostrum odit. Quam veritatis, illo aut perferendis ea modi culpa,
          necessitatibus officiis laboriosam beatae, exercitationem aliquid
          vitae id non. Reiciendis!
        </p>
        <div className="flex items-end justify-end">
          <div className="flex gap-2 py-2">
            <button
              className="rounded-xl border px-2 py-2 text-tangerine-500"
              onClick={handleOpenCenterModal}
            >
              Center Modal 열기
            </button>
            <button
              className="rounded-xl border px-2 py-2 text-tangerine-500"
              onClick={handleOpenFullPageModal}
            >
              FullPage Modal 열기
            </button>
          </div>
        </div>
      </div>
    );
  },
```

### 소소한 리팩토링 

`tailwind.config` 에서 `box-shadow` 들을 처음엔 `shadow-floating-button , shadow-info-snackbar` 로 정의해줬었는데 보다보니 재사용되는 `shadow` 들이더군요 

그래서 이름을 `shadow-custom-1 , shadow-custom-2` 로 리팩토링 해줬습니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
