### PR TITLE
[Hotfix] Image Blink 현상 버그 픽스

### DIFF
--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -16,7 +16,7 @@ import { usePostPetInfo } from "../api/petinfo";
 import { characterList, dogBreeds } from "../constants/form";
 import { usePetInfoStore } from "../store";
 
-const DEFAULT_PROFILE_IMAGE = "default-image.png";
+const DEFAULT_PROFILE_IMAGE = "/default-image.png";
 
 const TextCounter = ({
   text,
@@ -50,22 +50,20 @@ export const Form = ({ children }: { children: React.ReactNode }) => {
 export const ProfileInput = () => {
   const profileImage = usePetInfoStore((state) => state.profileImage);
   const setProfileImage = usePetInfoStore((state) => state.setProfileImage);
-  // 바텀 시트를 조작하기 위한 상태값
+  // 바텀시트를 조작하기 위한 state
   const [isOpen, setOpen] = useState<boolean>(false);
+  // actual dom 의 input 태그를 조작하기 위한 ref , state
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [inputKey, setInputKey] = useState<number>(0);
+  // 프로필 이미지를 보여주기 위한 state
+  const [profileUrl, setProfileUrl] = useState(() =>
+    profileImage ? URL.createObjectURL(profileImage) : DEFAULT_PROFILE_IMAGE,
+  );
 
-  // 상태에 저장된 파일 객체가 존재하는 경우엔 파일 객체를 URL로 변경하여 사용합니다.
-  // 만약 파일 객체가 존재하지 않는 경우 기본 이미지를 제공합니다.
-  const profileUrl = profileImage
-    ? URL.createObjectURL(profileImage)
-    : `${window.location.origin}/${DEFAULT_PROFILE_IMAGE}`;
-
-  // type이 file인 input에게 파일이 존재하는 경우엔 Blob URL을 생성하여 프로필 이미지로 설정합니다.
-  // 만약 사진이 존재하지 않는 경우 기본 이미지를 제공합니다.
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    setProfileImage(file || null);
+    setProfileImage(file!);
+    setProfileUrl(URL.createObjectURL(file!));
   };
 
   // 바텀 시트를 여닫는 핸들러

--- a/src/features/map/ui/MarkingFormModal.tsx
+++ b/src/features/map/ui/MarkingFormModal.tsx
@@ -141,19 +141,26 @@ const PostVisibilitySelect = () => {
   );
 };
 
+interface ImageUrl {
+  url: string;
+  lastModified: number;
+  name: string;
+}
+
 const PhotoInput = () => {
   const images = useMarkingFormStore((state) => state.images);
   const setImages = useMarkingFormStore((state) => state.setImages);
 
   const [inputKey, setInputKey] = useState<number>(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  // imageUrls 는 이미지 파일을 렌더링 하기 위해 사용되며 lastModified 는 images 내부 파일들을
-  // 식별 하기 위한 식별자로 사용됩니다.
-  const imageUrls = images.map((image) => ({
-    url: URL.createObjectURL(image),
-    lastModified: image.lastModified,
-    name: image.name,
-  }));
+
+  const [imageUrls, setImageUrls] = useState<ImageUrl[]>(() =>
+    images.map((image) => ({
+      url: URL.createObjectURL(image),
+      lastModified: image.lastModified,
+      name: image.name,
+    })),
+  );
 
   const handleOpenAlbum = () => {
     inputRef.current?.click();
@@ -174,12 +181,19 @@ const PhotoInput = () => {
     };
 
     const _images = [...images];
+    const _imageUrls = [...imageUrls];
+
     for (const newFile of newFiles) {
       if (isImageAlreadyExist(newFile)) {
         continue;
       }
 
       _images.push(newFile);
+      _imageUrls.push({
+        url: URL.createObjectURL(newFile),
+        lastModified: newFile.lastModified,
+        name: newFile.name,
+      });
 
       if (_images.length > 5) {
         throw new Error(MarkingModalError.maxPhotoCount);
@@ -187,10 +201,15 @@ const PhotoInput = () => {
     }
 
     setImages([..._images]);
+    setImageUrls([..._imageUrls]);
   };
 
   const handleRemoveImage = (lastModified: number) => {
     setImages(images.filter((image) => image.lastModified !== lastModified));
+    setImageUrls(
+      imageUrls.filter((image) => image.lastModified !== lastModified),
+    );
+
     setInputKey((prev) => prev + 1);
   };
 


### PR DESCRIPTION
# 관련 이슈 번호
close #209 

# 설명

## 버그 설명

![b;oml](https://github.com/user-attachments/assets/d68338b4-91e9-4ace-b4fa-179da9a9c450)

상태 변경이 일어나는 컴포넌트 안에서 `url` 형태로 이미지 파일을 렌더링 할 때 

리렌더링이 일어나게 되면 이미지가 반짝 거리는 블링크 현상이 발생합니다. 

### 버그가 발생한 상황

1. `PetInfoForm` 에서 이미지를 등록 함
2. 사진을 수정하기 위해 바텀시트를 열음
3. Blink!
4. 바텀시트를 다음
5. Blink!

> 이 문제는 비단 `PetInfoForm` 에 국한되지 않고 잦은 리렌더링이 일어나는 컴포넌트 들에서 `url` 형태로 이미지를 렌더링 하는 경우 동일합니다. 

### 예상 해결 방안

```tsx
// PetInfoForm 의 일부
const PhotoInput = () => {
  const images = useMarkingFormStore((state) => state.images);
  ...
  const imageUrls = images.map((image) => ({
    url: URL.createObjectURL(image),
    lastModified: image.lastModified,
    name: image.name,
  }));
...
```

아마 이런 이유가 발생하는 이유는 위 GIF 파일에서도 볼 수 있듯이 이미지 파일을 렌덜이 할 때 사용되는 `imagesUrl` 이 리렌더링과 함께 매번 새롭게 생성되기 때문인 거 같습니다. 

`imagesUrl` 객체가 새롭게 생성되어 `<img>` jsx 가 받는 `props` 등이 변화되어 액츄얼돔의 잦은 조작이 일어나서 그런 걸로 보입니다. 

리렌더링이 일어나도 `imagesUrl` 이 새롭게 생성되지 않게 객체가 아닌 `state` 로 관리해야겠습니다. 

----

```tsx
const PhotoInput = () => {
  const images = useMarkingFormStore((state) => state.images);
  const setImages = useMarkingFormStore((state) => state.setImages);

  const [inputKey, setInputKey] = useState<number>(0);
  const inputRef = useRef<HTMLInputElement>(null);

  const [imageUrls, setImageUrls] = useState<ImageUrl[]>(() =>
    images.map((image) => ({
      url: URL.createObjectURL(image),
      lastModified: image.lastModified,
      name: image.name,
    })),
  );
```


`imaegsUrl` 과 같은 값을 컴포넌트 리렌더링 시에도 기억 될 수 있도록 `state` 로 변경해줬습니다.

`ref` 냐 `useState` 냐 고민을 많이 했는데 리렌더링 시 `UI` 가 변경되어야 하는 경우엔 `state` 로 관리하는 것이 맞을 것 같아 `state` 로 수정해서 올립니다 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
