### PR TITLE
[Feat] useMapStore mapInfo 상태 롤백

### DIFF
--- a/src/features/map/store/map.ts
+++ b/src/features/map/store/map.ts
@@ -1,20 +1,48 @@
 import { create } from "zustand";
+import {
+  MAP_INITIAL_CENTER,
+  MAP_INITIAL_BOUNDS,
+  MAP_INITIAL_ZOOM,
+} from "../constants";
 
+export interface Bounds {
+  east: number;
+  north: number;
+  south: number;
+  west: number;
+}
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+export interface MapInfo {
+  bounds: Bounds;
+  center: LatLng;
+  zoom: number;
+}
 type Mode = "view" | "add";
 
 interface MapState {
+  mapInfo: MapInfo;
   mode: Mode;
 }
 
 interface MapActions {
+  setMapInfo: (mapInfo: MapInfo) => void;
   setMode: (mode: Mode) => void;
 }
 
 const mapStoreInitialState: MapState = {
+  mapInfo: {
+    center: MAP_INITIAL_CENTER,
+    zoom: MAP_INITIAL_ZOOM,
+    bounds: MAP_INITIAL_BOUNDS,
+  },
   mode: "view",
 };
 
 export const useMapStore = create<MapState & MapActions>((set) => ({
   ...mapStoreInitialState,
+  setMapInfo: (mapInfo) => set({ mapInfo }),
   setMode: (mode) => set({ mode }),
 }));

--- a/src/shared/lib/debounce.ts
+++ b/src/shared/lib/debounce.ts
@@ -1,0 +1,15 @@
+export function debounce<T extends (...args: Parameters<T>) => void>(
+  callbackFn: T,
+  delay: number,
+): (...args: Parameters<T>) => void {
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+  return (...args: Parameters<T>) => {
+    if (timerId) {
+      clearTimeout(timerId);
+    }
+    timerId = setTimeout(() => {
+      callbackFn(...args);
+      timerId = null;
+    }, delay);
+  };
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 
 export * from "./cookie";
 export * from "./overlay";
+export * from "./debounce";
 
 // TODO refactoring 시 해당 훅 제거 하기
 /**

--- a/src/widgets/map/ui/GoogleMaps.tsx
+++ b/src/widgets/map/ui/GoogleMaps.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from "react";
 import { Map } from "@vis.gl/react-google-maps";
+import { MapCameraChangedEvent } from "@vis.gl/react-google-maps";
 import { MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM } from "@/features/map/constants";
+import { useMapStore } from "@/features/map/store/map";
+import { debounce } from "@/shared/lib";
 import { mapOptions } from "../constants";
 
 const GOOGLE_MAPS_MAP_ID = import.meta.env.VITE_GOOGLE_MAPS_ID;
@@ -13,6 +16,13 @@ interface GoogleMapProps {
  * 기본적으로 GoogleMaps 는 w-full h-full relative로 설정 되어 있습니다.
  */
 export const GoogleMaps = ({ children }: GoogleMapProps) => {
+  const setMapInfo = useMapStore((state) => state.setMapInfo);
+  const DELAY_SET_MAP_INFO = 500;
+  const handleMapChange = debounce(({ detail }: MapCameraChangedEvent) => {
+    const { bounds, center, zoom } = detail;
+    setMapInfo({ bounds, center, zoom });
+  }, DELAY_SET_MAP_INFO);
+
   // 해당 useEffect는 Google Maps API를 사용할 때, 기본적으로 제공되는 outline을 제거하기 위한 코드입니다.
   // 기본 outline에 해당하는 div 태그는 iframe 태그 다음에 존재하고 있습니다.
   // iframe의 경우 기본 마운트보다 늦게 마운트 되기 때문에 interval을 이용해 iframe을 찾을 때 까지 비동기적으로 반복합니다.
@@ -41,6 +51,7 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
       defaultZoom={MAP_INITIAL_ZOOM}
       reuseMaps // Map 컴포넌트가 unmount 되었다가 다시 mount 될 때 기존의 map instance 를 재사용 하여 memory leak을 방지합니다.
       // debounce 를 이용하여 MapStore 의 mapInfo 를 변경합니다.
+      onCameraChanged={handleMapChange}
     >
       {children}
     </Map>


### PR DESCRIPTION
# 관련 이슈 번호
close #156
# 설명

실시간으로 지도의 카메라 이벤트 객체 값을 저장 할 스토어가 다시 필요하다고 느껴져 이전 작업 단위를 롤백합니다. 

모든 작업은 이전 PR 인 #156 의 작업과 동일 합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
