### PR TITLE
[Hotfix] Full Page 모달 너비 변경

### DIFF
--- a/src/entities/map/ui/Pin.stories.tsx
+++ b/src/entities/map/ui/Pin.stories.tsx
@@ -25,19 +25,19 @@ export const Default: Story = {
     <>
       <div>
         <h1>Default Pin</h1>
-        <Pin.Default imageUrl="/public/default-profile.svg" alt="기본 이미지" />
+        <Pin.Default imageUrl="/public/default-image.png" alt="기본 이미지" />
       </div>
       <div>
         <h1>Multiple Pin</h1>
         <p>MultiplePin 에서 markerCount의 최대값은 99입니다.</p>
         <div className="flex gap-4">
           <Pin.Multiple
-            imageUrl="/public/default-profile.svg"
+            imageUrl="/public/default-image.png"
             markerCount={2}
             alt="기본 이미지"
           />
           <Pin.Multiple
-            imageUrl="/public/default-profile.svg"
+            imageUrl="/public/default-image.png"
             markerCount={5000}
             alt="기본 이미지"
           />

--- a/src/shared/ui/modal/Modal.styles.ts
+++ b/src/shared/ui/modal/Modal.styles.ts
@@ -1,6 +1,6 @@
 export const modalStyles = {
   fullPage:
-    "left-0 top-0 h-full w-[37.5rem] mx-auto flex-col gap-8 bg-grey-0 overflow-y-auto",
+    "left-0 top-0 h-full w-full max-w-[37.5rem] mx-auto flex-col gap-8 bg-grey-0 overflow-y-auto",
   center:
     "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 flex w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 bg-grey-0",
 } as const;

--- a/src/shared/ui/modal/Modal.styles.ts
+++ b/src/shared/ui/modal/Modal.styles.ts
@@ -1,6 +1,6 @@
 export const modalStyles = {
   fullPage:
-    "fixed left-0 top-0 h-full w-full flex-col gap-8 bg-grey-0 overflow-y-auto",
+    "left-0 top-0 h-full w-[37.5rem] mx-auto flex-col gap-8 bg-grey-0 overflow-y-auto",
   center:
     "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 flex w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 bg-grey-0",
 } as const;


### PR DESCRIPTION
# 관련 이슈 번호
#146  
# 설명

기본 `Full Page` 모달의 너비를 `fixed w-100%` 였던 부분을 `static (기본) w-full max-w-[37.5rem] mx-auto` 으로 변경했습니다. 

이에 모바일 환경에서도 `MobieLayout` 의 크기와 동일하게 렌더링 됩니다. 

+ 추가로 `Pin` 부분에서 이미지 경로를 수정했습니다. 

> 하면서 느끼는게 확실히 경로나 변수명, 메시지 등을 하나의 리소스로 관리하는편이 좋겠다 느껴지네요 , 여기 저기서 수정 된 것들을 찾기가 쉽지 않군요 🥲

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
