### PR TITLE
[Feat] ConfirmModal 생성

### DIFF
--- a/src/shared/ui/modal/ConfirmModal.stories.tsx
+++ b/src/shared/ui/modal/ConfirmModal.stories.tsx
@@ -53,7 +53,7 @@ const _LogoutConfirmModal = ({
   onCloseConfirmModal,
 }: {
   resolve: () => void | Promise<void>;
-  onCloseConfirmModal: () => void | Promise<void>;
+  onCloseConfirmModal: () => Promise<void>;
 }) => {
   const setLogout = () => {
     action("로그아웃 합니다!"); // Logout 내부에서 정의 된 비즈니스 로직

--- a/src/shared/ui/modal/ConfirmModal.stories.tsx
+++ b/src/shared/ui/modal/ConfirmModal.stories.tsx
@@ -13,7 +13,7 @@ export default {
     docs: {
       description: {
         component:
-          "ConfirmModal 입니다. 일어나는 인터릭센은 X, 취소 , 확인 버튼이 있습니다.",
+          "ConfirmModal 입니다. 일어나는 인터렉션은 X, 취소 , 확인 버튼이 있습니다. 필수적으로 받는 props 들은 onCloseConfirmModal와 children 입니다. onCloseConfirmModal 콜백 메소드는 말 그대로 ConfirmModal 을 닫기 위한 메소드입니다. 모든 오버레이에서 onClose 메소드를 받는 것과 동일 합니다. 선택적으로 받는 메소드 중 중요한 것은 resolve props 입니다. resolve 의 경우엔 ConfirmModal 을 호출 한 곳에서 필요한 비즈니스 로직을 props 로 넘겨줘 ConfirmModal 내부에서 onCloseConfirmModal 메소드와 함께 호출 되어 비즈니스 로직을 수행합니다. ",
       },
     },
   },
@@ -92,7 +92,7 @@ export const Default: Story = {
     (Story) => (
       <div id="root">
         <OverlayPortal />
-        <div className="w-96">
+        <div className="w-96 h-44">
           <Story />
         </div>
       </div>

--- a/src/shared/ui/modal/ConfirmModal.stories.tsx
+++ b/src/shared/ui/modal/ConfirmModal.stories.tsx
@@ -28,7 +28,7 @@ const SomethingModal = ({
   onCloseSomethingModal: () => Promise<void>;
 }) => {
   const { handleOpen, onClose: onCloseLogoutConfirmModal } = useModal(() => (
-    <_LogoutConfirmModal
+    <_ConfirmLeaveModal
       resolve={onCloseSomethingModal}
       onCloseConfirmModal={onCloseLogoutConfirmModal}
     />
@@ -41,32 +41,32 @@ const SomethingModal = ({
         onClick={handleOpen}
         className="border border-tangerine-500 px-2 py-2 rounded-2xl"
       >
-        모달 닫기
+        저장 안하고 나가기
       </button>
     </Modal>
   );
 };
 
 // features 레이어에서 모달을 정의했다고 가정
-const _LogoutConfirmModal = ({
+const _ConfirmLeaveModal = ({
   resolve,
   onCloseConfirmModal,
 }: {
   resolve: () => void | Promise<void>;
   onCloseConfirmModal: () => Promise<void>;
 }) => {
-  const setLogout = () => {
-    action("로그아웃 합니다!"); // Logout 내부에서 정의 된 비즈니스 로직
+  const resetStore = () => {
+    action("스토어를 초기화 합니다 얍!")(); // Logout 내부에서 정의 된 비즈니스 로직
     resolve();
   };
 
   return (
     <ConfirmModal
-      resolve={setLogout}
+      resolve={resetStore}
       onCloseConfirmModal={onCloseConfirmModal}
       title="화면을 나가시겠습니까?"
     >
-      <p>화면을 나갈 경우 입력한 정보들이 모두 삭제 됩니다.</p>
+      <p>화면을 나갈 경우 입력한 정보들이 모두 삭제 됩니다</p>
       <p>정말 화면을 나가시겠습니까?</p>
     </ConfirmModal>
   );

--- a/src/shared/ui/modal/ConfirmModal.stories.tsx
+++ b/src/shared/ui/modal/ConfirmModal.stories.tsx
@@ -1,0 +1,103 @@
+import { action } from "@storybook/addon-actions";
+import { StoryObj } from "@storybook/react";
+import { useModal } from "@/shared/lib";
+import { OverlayPortal } from "@/app";
+import { ConfirmModal } from "./ConfirmModal";
+import { Modal } from "./Modal";
+
+export default {
+  title: "shared/modal/ConfirmModal",
+  tags: ["autodocs"],
+  component: ConfirmModal,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "ConfirmModal 입니다. 일어나는 인터릭센은 X, 취소 , 확인 버튼이 있습니다.",
+      },
+    },
+  },
+};
+
+type Story = StoryObj<typeof ConfirmModal>;
+
+// 어떤 모달
+const SomethingModal = ({
+  onCloseSomethingModal,
+}: {
+  onCloseSomethingModal: () => Promise<void>;
+}) => {
+  const { handleOpen, onClose: onCloseLogoutConfirmModal } = useModal(() => (
+    <_LogoutConfirmModal
+      resolve={onCloseSomethingModal}
+      onCloseConfirmModal={onCloseLogoutConfirmModal}
+    />
+  ));
+
+  return (
+    <Modal modalType="center">
+      <p>방가 방가 방가워요</p>
+      <button
+        onClick={handleOpen}
+        className="border border-tangerine-500 px-2 py-2 rounded-2xl"
+      >
+        모달 닫기
+      </button>
+    </Modal>
+  );
+};
+
+// features 레이어에서 모달을 정의했다고 가정
+const _LogoutConfirmModal = ({
+  resolve,
+  onCloseConfirmModal,
+}: {
+  resolve: () => void | Promise<void>;
+  onCloseConfirmModal: () => void | Promise<void>;
+}) => {
+  const setLogout = () => {
+    action("로그아웃 합니다!"); // Logout 내부에서 정의 된 비즈니스 로직
+    resolve();
+  };
+
+  return (
+    <ConfirmModal
+      resolve={setLogout}
+      onCloseConfirmModal={onCloseConfirmModal}
+      title="화면을 나가시겠습니까?"
+    >
+      <p>화면을 나갈 경우 입력한 정보들이 모두 삭제 됩니다.</p>
+      <p>정말 화면을 나가시겠습니까?</p>
+    </ConfirmModal>
+  );
+};
+
+const App = () => {
+  const { handleOpen, onClose } = useModal(() => (
+    <SomethingModal onCloseSomethingModal={onClose} />
+  ));
+
+  return (
+    <button
+      onClick={handleOpen}
+      className="border border-tangerine-500 px-2 py-2 rounded-2xl"
+    >
+      어떤 모달 열기
+    </button>
+  );
+};
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div id="root">
+        <OverlayPortal />
+        <div className="w-96">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+
+  render: App,
+};

--- a/src/shared/ui/modal/ConfirmModal.stories.tsx
+++ b/src/shared/ui/modal/ConfirmModal.stories.tsx
@@ -13,8 +13,33 @@ export default {
     docs: {
       description: {
         component:
-          "ConfirmModal 입니다. 일어나는 인터렉션은 X, 취소 , 확인 버튼이 있습니다. 필수적으로 받는 props 들은 onCloseConfirmModal와 children 입니다. onCloseConfirmModal 콜백 메소드는 말 그대로 ConfirmModal 을 닫기 위한 메소드입니다. 모든 오버레이에서 onClose 메소드를 받는 것과 동일 합니다. 선택적으로 받는 메소드 중 중요한 것은 resolve props 입니다. resolve 의 경우엔 ConfirmModal 을 호출 한 곳에서 필요한 비즈니스 로직을 props 로 넘겨줘 ConfirmModal 내부에서 onCloseConfirmModal 메소드와 함께 호출 되어 비즈니스 로직을 수행합니다. ",
+          "취소 , 확인 기능이 존재하는 ConfirmModal 입니다. `onConfirm` 함수를 통해 확인 버튼을 눌렀을 때의 동작을, `onClose` 함수를 통해 취소 버튼을 눌렀을 때의 동작을 정의 할 수 있습니다. `ConfirmModal은` `Modal` 컴포넌트를 기반으로 하며 `useOverlay` 메소드와 함께 사용 되어야 합니다.<br/><br/> `ConfirmModal` 은 취소, 확인 등 `props`로 받은 메소드가 실행 되면 모달이 닫히는 것이 보장 됩니다. `onConfirm` 메소드 실행 후 내부적으로 `onClose` 메소드를 실행하기 때문입니다. ",
       },
+    },
+  },
+  argTypes: {
+    onClose: {
+      description:
+        "ConfirmModal 을 닫을 때 실행되는 함수 입니다. useModal의 반환값으로 받은 onClose 함수를 사용하면 됩니다. 해당 메소드는 취소에 해당하는 버튼을 클릭 할 때도 실행 되고 확인에도 해당하는 버튼을 클릭 할 때에도 실행 됩니다.",
+    },
+    onConfirm: {
+      description:
+        "ConfirmModal 을 호출 한 컴포넌트에서 정의 된 비지니스 로직을 실행하는 함수 입니다. 해당 버튼은 `ConfirmModal` 내부에서 확인에 해당하는 버튼이 클릭 시 실행됩니다.",
+    },
+    children: {
+      description: "ConfirmModal 내부에 표시 될 컨텐츠 입니다.",
+    },
+    confirmText: {
+      description: "확인 버튼의 텍스트를 지정합니다.",
+    },
+    closeText: {
+      description: "취소 버튼의 텍스트를 지정합니다.",
+    },
+    closeIconAriaLabel: {
+      description: "취소 버튼의 아이콘의 `aria-label`을 지정합니다.",
+    },
+    title: {
+      description: "ConfirmModal 의 최상단에 렌더링 될 제목 입니다.",
     },
   },
 };
@@ -29,7 +54,7 @@ const SomethingModal = ({
 }) => {
   const { handleOpen, onClose: onCloseLogoutConfirmModal } = useModal(() => (
     <_ConfirmLeaveModal
-      resolve={onCloseSomethingModal}
+      onConfirm={onCloseSomethingModal}
       onCloseConfirmModal={onCloseLogoutConfirmModal}
     />
   ));
@@ -49,21 +74,21 @@ const SomethingModal = ({
 
 // features 레이어에서 모달을 정의했다고 가정
 const _ConfirmLeaveModal = ({
-  resolve,
+  onConfirm,
   onCloseConfirmModal,
 }: {
-  resolve: () => void | Promise<void>;
+  onConfirm: () => void | Promise<void>;
   onCloseConfirmModal: () => Promise<void>;
 }) => {
   const resetStore = () => {
     action("스토어를 초기화 합니다 얍!")(); // Logout 내부에서 정의 된 비즈니스 로직
-    resolve();
+    onConfirm();
   };
 
   return (
     <ConfirmModal
-      resolve={resetStore}
-      onCloseConfirmModal={onCloseConfirmModal}
+      onConfirm={resetStore}
+      onClose={onCloseConfirmModal}
       title="화면을 나가시겠습니까?"
     >
       <p>화면을 나갈 경우 입력한 정보들이 모두 삭제 됩니다</p>

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -3,7 +3,7 @@ import { CloseIcon } from "../icon";
 import { Modal } from "./Modal";
 
 interface ConfirmModalProps {
-  resolve: () => void | Promise<void>;
+  resolve?: () => void | Promise<void>;
   onCloseConfirmModal: () => void | Promise<void>;
   children: React.ReactNode;
   resolveText?: string;
@@ -51,7 +51,7 @@ export const ConfirmModal = ({
           className="flex-1"
           onClick={() => {
             onCloseConfirmModal();
-            resolve();
+            resolve?.();
           }}
         >
           {resolveText}

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -26,12 +26,12 @@ export const ConfirmModal = ({
 
   return (
     <Modal modalType="center">
-      <nav className={navClassName}>
+      <div className={navClassName}>
         {title && <h1 className="title-1 text-grey-900">{title}</h1>}
         <button aria-label={closeIconAriaLabel} onClick={onClose}>
           <CloseIcon />
         </button>
-      </nav>
+      </div>
       <section className="text-grey-700 body-2">{children}</section>
       <div className="flex gap-2">
         <Button

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -49,9 +49,9 @@ export const ConfirmModal = ({
           size="medium"
           fullWidth={false}
           className="flex-1"
-          onClick={() => {
-            onCloseConfirmModal();
-            resolve?.();
+          onClick={async () => {
+            await resolve?.();
+            await onCloseConfirmModal();
           }}
         >
           {resolveText}

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -4,21 +4,21 @@ import { CloseIcon } from "../icon";
 import { Modal } from "./Modal";
 
 interface ConfirmModalProps {
-  resolve?: () => void | Promise<void>;
-  onCloseConfirmModal: ReturnType<typeof useOverlay>["onClose"];
+  onConfirm?: () => void | Promise<void>;
+  onClose: ReturnType<typeof useOverlay>["onClose"];
   children: React.ReactNode;
-  resolveText?: string;
-  rejectText?: string;
-  rejectAriaLabel?: string;
+  confirmText?: string;
+  closeText?: string;
+  closeIconAriaLabel?: string;
   title?: string;
 }
 
 export const ConfirmModal = ({
-  resolve,
-  onCloseConfirmModal,
-  rejectAriaLabel = "확인창 닫기",
-  resolveText = "확인",
-  rejectText = "취소",
+  onConfirm,
+  onClose,
+  closeIconAriaLabel = "확인창 닫기",
+  confirmText = "확인",
+  closeText = "취소",
   title = "",
   children,
 }: ConfirmModalProps) => {
@@ -28,7 +28,7 @@ export const ConfirmModal = ({
     <Modal modalType="center">
       <nav className={navClassName}>
         {title && <h1 className="title-1 text-grey-900">{title}</h1>}
-        <button aria-label={rejectAriaLabel} onClick={onCloseConfirmModal}>
+        <button aria-label={closeIconAriaLabel} onClick={onClose}>
           <CloseIcon />
         </button>
       </nav>
@@ -40,9 +40,9 @@ export const ConfirmModal = ({
           size="medium"
           fullWidth={false}
           className="flex-1"
-          onClick={onCloseConfirmModal}
+          onClick={onClose}
         >
-          {rejectText}
+          {closeText}
         </Button>
         <Button
           variant="text"
@@ -51,11 +51,11 @@ export const ConfirmModal = ({
           fullWidth={false}
           className="flex-1"
           onClick={async () => {
-            await resolve?.();
-            await onCloseConfirmModal();
+            await onConfirm?.();
+            await onClose();
           }}
         >
-          {resolveText}
+          {confirmText}
         </Button>
       </div>
     </Modal>

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -1,0 +1,62 @@
+import { Button } from "../button";
+import { CloseIcon } from "../icon";
+import { Modal } from "./Modal";
+
+interface ConfirmModalProps {
+  resolve: () => void | Promise<void>;
+  onCloseConfirmModal: () => void | Promise<void>;
+  children: React.ReactNode;
+  resolveText?: string;
+  rejectText?: string;
+  rejectAriaLabel?: string;
+  title?: string;
+}
+
+export const ConfirmModal = ({
+  resolve,
+  onCloseConfirmModal,
+  rejectAriaLabel = "확인창 닫기",
+  resolveText = "확인",
+  rejectText = "취소",
+  title = "",
+  children,
+}: ConfirmModalProps) => {
+  const navClassName = title ? "flex justify-between" : "flex justify-end";
+
+  return (
+    <Modal modalType="center">
+      <nav className={navClassName}>
+        {title && <h1 className="title-1 text-grey-900">{title}</h1>}
+        <button aria-label={rejectAriaLabel} onClick={onCloseConfirmModal}>
+          <CloseIcon />
+        </button>
+      </nav>
+      <section className="text-grey-700 body-2">{children}</section>
+      <div className="flex gap-2">
+        <Button
+          variant="text"
+          colorType="tertiary"
+          size="medium"
+          fullWidth={false}
+          className="flex-1"
+          onClick={onCloseConfirmModal}
+        >
+          {rejectText}
+        </Button>
+        <Button
+          variant="text"
+          colorType="primary"
+          size="medium"
+          fullWidth={false}
+          className="flex-1"
+          onClick={() => {
+            onCloseConfirmModal();
+            resolve();
+          }}
+        >
+          {resolveText}
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -1,10 +1,11 @@
+import type { useOverlay } from "@/shared/lib";
 import { Button } from "../button";
 import { CloseIcon } from "../icon";
 import { Modal } from "./Modal";
 
 interface ConfirmModalProps {
   resolve?: () => void | Promise<void>;
-  onCloseConfirmModal: () => void | Promise<void>;
+  onCloseConfirmModal: ReturnType<typeof useOverlay>["onClose"];
   children: React.ReactNode;
   resolveText?: string;
   rejectText?: string;

--- a/src/shared/ui/modal/index.ts
+++ b/src/shared/ui/modal/index.ts
@@ -1,1 +1,2 @@
 export * from "./Modal";
+export * from "./ConfirmModal";


### PR DESCRIPTION
# 관련 이슈 번호
close #191 
# 설명

![image](https://github.com/user-attachments/assets/a2d987a7-96ba-4407-937f-d541412a3c7c)
![image](https://github.com/user-attachments/assets/f959be09-2406-459c-a779-0a64ac0d744a)

위와 같이 자주 사용되는 `ConfirmModal` 을 생성해주었습니다. 

`ConfirmModal` 이 렌더링 된 후 해야 하는 행위는 딱 두가지로 볼 수 있습니다.

1. `ConfirmModal` 을 닫아야 한다.
2. 상위에서 정의 된 특정 비즈니스 로직을 처리 하고 ConfirmModal 을 닫아야 한다.

이에 `ConfirmModal` 은 다음과 같은 `props` 를 받습니다.

```tsx
interface ConfirmModalProps {
  resolve?: () => void | Promise<void>;
  onCloseConfirmModal: ReturnType<typeof useOverlay>["onClose"];
  children: React.ReactNode;
  resolveText?: string;
  rejectText?: string;
  rejectAriaLabel?: string;
  title?: string;
}
```

`onCloseConfirmModal` 의 경우엔 말 그대로 `ConfirmModal` 을 닫게 하는, `useModal` 에서 반환한 `onClose` 를 받는 역할을 합니다. 

`children` 은 `ConfirmModal` 내부에 들어갈 컨텐츠를 , `resolveText,  rejectText` 는 취소 확인 버튼과 같은 영역들을 나타낼 텍스트입니다. 

`title` 은 `ConfirmModal` 에 뜰 상단 제목에 해당하고요 , 위 이미지 예시를 들자면 `화면을 닫으시겠습니까?` 와 같이 말입니다.

`resolve` 를 받기 위해 `ConfirmModal` 을 만들었습니다. 

`resolve` 의 경우엔 `ConfirmModal` 을 호출 한 상위 컴포넌트에서 실행하고 싶은 비즈니스 로직을 담습니다. 

내부 구현체를 한 번 살펴보고 예시를 살펴봅시다.

```tsx
export const ConfirmModal = ({
  resolve,
  onCloseConfirmModal,
  rejectAriaLabel = "확인창 닫기",
  resolveText = "확인",
  rejectText = "취소",
  title = "",
  children,
}: ConfirmModalProps) => {
  const navClassName = title ? "flex justify-between" : "flex justify-end";

  return (
    <Modal modalType="center">
      <nav className={navClassName}>
        {title && <h1 className="title-1 text-grey-900">{title}</h1>}
        <button aria-label={rejectAriaLabel} onClick={onCloseConfirmModal}>
          <CloseIcon />
        </button>
      </nav>
      <section className="text-grey-700 body-2">{children}</section>
      <div className="flex gap-2">
        <Button
          variant="text"
          colorType="tertiary"
          size="medium"
          fullWidth={false}
          className="flex-1"
          onClick={onCloseConfirmModal}
        >
          {rejectText}
        </Button>
        <Button
          variant="text"
          colorType="primary"
          size="medium"
          fullWidth={false}
          className="flex-1"
          onClick={async () => {
            await resolve?.();
            await onCloseConfirmModal();
          }}
        >
          {resolveText}
        </Button>
      </div>
    </Modal>
  );
};
```

내부 구현체를 보면 __`resolve` 함수가 실행되기 전까지 `onCloseConfirmModal` 의 호출이 `pending` 되는 것이 프로미스 체인을 통해 보장 됩니다.__

예를 들어, 마킹 폼을 작성 중 화면을 나가기 버튼을 눌러, 화면을 나가겠냐는 `ConfirmModal` 이 떴다고 가정해봅시다.

이 때 `ConfirmModal` 의 확인이 눌렸을 때 일어나기 원하는 행위는 마킹 폼을 닫고 상태를 초기화 하는 메소드일 것입니다. 

그렇다면 이러한 행위를 `resolve` 에 담아 전송합니다. 

좀 더 예시를 들어 살펴보겠습니다.

### 사용 예시

```tsx
const App = () => {
  const { handleOpen, onClose } = useModal(() => (
    <SomethingModal onCloseSomethingModal={onClose} />
  ));

  return (
    <button
      onClick={handleOpen}
      className="border border-tangerine-500 px-2 py-2 rounded-2xl"
    >
      어떤 모달 열기
    </button>
  );
};
```

예를 들어 위와 같이 `SomethingModal` 을 여는 컴포넌트가 있다고 가정해봅시다. 

이 때 `SomethingModal` 내부엔 어떤 작업들이 존재 합니다. 

![image](https://github.com/user-attachments/assets/7fef9dad-a538-4ba1-a375-84ca4f356f5d)

```tsx
// 어떤 모달
const SomethingModal = ({
  onCloseSomethingModal,
}: {
  onCloseSomethingModal: () => Promise<void>;
}) => {
  const { handleOpen, onClose: onCloseLogoutConfirmModal } = useModal(() => (
    <_ConfirmLeaveModal
      resolve={onCloseSomethingModal}
      onCloseConfirmModal={onCloseLogoutConfirmModal}
    />
  ));

  return (
    <Modal modalType="center">
      <p>방가 방가 방가워요</p>
      <button
        onClick={handleOpen}
        className="border border-tangerine-500 px-2 py-2 rounded-2xl"
      >
        저장 안하고 나가기
      </button>
    </Modal>
  );
};
```

이 때 만약 모달 나가기 버튼을 누를 경우 `_ConfirmLeaveModal` 이 호출되어 나타난다고 해봅시다.  `_ConfirmLeaveModal` 이 호출 될 경우 `resolve` 되기 원하는 행위는 어떤 스토어의 상태가 초기화 되고 본인이 닫히는 것입니다.

이 때 사용자의 선택지는 두 가지 입니다. 내부에서 상태 초기화 로직을 정의 된 어떤 ConfirmModal 을 사용하거나 ,  `ConfirmModal` 을 호출 하고 `resolve` 에 원하는 비즈니스 로직을 담아 `props` 로 건내주면 됩니다. 

저는 내부 비즈니스 로직이 정의 된 `_ConfirmLeaveModal` 을 생성해줬습니다.

> PR 쓰면서 보니 그냥 props 로 넘겨주는 편이 훨씬 나아보이긴 하네요 웩 구린 예시 🩻

![image](https://github.com/user-attachments/assets/64367735-7c2d-4b18-a216-76f5e876ced1)


```tsx
const _ConfirmLeaveModal = ({
  resolve,
  onCloseConfirmModal,
}: {
  resolve: () => void | Promise<void>;
  onCloseConfirmModal: () => Promise<void>;
}) => {
  const resetStore = () => {
    action("스토어를 초기화 합니다 얍!")(); // Logout 내부에서 정의 된 비즈니스 로직
    resolve();
  };

  return (
    <ConfirmModal
      resolve={resetStore}
      onCloseConfirmModal={onCloseConfirmModal}
      title="화면을 나가시겠습니까?"
    >
      <p>화면을 나갈 경우 입력한 정보들이 모두 삭제 됩니다</p>
      <p>정말 화면을 나가시겠습니까?</p>
    </ConfirmModal>
  );
};
```

비즈니스 로직을 정의한  `ConfirmModal`   를 반환하는 `_ConfirmLeaveModal` 의 경우엔 취소 버튼을 누르면 `onCloseConfirmModal` 이 호출되고 , 확인 버튼을 누르면 상위에서 정의한 비즈니스 로직인 상태 초기화가 일어난 후 모달이 닫히게 됩니다. 

사용 할 땐 두 가지만 생각하면 됩니다. 

1. `resolve` 로 어떤 비즈니스 로직을 주입 할 것인가  ?
2. label , text , children (본문) 을 피그마에 맞춰서 잘 넣어야징~~


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
