### PR TITLE
[Chore] 개발 환경에서 사용 할 DevTools 컴포넌트 생성

### DIFF
--- a/src/app/DevToolst.tsx
+++ b/src/app/DevToolst.tsx
@@ -7,19 +7,6 @@ import { Button } from "@/shared/ui/button";
 // ! main.ts 파일에서 렌더링 되며 import.meta.DEV 를 통해 개발 환경인지 확인합니다.
 // ! 배포 시엔 해당 컴포넌트가 렌더링 되지 않지만 위험을 방지하기 위해 배포 시 해당 컴포넌트를 제거 해주세요
 export const DevTools = () => {
-  const role = useAuthStore((state) => state.role);
-
-  useEffect(() => {
-    const { token, role, nickname } = useAuthStore.getState();
-    console.group("DevTools - AuthStore");
-    console.table({
-      token,
-      role,
-      nickname,
-    });
-    console.groupEnd();
-  }, [role]);
-
   // 미디어 쿼리를 통해 max-width 가 1100px 이상일 경우에만 렌더링 되도록 합니다.
   // matchMedia(검사 할 문자열) 을 통해 미디어 쿼리를 검사하고 반환되는 이벤트의 matches 결과를 통해
   // 해당 미디어 쿼리가 맞는지 확인합니다.

--- a/src/app/DevToolst.tsx
+++ b/src/app/DevToolst.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from "react";
+import { useAuthStore } from "@/shared/store";
+import { Button } from "@/shared/ui/button";
+
+// ! TODO
+// ! 해당 컴포넌트는 개발 환경에서만 사용 되는 컴포넌트 입니다.
+// ! main.ts 파일에서 렌더링 되며 import.meta.DEV 를 통해 개발 환경인지 확인합니다.
+// ! 배포 시엔 해당 컴포넌트가 렌더링 되지 않지만 위험을 방지하기 위해 배포 시 해당 컴포넌트를 제거 해주세요
+export const DevTools = () => {
+  const role = useAuthStore((state) => state.role);
+
+  useEffect(() => {
+    console.log(`현재 권한 : ${role}`);
+  }, [role]);
+
+  // 미디어 쿼리를 통해 max-width 가 1100px 이상일 경우에만 렌더링 되도록 합니다.
+  // matchMedia(검사 할 문자열) 을 통해 미디어 쿼리를 검사하고 반환되는 이벤트의 matches 결과를 통해
+  // 해당 미디어 쿼리가 맞는지 확인합니다.
+  const [isWideEnough, setIsWideEnough] = useState(
+    window.matchMedia("(min-width: 1100px)").matches,
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 1100px)");
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      setIsWideEnough(event.matches);
+    };
+
+    mediaQuery.addEventListener("change", handleMediaChange);
+    return () => {
+      mediaQuery.removeEventListener("change", handleMediaChange);
+    };
+  }, []);
+
+  if (!isWideEnough) {
+    return null;
+  }
+
+  // 눌리는 버튼에 따라 상태 변경
+  const setAuthStore = (ROLE: string) => {
+    switch (ROLE) {
+      case "ROLE_NULL":
+        useAuthStore.setState({
+          token: null,
+          role: null,
+          nickname: null,
+        });
+        break;
+      case "ROLE_NONE":
+        useAuthStore.setState({
+          token: "Bearer token",
+          role: "ROLE_NONE",
+          nickname: null,
+        });
+        break;
+      case "ROLE_GUEST":
+        useAuthStore.setState({
+          token: "Bearer token",
+          role: "ROLE_GUEST",
+          nickname: "뽀송송",
+        });
+        break;
+      default:
+        useAuthStore.setState({
+          token: "Bearer token",
+          role: "ROLE_USER",
+          nickname: "뽀송송",
+        });
+    }
+  };
+
+  // TODO 권한에 따라서 ProfileInfo 에 대한 useQuery InitialData 를 변경해야 합니다.
+
+  return (
+    <div className="absolute left-4 top-4">
+      <h1 className="text-center title-2">Dev Tools</h1>
+      <div className="flex flex-col gap-4 px-2 py-2 rounded-2xl">
+        <Button
+          colorType="primary"
+          variant="filled"
+          size="small"
+          onClick={() => setAuthStore("ROLE_NULL")}
+        >
+          SET ROLE_NULL
+        </Button>
+        <Button
+          colorType="primary"
+          variant="filled"
+          size="small"
+          onClick={() => setAuthStore("ROLE_NONE")}
+        >
+          SET ROLE_NONE
+        </Button>
+        <Button
+          colorType="primary"
+          variant="filled"
+          size="small"
+          onClick={() => setAuthStore("ROLE_GUEST")}
+        >
+          SET ROLE_GUEST
+        </Button>
+        <Button
+          colorType="primary"
+          variant="filled"
+          size="small"
+          onClick={() => setAuthStore("ROLE_USER")}
+        >
+          SET ROLE_USER
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/app/DevToolst.tsx
+++ b/src/app/DevToolst.tsx
@@ -10,7 +10,14 @@ export const DevTools = () => {
   const role = useAuthStore((state) => state.role);
 
   useEffect(() => {
-    console.log(`현재 권한 : ${role}`);
+    const { token, role, nickname } = useAuthStore.getState();
+    console.group("DevTools - AuthStore");
+    console.table({
+      token,
+      role,
+      nickname,
+    });
+    console.groupEnd();
   }, [role]);
 
   // 미디어 쿼리를 통해 max-width 가 1100px 이상일 경우에만 렌더링 되도록 합니다.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,19 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { ReactQueryProvider, MobileLayout, router } from "./app";
+import { DevTools } from "./app/DevToolst";
 import { GoogleMapsProvider } from "./app/GoogleMapsProvider";
 import "./global.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
+    {/* 
+    // ! TODO
+    // ! 해당 컴포넌트는 개발 환경에서만 사용 되는 컴포넌트 입니다.
+    // ! main.ts 파일에서 렌더링 되며 import.meta.DEV 를 통해 개발 환경인지 확인합니다.
+    // ! 배포 시엔 해당 컴포넌트가 렌더링 되지 않지만 위험을 방지하기 위해 배포 시 해당 컴포넌트를 제거 해주세요
+ */}
+    {import.meta.env.DEV && <DevTools />}
     <ReactQueryProvider>
       <MobileLayout>
         <GoogleMapsProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,14 +8,14 @@ import "./global.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    {/* 
+    <ReactQueryProvider>
+      {/* 
     // ! TODO
     // ! 해당 컴포넌트는 개발 환경에서만 사용 되는 컴포넌트 입니다.
     // ! main.ts 파일에서 렌더링 되며 import.meta.DEV 를 통해 개발 환경인지 확인합니다.
     // ! 배포 시엔 해당 컴포넌트가 렌더링 되지 않지만 위험을 방지하기 위해 배포 시 해당 컴포넌트를 제거 해주세요
  */}
-    {import.meta.env.DEV && <DevTools />}
-    <ReactQueryProvider>
+      {import.meta.env.DEV && <DevTools />}
       <MobileLayout>
         <GoogleMapsProvider>
           <RouterProvider router={router} />

--- a/src/shared/store/auth.ts
+++ b/src/shared/store/auth.ts
@@ -24,3 +24,20 @@ export const useAuthStore = create<AuthStore>((set) => ({
   setRole: (role: string | null) => set({ role }),
   setNickname: (nickname: string | null) => set({ nickname }),
 }));
+
+// ! TODO
+// ! 해당 컴포넌트는 개발 환경에서만 사용 되는 컴포넌트 입니다.
+// ! import.meta.DEV 를 통해 개발 환경인지 확인합니다.
+// ! 배포 시엔 해당 컴포넌트가 렌더링 되지 않지만 위험을 방지하기 위해 배포 시 해당 컴포넌트를 제거 해주세요
+useAuthStore.subscribe((state) => {
+  const { token, role, nickname } = state;
+  if (import.meta.env.DEV) {
+    console.group("DevTools - AuthStore");
+    console.table({
+      token,
+      role,
+      nickname,
+    });
+    console.groupEnd();
+  }
+});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -14,6 +14,7 @@ declare module "*.svg" {
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  DEV: boolean;
   readonly VITE_APP_TITLE: string;
   readonly VITE_GOOGLE_MAPS_API_KEY: string;
   readonly VITE_GOOGLE_MAPS_ID: string;


### PR DESCRIPTION
# 관련 이슈 번호
close #194 
# 설명

개발 환경에서 `useAuthStore` 를 조작 할 `DevTools` 컴포넌트를 생성했습니다. 

`DevTools` 컴포넌트는 다음과 같은 환경에서만 렌더링 됩니다.

1. 개발 환경 `import.meta.DEV = true` 
2. 뷰포트의 크기가 `1100px` 이상 일 때 

```tsx
createRoot(document.getElementById("root")!).render(
  <StrictMode>
    {/* 
    // ! TODO
    // ! 해당 컴포넌트는 개발 환경에서만 사용 되는 컴포넌트 입니다.
    // ! main.ts 파일에서 렌더링 되며 import.meta.DEV 를 통해 개발 환경인지 확인합니다.
    // ! 배포 시엔 해당 컴포넌트가 렌더링 되지 않지만 위험을 방지하기 위해 배포 시 해당 컴포넌트를 제거 해주세요
 */}
    {import.meta.env.DEV && <DevTools />}
...
```

우선 `main.ts` 에서 개발 환경에서만 `DevTools` 컴포넌트가 렌더링 되도록 해주었습니다. 

```tsx
import { useState, useEffect } from "react";
import { useAuthStore } from "@/shared/store";
import { Button } from "@/shared/ui/button";

// ! TODO
// ! 해당 컴포넌트는 개발 환경에서만 사용 되는 컴포넌트 입니다.
// ! main.ts 파일에서 렌더링 되며 import.meta.DEV 를 통해 개발 환경인지 확인합니다.
// ! 배포 시엔 해당 컴포넌트가 렌더링 되지 않지만 위험을 방지하기 위해 배포 시 해당 컴포넌트를 제거 해주세요
export const DevTools = () => {
  const role = useAuthStore((state) => state.role);

  useEffect(() => {
    console.log(`현재 권한 : ${role}`);
  }, [role]);

  // 미디어 쿼리를 통해 max-width 가 1100px 이상일 경우에만 렌더링 되도록 합니다.
  // matchMedia(검사 할 문자열) 을 통해 미디어 쿼리를 검사하고 반환되는 이벤트의 matches 결과를 통해
  // 해당 미디어 쿼리가 맞는지 확인합니다.
  const [isWideEnough, setIsWideEnough] = useState(
    window.matchMedia("(min-width: 1100px)").matches,
  );

  useEffect(() => {
    const mediaQuery = window.matchMedia("(min-width: 1100px)");
    const handleMediaChange = (event: MediaQueryListEvent) => {
      setIsWideEnough(event.matches);
    };

    mediaQuery.addEventListener("change", handleMediaChange);
    return () => {
      mediaQuery.removeEventListener("change", handleMediaChange);
    };
  }, []);

  if (!isWideEnough) {
    return null;
  }

  // 눌리는 버튼에 따라 상태 변경
  const setAuthStore = (ROLE: string) => {
    switch (ROLE) {
      case "ROLE_NULL":
        useAuthStore.setState({
          token: null,
          role: null,
          nickname: null,
        });
        break;
      case "ROLE_NONE":
        useAuthStore.setState({
          token: "Bearer token",
          role: "ROLE_NONE",
          nickname: null,
        });
        break;
      case "ROLE_GUEST":
        useAuthStore.setState({
          token: "Bearer token",
          role: "ROLE_GUEST",
          nickname: "뽀송송",
        });
        break;
      default:
        useAuthStore.setState({
          token: "Bearer token",
          role: "ROLE_USER",
          nickname: "뽀송송",
        });
    }
  };

  // TODO 권한에 따라서 ProfileInfo 에 대한 useQuery InitialData 를 변경해야 합니다.

  return (
    <div className="absolute left-4 top-4">
      <h1 className="text-center title-2">Dev Tools</h1>
      <div className="flex flex-col gap-4 px-2 py-2 rounded-2xl">
        <Button
          colorType="primary"
          variant="filled"
          size="small"
          onClick={() => setAuthStore("ROLE_NULL")}
        >
          SET ROLE_NULL
        </Button>
        <Button
          colorType="primary"
          variant="filled"
          size="small"
          onClick={() => setAuthStore("ROLE_NONE")}
        >
          SET ROLE_NONE
        </Button>
        <Button
          colorType="primary"
          variant="filled"
          size="small"
          onClick={() => setAuthStore("ROLE_GUEST")}
        >
          SET ROLE_GUEST
        </Button>
        <Button
          colorType="primary"
          variant="filled"
          size="small"
          onClick={() => setAuthStore("ROLE_USER")}
        >
          SET ROLE_USER
        </Button>
      </div>
    </div>
  );
};
```

> 뷰포트의 크기가 1100px 이상 일 때에만 렌더링 되게 한 것은 모바일 환경으로 바라 볼 때 UI 를 가리지 않게 하기 위함입니다.

![image](https://github.com/user-attachments/assets/cff098d7-51ea-4e54-b840-9f1764dfba07)

버튼이 눌려 `AuthStore` 가 변경 되면 변경 내역이 로깅 됩니다.




# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
