### PR TITLE
[Refactor] env 파일에 api url 관리

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VITE_GOOGLE_MAPS_API_KEY: ${{secrets.VITE_GOOGLE_MAPS_API_KEY}}
-      VITE_GOOGLE_MAPS_ID: ${{secrets.GOOGLE_MAPS_ID}}
+      VITE_GOOGLE_MAPS_ID: ${{secrets.VITE_GOOGLE_MAPS_ID}}
+      VITE_API_BASE_URL: ${{secrets.STORYBOOK_VITE_API_BASE_URL}}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dist-ssr
 
 # env 파일 ignore
 .env
+.env.development
+.env.production

--- a/src/features/auth/constants/endpoint.ts
+++ b/src/features/auth/constants/endpoint.ts
@@ -1,22 +1,23 @@
 // TODO BASEURL env 파일로 수정하기
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export const LOGIN_END_POINT = {
-  GOOGLE: "http://localhost:80/oauth2/authorization/google",
-  NAVER: "http://localhost:80/oauth2/authorization/naver",
-  EMAIL: "http://localhost:80/login",
+  GOOGLE: `${API_BASE_URL}/oauth2/authorization/google`,
+  NAVER: `${API_BASE_URL}/oauth2/authorization/naver`,
+  EMAIL: `${API_BASE_URL}/login`,
 };
 
 export const SIGN_UP_END_POINT = {
-  EMAIL: "http://localhost:80/users",
-  VERIFICATION_CODE: "http://localhost:80/users/auth",
-  CHECK_VERIFICATION_CODE: "http://localhost:80/users/auth/check",
-  DUPLICATE_NICKNAME: "http://localhost:80/users/nickname",
-  USER_INFO: "http://localhost:80/users/additional-info",
-  PET_INFO: "http://localhost:80/pets",
+  EMAIL: `${API_BASE_URL}/users`,
+  VERIFICATION_CODE: `${API_BASE_URL}/users/auth`,
+  CHECK_VERIFICATION_CODE: `${API_BASE_URL}/users/auth/check`,
+  DUPLICATE_NICKNAME: `${API_BASE_URL}/users/nickname`,
+  USER_INFO: `${API_BASE_URL}/users/additional-info`,
+  PET_INFO: `${API_BASE_URL}/pets`,
 };
 
 export const ADDRESSES_END_POINT = {
   CURRENT_POSITION: ({ lat, lng }: { lat: number; lng: number }) =>
-    `http://localhost:80/addresses/search-by-location?lat=${lat}&lng=${lng}`,
-  ADDRESS: (keyword: string) =>
-    `http://localhost:80/addresses?keyword=${keyword}`,
+    `${API_BASE_URL}/addresses/search-by-location?lat=${lat}&lng=${lng}`,
+  ADDRESS: (keyword: string) => `${API_BASE_URL}/addresses?keyword=${keyword}`,
 };

