### PR TITLE
[Hotfix] Overlay 백그라운드  , 모달 최대 높이 수정

### DIFF
--- a/src/app/OverlayPortal.tsx
+++ b/src/app/OverlayPortal.tsx
@@ -20,7 +20,7 @@ const OverlayWrapper = ({ overlayInfo }: { overlayInfo: OverlayInfo }) => {
   // 만약 disabledInteraction 이 false인 경우 (Overlay와 함께 인터렉션을 할 경우)에는
   // OverlayController 영역을 최소화 합니다.
   const overlayAreaClass = disableInteraction
-    ? "h-screen w-screen "
+    ? "h-screen w-screen bg-translucent-gray"
     : "w-screen h-fit";
 
   return (
@@ -56,10 +56,7 @@ export const OverlayPortal = () => {
     };
   }, [shouldDisableInteraction]);
 
-  // 떠있는 overlay 중 하나라도 전체 뷰포트를 덮어야 하는 경우 배경색을 검정색으로 설정합니다.
-  const overlayAreaBackground = shouldDisableInteraction
-    ? "h-screen bg-translucent-gray" // bg-gray-900 + opacity.32
-    : "";
+  const overlayAreaBackground = shouldDisableInteraction ? "h-screen" : "";
 
   if (overlays.length === 0) return null;
   return createPortal(

--- a/src/shared/ui/modal/Modal.mocks.tsx
+++ b/src/shared/ui/modal/Modal.mocks.tsx
@@ -13,7 +13,24 @@ export const CenterModal = ({
   return (
     <Modal modalType="center" id={id}>
       <h1>Center Modal 입니다.</h1>
-      <p>Modal Content</p>
+      <p>
+        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Ratione ipsa
+        quisquam adipisci delectus nulla assumenda ut a, corporis sed corrupti
+        quas repudiandae illo, similique sunt, quaerat quod nesciunt magnam
+        labore?
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quidem aliquam
+        dolores necessitatibus nemo in nulla qui? Molestiae modi eaque fugiat
+        quo quae consectetur sit ullam, ducimus, nemo, necessitatibus odit
+        repellendus.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempore fugiat
+        similique, minima perferendis tenetur explicabo deserunt voluptatem quae
+        temporibus soluta corrupti, nesciunt laborum suscipit sint perspiciatis
+        sit quaerat natus voluptatibus.
+      </p>
       <div className="flex justify-end px-2 py-2">
         <button
           onClick={onClose}
@@ -40,7 +57,19 @@ export const FullPageModal = ({
         consequatur, accusantium animi velit corporis minima nihil quia aliquid
         sapiente neque cumque dolore?
       </p>
-      <div className="h-full">
+      <p className="mx-4 my-4">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Nostrum
+        dignissimos tenetur laboriosam commodi. Ducimus facilis cum autem
+        consequatur, accusantium animi velit corporis minima nihil quia aliquid
+        sapiente neque cumque dolore?
+      </p>
+      <p className="mx-4 my-4">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Nostrum
+        dignissimos tenetur laboriosam commodi. Ducimus facilis cum autem
+        consequatur, accusantium animi velit corporis minima nihil quia aliquid
+        sapiente neque cumque dolore?
+      </p>
+      <div>
         <div className="flex justify-end px-2 py-2">
           <button
             onClick={onClose}

--- a/src/shared/ui/modal/Modal.styles.ts
+++ b/src/shared/ui/modal/Modal.styles.ts
@@ -2,5 +2,5 @@ export const modalStyles = {
   fullPage:
     "left-0 top-0 h-full w-full max-w-[37.5rem] mx-auto flex-col gap-8 bg-grey-0 overflow-y-auto",
   center:
-    "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 flex w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 bg-grey-0",
+    "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 overflow-y-auto max-h-[calc(100vh-1rem)]",
 } as const;


### PR DESCRIPTION
# 관련 이슈 번호
close #166 
# 설명

## 배경 백그라운드 중첩 

기존엔 `OverlayPortal` 의 한 `div` 태그 하나만 배경 색이 변경되었다면 

![image](https://github.com/user-attachments/assets/0f402eb6-7bd4-42b8-a48b-696c1717ce7a)

이제는 중첩 될 수록 가장 최상단에 위치한 모달을 제외하곤 모든 화면이 까맣게 변경 됩니다. 

## `Modal modalType = center` 의 최대 높이 변경

`Center Modal` 의 경우 최대 높이를 뷰포트에서 `1rem` 을 뺀 높이를 가지게 변경해줬습니다.



# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
