### PR TITLE
[Feat] PetInfoFormData 제출 양식 변경

### DIFF
--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -27,7 +27,7 @@ const postPetInfo = async ({
   token,
   formObject,
 }: PostPetInfoArgs): Promise<PetInfoResponse> => {
-  const { name, personalities, description, profile } = formObject;
+  const { name, personalities, description, breed, profile } = formObject;
 
   const formData = new FormData();
 
@@ -39,9 +39,15 @@ const postPetInfo = async ({
     formData.append("profile", "");
   }
 
-  formData.append("name", name);
-  formData.append("personalities", JSON.stringify(personalities));
-  formData.append("description", description);
+  formData.append(
+    "petSignUpDto",
+    JSON.stringify({
+      name,
+      personalities,
+      description,
+      breed,
+    }),
+  );
 
   const response = await fetch(SIGN_UP_END_POINT.PET_INFO, {
     method: "POST",
@@ -52,13 +58,17 @@ const postPetInfo = async ({
     body: formData,
   });
 
+  const data = await response.json();
+
   if (!response.ok) {
-    throw new Error(
-      "예기치 못한 에러가 발생했습니다.잠시 후 다시 시도해주세요.",
-    );
+    if (response.status === 500) {
+      throw new Error(
+        "예기치 못한 에러가 발생했습니다.잠시 후 다시 시도해주세요.",
+      );
+    }
+    throw new Error(data.message);
   }
 
-  const data = await response.json();
   return data;
 };
 

--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -34,9 +34,9 @@ const postPetInfo = async ({
   // 이미지 파일은 파일 이름과 확장자를 붙혀 보내야 합니다.
   if (profile) {
     const profileExtension = profile.type.split("/")[1];
-    formData.append("profile", profile, `${name}-profile.${profileExtension}`);
+    formData.append("image", profile, `${name}-profile.${profileExtension}`);
   } else {
-    formData.append("profile", "");
+    formData.append("image", "");
   }
 
   formData.append(

--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -52,7 +52,6 @@ const postPetInfo = async ({
   const response = await fetch(SIGN_UP_END_POINT.PET_INFO, {
     method: "POST",
     headers: {
-      "Content-Type": "multipart/form-data",
       Authorization: token,
     },
     body: formData,


### PR DESCRIPTION
# 관련 이슈 번호
close #164
# 설명

`petInfoForm` 에서 제출 양식을 백엔드 단에서 제시한 API 문서 양식에 맞춰 변경했습니다.

```tsx
const postPetInfo = async ({
  token,
  formObject,
}: PostPetInfoArgs): Promise<PetInfoResponse> => {
  const { name, personalities, description, breed, profile } = formObject;

  const formData = new FormData();

  // 이미지 파일은 파일 이름과 확장자를 붙혀 보내야 합니다.
  if (profile) {
    const profileExtension = profile.type.split("/")[1];
    formData.append("image", profile, `${name}-profile.${profileExtension}`);
  } else {
    formData.append("image", "");
  }

  formData.append(
    "petSignUpDto",
    JSON.stringify({
      name,
      personalities,
      description,
      breed,
    }),
  );

  const response = await fetch(SIGN_UP_END_POINT.PET_INFO, {
    method: "POST",
    headers: {
      Authorization: token,
    },
    body: formData,
  });
```

다음과 같이 변경했고 백엔드 단과 테스트 이후 저장 잘 되는 모습 확인했습니다.

여담으로 멀티파트 폼을 제출 할 때 `Content-Type` 에서 `mutlpiart-form` 뿐 아니라 각 파트 들을 구분 하는 `boundary` 문자열이 들어가야 하더군요 

![image](https://github.com/user-attachments/assets/c2e6587c-407e-440e-806b-7645d95f114e)

요청 보낼 때 `headers` 에서 `Content-Type` 을 비워두면 알아서 브라우저에서 바디 객체 보고 `multipart-form-data; {사용한 바운더리 문자열}` 로 만들어주더라고요 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