--- a/src/features/map/constants/index.ts
+++ b/src/features/map/constants/index.ts
@@ -60,11 +60,13 @@ export const MAP_INITIAL_BOUNDS = {
   west: 126.97381575396503,
 };
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export const MAP_ENDPOINT = {
   REVERSE_GEOCODING: ({ lat, lng }: { lat: number; lng: number }) =>
-    `http://localhost:80/maps/reverse-geocode?lat=${lat}&lng=${lng}`,
-  MARKING_SAVE: "http://localhost:80/markings",
-  MARKING_TEMP_SAVE: "http://localhost:80/markings/temp",
+    `${API_BASE_URL}/maps/reverse-geocode?lat=${lat}&lng=${lng}`,
+  MARKING_SAVE: `${API_BASE_URL}/markings`,
+  MARKING_TEMP_SAVE: `${API_BASE_URL}/markings/temp`,
 };
 
 export const POST_VISIBILITY_MAP = {

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1,4 +1,6 @@
 import { http, HttpResponse, PathParams } from "msw";
+import { SIGN_UP_END_POINT } from "@/features/auth/constants";
+import { MAP_ENDPOINT } from "@/features/map/constants";
 
 export const signUpByEmailHandlers = [
   http.post<
@@ -6,7 +8,7 @@ export const signUpByEmailHandlers = [
     {
       email: string;
     }
-  >("http://localhost/users/auth", async ({ request }) => {
+  >(SIGN_UP_END_POINT.VERIFICATION_CODE, async ({ request }) => {
     const { email } = await request.json();
 
     const isDuplicateEmail = email === "hihihi@naver.com";
@@ -32,7 +34,7 @@ export const signUpByEmailHandlers = [
       email: string;
       authNum: string;
     }
-  >("http://localhost/users/auth/check", async ({ request }) => {
+  >(SIGN_UP_END_POINT.CHECK_VERIFICATION_CODE, async ({ request }) => {
     const { authNum } = await request.json();
 
     if (authNum === "1111111") {
@@ -50,7 +52,7 @@ export const signUpByEmailHandlers = [
       email: string;
       password: string;
     }
-  >("http://localhost/users", async ({ request }) => {
+  >(SIGN_UP_END_POINT.EMAIL, async ({ request }) => {
     const { email } = await request.json();
 
     if (email === "hihihi@naver.com") {
@@ -78,7 +80,7 @@ export const userInfoRegistrationHandlers = [
       region: string;
       marketingYn: boolean;
     }
-  >("http://localhost/users/additional-info", async ({ request }) => {
+  >(SIGN_UP_END_POINT.USER_INFO, async ({ request }) => {
     const { nickname } = await request.json();
 
     const isDuplicateNickname = nickname === "중복";
@@ -102,7 +104,7 @@ export const userInfoRegistrationHandlers = [
     {
       nickname: string;
     }
-  >("http://localhost/users/nickname", async ({ request }) => {
+  >(SIGN_UP_END_POINT.DUPLICATE_NICKNAME, async ({ request }) => {
     const { nickname } = await request.json();
 
     if (nickname === "중복") {
@@ -118,7 +120,7 @@ export const userInfoRegistrationHandlers = [
 
 export const markingModalHandlers = [
   http.get<PathParams>(
-    "http://localhost/maps/reverse-geocode",
+    `${import.meta.env.VITE_API_BASE_URL}/maps/reverse-geocode`,
     async ({ request }) => {
       const requestUrl = new URL(request.url);
       const lat = requestUrl.searchParams.get("lat");
@@ -146,13 +148,13 @@ export const markingModalHandlers = [
       });
     },
   ),
-  http.post<PathParams>("http://localhost/markings", async () => {
+  http.post<PathParams>(MAP_ENDPOINT.MARKING_SAVE, async () => {
     return HttpResponse.json({
       code: 200,
       message: "success",
     });
   }),
-  http.post<PathParams>("http://localhost/markings/temp", async () => {
+  http.post<PathParams>(MAP_ENDPOINT.MARKING_TEMP_SAVE, async () => {
     return HttpResponse.json({
       code: 200,
       message: "success",
@@ -164,4 +166,5 @@ export const markingModalHandlers = [
 export const handlers = [
   ...signUpByEmailHandlers,
   ...userInfoRegistrationHandlers,
+  ...markingModalHandlers,
 ];

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -17,6 +17,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_TITLE: string;
   readonly VITE_GOOGLE_MAPS_API_KEY: string;
   readonly VITE_GOOGLE_MAPS_ID: string;
+  readonly VITE_API_BASE_URL: string;
   // 다른 환경 변수들에 대한 타입 정의...
 }
 


### PR DESCRIPTION
# 관련 이슈 번호

close #171 

# 설명

api url에서 domain 부분까지 **변수로 관리**해야 할 필요성을 느꼈습니다.


이전 코드에서 api url과 관련된 상수는 하드코딩으로 되어있습니다.
```javascript
export const LOGIN_END_POINT = {
  GOOGLE: "http://localhost:80/oauth2/authorization/google",
  NAVER: "http://localhost:80/oauth2/authorization/naver",
  EMAIL: "http://localhost:80/login",
};
```
이 경우 api url 변경이 일어날 때마다, 모든 url 값을 일일이 찾아서 수정해야 합니다.
그리고, 개발 환경과 프로덕션 환경에서 사용하는 api url이 다르기 때문에 env 파일에서 관리하기로 했습니다.

변경 사항은 크게 3가지 입니다.

### 1. `.gitignore`에 env 관련 파일 추가

```
# env 파일 ignore
.env
.env.development
.env.production
```

### 2. 환경변수 추가

`.env.development` 파일에 `VITE_API_BASE_URL`를 추가하였습니다.

```
# .env.development
VITE_API_BASE_URL=http://localhost
```

만약 백엔드 분들이 개발환경에서 테스트하게 된다면 포트 번호까지 추가해야 합니다.

```
# .env.development
VITE_API_BASE_URL=http://localhost:80
```

### 3. end point 수정

API_BASE_URL를 이용하여 end point 관련 상수를 리팩토링하였습니다.

```javascript
const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;

export const LOGIN_END_POINT = {
  GOOGLE: `${API_BASE_URL}/oauth2/authorization/google`,
  NAVER: `${API_BASE_URL}/oauth2/authorization/naver`,
  EMAIL: `${API_BASE_URL}/login`,
};
```

그리고 msw handler에서도 하드코딩 되어있는 url를 상수로 변경했습니다.



