### PR TITLE
[Hotfix] OverlayPortal 인터렉션 막히는 문제 해결

### DIFF
--- a/src/app/OverlayPortal.tsx
+++ b/src/app/OverlayPortal.tsx
@@ -58,13 +58,13 @@ export const OverlayPortal = () => {
 
   // 떠있는 overlay 중 하나라도 전체 뷰포트를 덮어야 하는 경우 배경색을 검정색으로 설정합니다.
   const overlayAreaBackground = shouldDisableInteraction
-    ? "bg-translucent-gray" // bg-gray-900 + opacity.32
+    ? "h-screen bg-translucent-gray" // bg-gray-900 + opacity.32
     : "";
 
   if (overlays.length === 0) return null;
   return createPortal(
     <div
-      className={`fixed left-0 top-0 z-[1000] h-screen w-screen ${overlayAreaBackground}`}
+      className={`fixed left-0 top-0 z-[1000] w-screen ${overlayAreaBackground}`}
     >
       {overlays.map((overlayInfo) => (
         <OverlayWrapper key={overlayInfo.id} overlayInfo={overlayInfo} />


### PR DESCRIPTION
# 관련 이슈 번호
close #159 
# 설명

이전 `OverlayPortal` 에선 `shouldDisabledInteraction` 이 `false` 여도 `OverlayPortal` 컴포넌트 자체가 `w-screen , h-screen` 이여서 

스크롤만 가능했을 뿐,  인터렉션은 못했습니다. 

이에 `OverlayPortal` 컴포넌트의 크기를 `sholdDisabledInteraction` 이 `false` 이면 뷰포트 전체를 채우지 않도록 수정해주었습니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
