### PR TITLE
[Chore] 스토리북 CI 환경 생성

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -35,6 +35,6 @@ jobs:
           onlyChanged: true
 
       - name: comment PR with chromatic results
-        uses: thollander/actions-comment-pull-request@v1
+        uses: thollander/actions-comment-pull-request@v2
         with:
           message: "👀 코드리뷰 전! Storybook 미리보기: ${{ steps.chromatic.outputs.storybookUrl }}"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.YONGHYEUN_GITHUB_TOKEN }}
+          exitZeroOnChanges: true
+          onlyChanged: true
 
       - name: comment PR with chromatic results
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -10,45 +10,19 @@ jobs:
     name: Run Chromatic and Test Storybook
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: Install dependencies
-        run: npm ci
-      - name: Install playwright browsers
-        run: npx playwright install
-      - name: Run interaction tests and save output
-        id: test-storybook
-        run: npm run test-storybook 2> >(sed 's/\x1b\[[0-9;]*m//g' > test-storybook-output.txt)
-        continue-on-error: true
-      - name: Post test results as PR comment
-        uses: actions/github-script@v6
-        if: always()
-        with:
-          github-token: ${{secrets.YONGHYEUN_GITHUB_TOKEN}}
-          script: |
-            const fs = require('fs');
-            const output = fs.readFileSync('test-storybook-output.txt', 'utf8');
-            const outcome = "${{ steps.test-storybook.outcome }}"; 
-            const success = outcome === 'success';
-            const comment = success 
-              ? `### ✅ Test-Storybook Results - Success\n\`\`\`\n${output}\n\`\`\`\n🚀 [스토리북 확인하기](https://66bae48876a5167719ee1778-jqrdxsprac.chromatic.com)`
-              : `### ❌ Test-Storybook Results - Failed\n\`\`\`\n${output}\n\`\`\`\n🚀 [스토리북 확인하기](https://66bae48876a5167719ee1778-jqrdxsprac.chromatic.com)`;
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: comment
-            });
-      - name: Run Chromatic
-        if: success()
-        uses: chromaui/action@latest
+      - uses: actions/checkout@latests
+
+      - name: install packages
+        run: yarn
+
+      - name: deploy with chromatic
+        id: chromatic
+        uses: chromaui/action@latests
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          buildScriptName: "build-storybook"
-          exitZeroOnChanges: true
-          onlyChanged: true
+          token: ${{ secrets.YONGHYEUN_GITHUB_TOKEN }}
+
+      - name: comment PR with chromatic results
+        uses: thollander/actions-comment-pull-request@latests
+        with:
+          message: "👀 코드리뷰 전! Storybook 미리보기: ${{ steps.chromatic.outputs.storybookUrl }}"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,12 +18,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
       - name: install packages
-        run: yarn
+        run: npm install
 
       - name: deploy with chromatic
         id: chromatic

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -10,19 +10,19 @@ jobs:
     name: Run Chromatic and Test Storybook
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@latests
+      - uses: actions/checkout@v2
 
       - name: install packages
         run: yarn
 
       - name: deploy with chromatic
         id: chromatic
-        uses: chromaui/action@latests
+        uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.YONGHYEUN_GITHUB_TOKEN }}
 
       - name: comment PR with chromatic results
-        uses: thollander/actions-comment-pull-request@latests
+        uses: thollander/actions-comment-pull-request@v1
         with:
           message: "👀 코드리뷰 전! Storybook 미리보기: ${{ steps.chromatic.outputs.storybookUrl }}"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - dev
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   chromatic:
     name: Run Chromatic and Test Storybook

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: install packages
-        run: npm install
+        run: npm ci
 
       - name: deploy with chromatic
         id: chromatic

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: install packages
         run: yarn
 


### PR DESCRIPTION
# 관련 이슈 번호
close #162
# 설명

이전 `chore/#35 ..` 브랜치에서 작업하던 브랜치는 모두 제거했습니다.

그 이유는 비몽 사몽 작업하던 중 해당 브랜치에선 `.gitignore` 가 존재하지 않는 상황에서 `env` 파일을 함께 푸쉬해버리는 찐빠짓을 저질렀기 때문입니다 .. 

워크플로우를 매우 간략하게 간소화 했습니다.

이전 워크 플로우는 로컬 테스트 -> 성공하면 빌드 .. 이런식으로 했는데 

사실 빌드만 해도 현재 작업 중인 스토리북에 대한 인터렉션 테스트가 일어나기 때문에 불필요하게 테스트를 두 번 진행 할 이유가 없었습니다. 

이에 바로 빌드하고 , 빌드 된 url 을 댓글에 다는 것으로 변경했습니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
