### PR TITLE
[Hotfix] input file 을 제거해도 업데이트가 되지 않는 버그 수정

### DIFF
--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -53,6 +53,7 @@ export const ProfileInput = () => {
   // 바텀 시트를 조작하기 위한 상태값
   const [isOpen, setOpen] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const [inputKey, setInputKey] = useState<number>(0);
 
   // 상태에 저장된 파일 객체가 존재하는 경우엔 파일 객체를 URL로 변경하여 사용합니다.
   // 만약 파일 객체가 존재하지 않는 경우 기본 이미지를 제공합니다.
@@ -74,6 +75,7 @@ export const ProfileInput = () => {
   // 사진을 삭제하는 핸들러
   const handleDelete = () => {
     setProfileImage(null);
+    setInputKey((prev) => prev + 1);
   };
 
   // 사진 선택하기 버튼을 클릭했을 때 input을 클릭하는 핸들기
@@ -92,6 +94,7 @@ export const ProfileInput = () => {
         aria-label="profile-image-button"
       >
         <input
+          key={inputKey}
           type="file"
           accept="image/jpeg, image/png, image/webp"
           className="sr-only"

--- a/src/features/map/ui/MarkingFormModal.tsx
+++ b/src/features/map/ui/MarkingFormModal.tsx
@@ -142,10 +142,11 @@ const PostVisibilitySelect = () => {
 };
 
 const PhotoInput = () => {
-  const inputRef = useRef<HTMLInputElement>(null);
   const images = useMarkingFormStore((state) => state.images);
   const setImages = useMarkingFormStore((state) => state.setImages);
 
+  const [inputKey, setInputKey] = useState<number>(0);
+  const inputRef = useRef<HTMLInputElement>(null);
   // imageUrls 는 이미지 파일을 렌더링 하기 위해 사용되며 lastModified 는 images 내부 파일들을
   // 식별 하기 위한 식별자로 사용됩니다.
   const imageUrls = images.map((image) => ({
@@ -174,9 +175,11 @@ const PhotoInput = () => {
 
     const _images = [...images];
     for (const newFile of newFiles) {
-      if (!isImageAlreadyExist(newFile)) {
-        _images.push(newFile);
+      if (isImageAlreadyExist(newFile)) {
+        continue;
       }
+
+      _images.push(newFile);
 
       if (_images.length > 5) {
         throw new Error(MarkingModalError.maxPhotoCount);
@@ -188,12 +191,14 @@ const PhotoInput = () => {
 
   const handleRemoveImage = (lastModified: number) => {
     setImages(images.filter((image) => image.lastModified !== lastModified));
+    setInputKey((prev) => prev + 1);
   };
 
   return (
     <div>
       {/* 사진을 담을 input , sr-only로 실제 화면에 렌더링 되지 않음*/}
       <input
+        key={inputKey}
         type="file"
         accept=".jpeg,.jpg,.png,.webp"
         multiple


### PR DESCRIPTION
# 관련 이슈 번호

close #206 
#205 
# 설명

## 버그 설명

![bug](https://github.com/user-attachments/assets/66223eb2-3216-4195-b059-dc59b174d200)

#205 의 작업을 하던 중 버그가 발견되어 호다닥 브랜치를 생성합니다. 위의 이미지는 `PetInfoForm` 모달의 일부 모습입니다만 

파일을 업로드 하는 모든 작업에 해당 됩니다. (버그는 `MarkingFormModal` 에서 최초로 발견됨)

### 버그가 발생한 상황

1. `input type = file` 에서 파일을 추가하여 `store` 에 해당 이미지 저장 
2. `store` 에서 이미지를 제거하는 행위를 시행 
3. `store` 에서 제거했던 이미지를 다시 `input type = file` 에 업로드 
4. `input type = file` 에 업로드가 되지 않음 

### 예상 해결 방안

우선 가장 의문이 드는 부분은 왜 업로드가 되지 않는가 ? 입니다. 

업로드가 되지 않는 이유는 `JS` 의 문제가 아닌 실제 `Actual DOM` 이 올바르게 조작되지 않았기 때문에 일어났습니다.

우선 기본적으로 __`input type = file` 의 경우 중복되는 파일의 업로드가 일어나지 않습니다.__

그렇다면 `store` 의 이미지를 제거해도 4번 상황이 발생한 이유는 사진 업로드를 담당하고 있는 `input` 에 담긴 `file` 이 변경되지 않았기 때문입니다. 

### 저는 리액트의 `Reconciliation` 과정에 대해 잘못 이해하고 있었습니다.

```tsx
// PetInfoForm 의 일부
export const ProfileInput = () => {
  const profileImage = usePetInfoStore((state) => state.profileImage);
  const setProfileImage = usePetInfoStore((state) => state.setProfileImage);
  // 바텀 시트를 조작하기 위한 상태값
  const [isOpen, setOpen] = useState<boolean>(false);
  const inputRef = useRef<HTMLInputElement | null>(null);

  return (
<>
    ...
        <input
          type="file"
          accept="image/jpeg, image/png, image/webp"
          className="sr-only"
          id="profile"
          ref={inputRef}
          onChange={handleFileChange}
        />
   ...
)
```

컴포넌트 내부에서 상태가 변경되면 해당 컴포넌트가 다시 호출된다는 사실은 너무나도 자명한 사실입니다. 

하지만 그 컴포넌트의 모든 결과값이 모두 새롭게 액츄얼 돔에 적용되는 것은 아닙니다. 

리액트는 상태 변경에 의해 컴포넌트가 새롭게 호출되고 나면 다음과 같은 과정을 거쳐 `virtual dom` 을 생성하고 `actual dom` 을 업데이트 합니다. 

1. 컴포넌트 리렌더링되어 새로운 `virtual dom` 생성
2. 이전 `virtual dom` 과 현재 `virtual dom` 의 차이점 비교 (diffing)
3. `diffing` 과정에서 `key , id , className, props ... ` 등등 다양한 값들을 비교하여 변경이 필요하지 않은 부분은 업데이트 하지 않음 
4. `diffing` 과정에서 업데이트가 필요하다고 판단되는 요소를 찾아 `actual dom` 조작 

다시 위 상황으로 돌아가봅시다. 

`input type = file` 액츄얼돔은 `ProfileInput ` 컴포넌트가 리렌더링 되었다고 해서 액츄얼돔의 `input` 이 매 번 업데이트 될까요 ? 

그렇지 않습니다. `input jsx` 가 `key , id , props` 들로 받은 값들이 변경되지 않았기 때문입니다. 

이로인해 사진을 `JS` 조작을 통해 스토어에서 제거하더라도 액츄얼돔에 존재하는 `input` 은 조작한 사진을 들고 있는 상태로 남아있게 됩니다. 

> 코드 상에서 삭제 된 것 처럼 보인 이유는 렌더링 시 사용되는 사진은 `input` 이 들고 있는 파일이 아닌,  JS 의 상태 값으로 들고 있는 이미지이기 때문입니다.

### 어떻게 해결할까 ? 

우린 사실 `input` 에서 어떤 값을 가지고 있는지는 궁금하지 않습니다. 

> 특히나 저는 `Form` 을 제출 할 때 액츄얼 돔이 들고 있는 값으로 제출하지 않고 JS 상에서 들고 있는 값을 제출하기에 더더욱 상관이 없습니다.

우리가 원하는 것은 `JS` 에서 사진을 삭제 시켰을 때 `input` 이 액츄얼 돔 상에서 업데이트 되기를 기대합니다. 더 이상 그 사진을 들고 있기를 기대하지 않기 때문입니다. 

```tsx
export const ProfileInput = () => {
  ...
  const [inputKey, setInputKey] = useState<number>(0);

  ...
   // 사진을 삭제하는 핸들러
  const handleDelete = () => {
    setProfileImage(null);
    setInputKey((prev) => prev + 1);
  };

  return (
<>
    ...
        <input
          type="file"
          accept="image/jpeg, image/png, image/webp"
          className="sr-only"
          id="profile"
          ref={inputRef}
          onChange={handleFileChange}
        />
   ...
)
```
 
다음과 같이 사진이 삭제 될 경우 액츄얼 돔 상의 `Input`  를 업데이트 하기 위해 상태 값을 `key` 로 물려줍시다. 

![fixed](https://github.com/user-attachments/assets/265a3022-9485-4d9a-9cc8-5de7ab1c369f)

위와 같이 해결하여 버그를 제거했습니다.

맨날 리렌더링 리렌더링 노래를 불러 놓고 여태 리렌더링에 대해서 가장 중요한 부분을 놓치고 있었군 싶습니다 캭


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
