### PR TITLE
[Feat] 회원 가입 단계에서 지속적으로 토큰 업데이트

### DIFF
--- a/src/features/auth/api/petinfo.ts
+++ b/src/features/auth/api/petinfo.ts
@@ -7,6 +7,7 @@ export interface PetInfoResponse {
   message: string;
   content: {
     role: string;
+    authorization: string;
   };
 }
 

--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -192,6 +192,7 @@ interface UserInfoRegistrationResponse {
   content: {
     role: string;
     nickname: string;
+    authorization: string;
   };
 }
 

--- a/src/features/auth/ui/PetInfoForm.stories.tsx
+++ b/src/features/auth/ui/PetInfoForm.stories.tsx
@@ -34,7 +34,8 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
             code: 200,
             message: "success",
             content: {
-              role: "USER_USER",
+              role: "ROLE_USER",
+              authorization: "Bearer token ROLE_USER",
             },
           });
         }),
@@ -427,8 +428,9 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
 
         await userEvent.click($submit);
 
-        const { role } = useAuthStore.getState();
-        expect(role).toBe("USER_USER");
+        const { role, token } = useAuthStore.getState();
+        expect(role).toBe("ROLE_USER");
+        expect(token).toBe("Bearer token ROLE_USER");
       },
     );
   },

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -253,6 +253,7 @@ export const SubmitButton = () => {
    */
   const navigate = useNavigate();
   const setRole = useAuthStore((state) => state.setRole);
+  const setToken = useAuthStore((state) => state.setToken);
   const { mutate: postPetInfo } = usePostPetInfo();
 
   // 필수 항목을 모두 입력하지 않은 경우 나타 날 스낵바
@@ -294,10 +295,11 @@ export const SubmitButton = () => {
       },
       {
         onSuccess: (data) => {
-          const { role } = data.content;
+          const { role, authorization } = data.content;
           const { lastNoneAuthRoute } = useRouteHistoryStore.getState();
 
           setRole(role);
+          setToken(authorization);
           navigate(lastNoneAuthRoute);
         },
         // TODO 에러 바운더리 생성되면 로직 변경하기

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -340,6 +340,7 @@ const UserInfoRegistrationForm = () => {
   const token = useAuthStore((state) => state.token);
   const setNickname = useAuthStore((state) => state.setNickname);
   const setRole = useAuthStore((state) => state.setRole);
+  const setToken = useAuthStore((state) => state.setToken);
 
   const { mutate: putUserInfoRegistration } = usePutUserInfoRegistration();
 
@@ -414,11 +415,12 @@ const UserInfoRegistrationForm = () => {
       {
         onSuccess: (data) => {
           const {
-            content: { nickname, role },
+            content: { nickname, role, authorization },
           } = data;
 
           setNickname(nickname);
           setRole(role);
+          setToken(authorization);
 
           openLandingModal();
         },


### PR DESCRIPTION
# 관련 이슈 번호
close #216 
# 설명

유저토큰이 액세스 토큰에 추가됨에 따라 회원 가입 단계가 진행되면 `useAuthStore` 에서 저장하는 `token` 값도 함께 업데이트 해나가야 합니다.

이에 수정합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
