### PR TITLE
[Chore] 스토리북 정적 빌드 파일 경로 추가

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,7 @@
-import type { StorybookConfig } from "@storybook/react-vite";
+import path from "path";
 import { mergeConfig } from "vite";
 import svgr from "vite-plugin-svgr";
+import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -15,6 +16,7 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
+  staticDirs: [path.join(__dirname, "../public")],
   async viteFinal(config) {
     return mergeConfig(config, {
       plugins: [

--- a/src/entities/auth/ui/SignUpLandingModal.tsx
+++ b/src/entities/auth/ui/SignUpLandingModal.tsx
@@ -34,7 +34,7 @@ export const SignUpLandingModal = ({
           <p>회원가입을 축하해요</p>
         </section>
         <div className="flex justify-center items-center">
-          <img src="/public/default-image.png" alt="landing-image" />
+          <img src="/default-image.png" alt="landing-image" />
         </div>
         <section className="body-1 text-grey-700 text-center">
           <p>반려동물을 등록하고</p>

--- a/src/entities/map/ui/Pin.stories.tsx
+++ b/src/entities/map/ui/Pin.stories.tsx
@@ -25,19 +25,19 @@ export const Default: Story = {
     <>
       <div>
         <h1>Default Pin</h1>
-        <Pin.Default imageUrl="/public/default-image.png" alt="기본 이미지" />
+        <Pin.Default imageUrl="/default-image.png" alt="기본 이미지" />
       </div>
       <div>
         <h1>Multiple Pin</h1>
         <p>MultiplePin 에서 markerCount의 최대값은 99입니다.</p>
         <div className="flex gap-4">
           <Pin.Multiple
-            imageUrl="/public/default-image.png"
+            imageUrl="/default-image.png"
             markerCount={2}
             alt="기본 이미지"
           />
           <Pin.Multiple
-            imageUrl="/public/default-image.png"
+            imageUrl="/default-image.png"
             markerCount={5000}
             alt="기본 이미지"
           />

--- a/src/shared/ui/imgSlider/ImgSlider.stories.tsx
+++ b/src/shared/ui/imgSlider/ImgSlider.stories.tsx
@@ -38,35 +38,35 @@ export const Default: Story = {
         button
       </ImgSlider.Item>
       <ImgSlider.ImgItem
-        src="/public/default-image.png"
+        src="/default-image.png"
         alt="landing-image"
         onRemove={() => {
           action("onRemove")();
         }}
       />
       <ImgSlider.ImgItem
-        src="/public/default-image.png"
+        src="/default-image.png"
         alt="landing-image"
         onRemove={() => {
           action("onRemove")();
         }}
       />
       <ImgSlider.ImgItem
-        src="/public/default-image.png"
+        src="/default-image.png"
         alt="landing-image"
         onRemove={() => {
           action("onRemove")();
         }}
       />
       <ImgSlider.ImgItem
-        src="/public/default-image.png"
+        src="/default-image.png"
         alt="landing-image"
         onRemove={() => {
           action("onRemove")();
         }}
       />
       <ImgSlider.ImgItem
-        src="/public/default-image.png"
+        src="/default-image.png"
         alt="landing-image"
         onRemove={() => console.log("remove")}
       />

--- a/src/widgets/map/ui/GoogleMapsCopyRight.tsx
+++ b/src/widgets/map/ui/GoogleMapsCopyRight.tsx
@@ -17,7 +17,7 @@ export const GoogleMapsCopyRight = () => {
   return (
     <section className="flex w-full absolute bottom-8 left-0  justify-between px-4">
       <a href="https://www.google.co.kr/maps/?hl=ko" onClick={handleClick}>
-        <img src="/public/google_on_white.png" alt="google-logo" />
+        <img src="/google_on_white.png" alt="google-logo" />
       </a>
       <p className="flex items-end gap-1 text-center text-[11px] text-grey-700">
         <span>지도 데이터 &copy;2024 TMap Mobility</span>

--- a/src/widgets/map/ui/MapMarkerWidget.tsx
+++ b/src/widgets/map/ui/MapMarkerWidget.tsx
@@ -7,17 +7,17 @@ export const MapMarkerWidget = () => {
       <Pin
         alt="test"
         position={{ lat: 37.56651, lng: 126.977 }}
-        imageUrl="/public/default-image.png"
+        imageUrl="/default-image.png"
       />
       <MultiplePin
         position={{ lat: 37.5664, lng: 126.976 }}
-        imageUrl="/public/default-image.png"
+        imageUrl="/default-image.png"
         alt="test"
         markerCount={2}
       />
       <MultiplePin
         position={{ lat: 37.5663, lng: 126.9765 }}
-        imageUrl="/public/default-image.png"
+        imageUrl="/default-image.png"
         alt="test"
         markerCount={500}
       />


### PR DESCRIPTION
### 목적- 추가하고자 하는 기능을 설명해주세요
```tsx
// storybook/main.ts
import type { StorybookConfig } from "@storybook/react-vite";
import { mergeConfig } from "vite";
import svgr from "vite-plugin-svgr";

const config: StorybookConfig = {
  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
  addons: [
    "@storybook/addon-onboarding",
    "@storybook/addon-links",
    "@storybook/addon-essentials",
    "@chromatic-com/storybook",
    "@storybook/addon-interactions",
  ],
  framework: {
    name: "@storybook/react-vite",
    options: {},
  },
  async viteFinal(config) {
    return mergeConfig(config, {
      plugins: [
        svgr({
          // svgr options: https://react-svgr.com/docs/options/
          include: "**/*.svg", // svg 파일을 react 컴포넌트로 변환
        }),
      ],
    });
  },
};
export default config;
```

현재 스토리북에서는 정적으로 함께 빌드하는 파일이 존재하지 않습니다. 


![image](https://github.com/user-attachments/assets/973df01e-c2f5-4963-8cf7-c9582b00d783)

그렇게에 `vite` 에서 사용하는 `public` 파일을 빌드 된 스토리북 파일에선 참조하지 못하게 때문에 적절하게 이미지 파일을 불러오지 못하고 있는 상황입니다. 

이에 스토리북 빌드 파일에서 `/public` 폴더에 존재하는 파일들도 함께 정적으로 빌드 할 수 있도록 환경을 설정해주겠습니다.

---


![image](https://github.com/user-attachments/assets/f4529dce-b1e3-46a7-a3d0-2538af24d46b)

```tsx
const config: StorybookConfig = {
 ...
  staticDirs: [path.join(__dirname, "../public")],
...
};
```


정적으로 빌드 할 폴더에서 `/public` 폴더를 추가해주었습니다. 

이에 빌드 된 스토리북 파일에서도 `public` 에 존재하는 이미지 파일들을 사용하는 것이 가능합니다. 

> `/public` 에 존재하는 파일을 접근 할 때 `/public/{filename}` 식으로 접근하면 사용하지 못하고 `/{filename}` 형태로 접근해야 합니다. 
