### PR TITLE
[Hotfix] my-page/setting 에서 라우팅 처리 하기 

### DIFF
--- a/src/features/setting/ui/_LogoutModal.tsx
+++ b/src/features/setting/ui/_LogoutModal.tsx
@@ -17,7 +17,7 @@ export const LogoutModal = ({
       nickname: null,
     });
     onCloseLogoutModal();
-    navigate("/search");
+    navigate("/");
   };
 
   return (

--- a/src/pages/my-page/setting/page.tsx
+++ b/src/pages/my-page/setting/page.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   AccountManagement,
   EditMyInfo,
@@ -8,10 +10,24 @@ import {
   LogoutButton,
 } from "@/features/setting/ui";
 import { VersionInfo } from "@/entities/setting/ui";
+import { useAuthStore } from "@/shared/store";
 import { DividerLine } from "@/shared/ui/divider";
 import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
 
 export const SettingPage = () => {
+  const navigate = useNavigate();
+  const role = useAuthStore((state) => state.role);
+
+  useEffect(() => {
+    if (role === null) {
+      navigate("/my-page");
+    }
+  }, [navigate, role]);
+
+  if (role === null) {
+    return null;
+  }
+
   return (
     <>
       <section>


### PR DESCRIPTION
# 관련 이슈 번호
close #201 
#186 
# 설명

# 권한에 따른 라우팅

이전엔 `/my-page/setting` 에 권한이 없는 채로 접속 한 경우 (`url` 을 통한 직접적인 접근) 에 설정 페이지를 이용하는 것이 가능했습니다.

해당 작업을 막기 위해 권한에 따른 반환값과 라우팅 처리를 해줬습니다.

```tsx
export const SettingPage = () => {
  const navigate = useNavigate();
  const role = useAuthStore((state) => state.role);

  useEffect(() => {
    if (role === null) {
      navigate("/my-page");
    }
  }, [navigate, role]);

  if (role === null) {
    return null;
  }
...
```

> `useAuthStore.getState()` 로 불러와도 되겠지만 더 성능 상 문제 없고 , 더 확실한 상태 값을 가져 올 수 있도록 구독 시켰습니다. 

# 로그아웃 시 라우팅 경로 

이전엔 로그아웃 시 `/search` 경로로 리다이렉션 시켰지만 이게 웬걸, 저흰 `/search` 라는 경로가 존재하지 않습니다.

이에 `/search` 가 아닌 `/` 로 라우팅 시켰습니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
