### PR TITLE
[Feat] useMapStore 생성

### DIFF
--- a/src/features/map/constants/index.ts
+++ b/src/features/map/constants/index.ts
@@ -50,3 +50,12 @@ export const mapOptions = {
   // 모든 제스처를 활성화합니다. 사용자는 한 손가락으로 드래그하고, 두 손가락으로 확대/축소할 수 있습니다.
   gestureHandling: "greedy",
 };
+
+export const MAP_INITIAL_CENTER = { lat: 37.5665, lng: 126.978 };
+export const MAP_INITIAL_ZOOM = 16;
+export const MAP_INITIAL_BOUNDS = {
+  east: 126.98218424603498,
+  north: 37.572444179048894,
+  south: 37.56055534657849,
+  west: 126.97381575396503,
+};

--- a/src/features/map/store/index.ts
+++ b/src/features/map/store/index.ts
@@ -1,0 +1,1 @@
+export * from "./map";

--- a/src/features/map/store/map.ts
+++ b/src/features/map/store/map.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+import {
+  MAP_INITIAL_CENTER,
+  MAP_INITIAL_BOUNDS,
+  MAP_INITIAL_ZOOM,
+} from "../constants";
+
+export interface Bounds {
+  east: number;
+  north: number;
+  south: number;
+  west: number;
+}
+
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export interface MapInfo {
+  bounds: Bounds;
+  center: LatLng;
+  zoom: number;
+}
+
+interface MapState {
+  mapInfo: MapInfo;
+}
+
+interface MapActions {
+  setMapInfo: (mapInfo: MapInfo) => void;
+}
+
+const mapStoreInitialState: MapState = {
+  mapInfo: {
+    center: MAP_INITIAL_CENTER,
+    zoom: MAP_INITIAL_ZOOM,
+    bounds: MAP_INITIAL_BOUNDS,
+  },
+};
+
+export const useMapStore = create<MapState & MapActions>((set) => ({
+  ...mapStoreInitialState,
+  setMapInfo: (mapInfo) => set({ mapInfo }),
+}));

--- a/src/shared/lib/debounce.ts
+++ b/src/shared/lib/debounce.ts
@@ -1,0 +1,17 @@
+export function debounce<T extends (...args: Parameters<T>) => void>(
+  callbackFn: T,
+  delay: number,
+): (...args: Parameters<T>) => void {
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+
+  return (...args: Parameters<T>) => {
+    if (timerId) {
+      clearTimeout(timerId);
+    }
+
+    timerId = setTimeout(() => {
+      callbackFn(...args);
+      timerId = null;
+    }, delay);
+  };
+}

--- a/src/widgets/map/ui/GoogleMaps.tsx
+++ b/src/widgets/map/ui/GoogleMaps.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from "react";
-import { Map } from "@vis.gl/react-google-maps";
+import { Map, MapCameraChangedEvent } from "@vis.gl/react-google-maps";
 import { MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM } from "@/features/map/constants";
+import { useMapStore } from "@/features/map/store/map";
+import { debounce } from "@/shared/lib/debounce";
 import { mapOptions } from "../constants";
 
 const GOOGLE_MAPS_MAP_ID = import.meta.env.VITE_GOOGLE_MAPS_ID;
@@ -13,6 +15,14 @@ interface GoogleMapProps {
  * 기본적으로 GoogleMaps 는 w-full h-full relative로 설정 되어 있습니다.
  */
 export const GoogleMaps = ({ children }: GoogleMapProps) => {
+  const setMapInfo = useMapStore((state) => state.setMapInfo);
+  const DELAY_SET_MAP_INFO = 500;
+
+  const handleMapChange = debounce(({ detail }: MapCameraChangedEvent) => {
+    const { bounds, center, zoom } = detail;
+    setMapInfo({ bounds, center, zoom });
+  }, DELAY_SET_MAP_INFO);
+
   // 해당 useEffect는 Google Maps API를 사용할 때, 기본적으로 제공되는 outline을 제거하기 위한 코드입니다.
   // 기본 outline에 해당하는 div 태그는 iframe 태그 다음에 존재하고 있습니다.
   // iframe의 경우 기본 마운트보다 늦게 마운트 되기 때문에 interval을 이용해 iframe을 찾을 때 까지 비동기적으로 반복합니다.
@@ -40,6 +50,8 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
       defaultCenter={MAP_INITIAL_CENTER}
       defaultZoom={MAP_INITIAL_ZOOM}
       reuseMaps // Map 컴포넌트가 unmount 되었다가 다시 mount 될 때 기존의 map instance 를 재사용 하여 memory leak을 방지합니다.
+      // debounce 를 이용하여 MapStore 의 mapInfo 를 변경합니다.
+      onCameraChanged={handleMapChange}
     >
       {children}
     </Map>

--- a/src/widgets/map/ui/GoogleMaps.tsx
+++ b/src/widgets/map/ui/GoogleMaps.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Map } from "@vis.gl/react-google-maps";
+import { MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM } from "@/features/map/constants";
 import { mapOptions } from "../constants";
 
 const GOOGLE_MAPS_MAP_ID = import.meta.env.VITE_GOOGLE_MAPS_ID;
@@ -36,8 +37,8 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
       mapId={GOOGLE_MAPS_MAP_ID}
       options={mapOptions}
       // TODO 상태 붙혀서 default Center 이동시키기
-      defaultCenter={{ lat: 37.5665, lng: 126.978 }}
-      defaultZoom={16}
+      defaultCenter={MAP_INITIAL_CENTER}
+      defaultZoom={MAP_INITIAL_ZOOM}
       reuseMaps // Map 컴포넌트가 unmount 되었다가 다시 mount 될 때 기존의 map instance 를 재사용 하여 memory leak을 방지합니다.
     >
       {children}


### PR DESCRIPTION
# 관련 이슈 번호
close #156 
# 설명

### 목적

여태 지도가 이동하여 지도의 중심 좌표 및 줌 레벨 등이 변하면 

`useMap` 으로 불러온 `Map` 인스턴스 내부 정보들도 변경 될 줄 알았는데 그렇지 않더군요 ..

그래서 지도의 정보들을 상태값으로서 저장하고 있어야 합니다.  

---

# `Map.onCameraChanged` 시 나타나는 이벤트 객체 

카메라 이벤트 발생 할 때 접근 가능한 `MapCameraChangedEvent` 객체엔 다음과 같은 정보들이 존재 합니다. 

![image](https://github.com/user-attachments/assets/60e6d007-9297-4f73-a665-8de3be07b007)

우리가 사용 할 정보들은 `lat , lng , boundary , zoom` 이기에 해당 값들을 스토어로 저장 해야 합니다. 

---

# debounce 메소드 생성

```tsx
// shared/lib/debounce.ts
export function debounce<T extends (...args: Parameters<T>) => void>(
  callbackFn: T,
  delay: number,
): (...args: Parameters<T>) => void {
  let timerId: ReturnType<typeof setTimeout> | null = null;

  return (...args: Parameters<T>) => {
    if (timerId) {
      clearTimeout(timerId);
    }

    timerId = setTimeout(() => {
      callbackFn(...args);
      timerId = null;
    }, delay);
  };
}
```

다음과 같이 인수로 받은 콜백 함수를 디바운스 된 메소드로 반환하는 메소드를 생성했습니다.

# useMapStore 생성

```tsx
// features/map/store/map.ts
import { create } from "zustand";
import {
  MAP_INITIAL_CENTER,
  MAP_INITIAL_BOUNDS,
  MAP_INITIAL_ZOOM,
} from "../constants";

export interface Bounds {
  east: number;
  north: number;
  south: number;
  west: number;
}

export interface LatLng {
  lat: number;
  lng: number;
}

export interface MapInfo {
  bounds: Bounds;
  center: LatLng;
  zoom: number;
}

interface MapState {
  mapInfo: MapInfo;
}

interface MapActions {
  setMapInfo: (mapInfo: MapInfo) => void;
}

const mapStoreInitialState: MapState = {
  mapInfo: {
    center: MAP_INITIAL_CENTER,
    zoom: MAP_INITIAL_ZOOM,
    bounds: MAP_INITIAL_BOUNDS,
  },
};

export const useMapStore = create<MapState & MapActions>((set) => ({
  ...mapStoreInitialState,
  setMapInfo: (mapInfo) => set({ mapInfo }),
}));
```

이후 구글 맵의 위치 정보를 저장하기 위한 스토어를 생성했습니다.

---

# useMapStore GoogleMap 컴포넌트에 부착

```tsx
export const GoogleMaps = ({ children }: GoogleMapProps) => {
  const setMapInfo = useMapStore((state) => state.setMapInfo);

  const DELAY_SET_MAP_INFO = 500;

  const handleMapChange = debounce(({ detail }: MapCameraChangedEvent) => {
    const { bounds, center, zoom } = detail;
    setMapInfo({ bounds, center, zoom });
  }, DELAY_SET_MAP_INFO);

  return (
    <Map
      ...
      onCameraChanged={handleMapChange}
    >
      {children}
    </Map>
  );
};
```

이후 `onCameraChanged` 이벤트에 디바운스 된 핸들러를 부착하여 `500ms` 이후 상태가 스토어에 저장 됩니다. 





# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
