### PR TITLE
[Hotfix] 모달이 뜬 채로 라우팅이 될 경우 모달이 여전히 남아있는 버그 수정

### DIFF
--- a/src/app/OverlayPortal.tsx
+++ b/src/app/OverlayPortal.tsx
@@ -42,7 +42,7 @@ const OverlayWrapper = ({ overlayInfo }: { overlayInfo: OverlayInfo }) => {
  * 오버레이가 열린 채로 라우팅이 일어나면 모든 오버레이를 제거 합니다.
  */
 export const OverlayPortal = () => {
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
   const overlays = useOverlayStore((state) => state.overlays);
   const resetOverlays = useOverlayStore((state) => state.resetOverlays);
 
@@ -64,7 +64,7 @@ export const OverlayPortal = () => {
   // 페이지 이동 시 모든 오버레이를 제거합니다.
   useEffect(() => {
     resetOverlays();
-  }, [pathname, resetOverlays]);
+  }, [pathname, search, resetOverlays]);
 
   const overlayAreaBackground = shouldDisableInteraction ? "h-screen" : "";
 

--- a/src/app/OverlayPortal.tsx
+++ b/src/app/OverlayPortal.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
+import { useLocation } from "react-router-dom";
 import { useOverlayStore } from "@/shared/store/overlay";
 import type { OverlayInfo } from "@/shared/store/overlay";
 
@@ -37,9 +38,13 @@ const OverlayWrapper = ({ overlayInfo }: { overlayInfo: OverlayInfo }) => {
  * OverlayPortal 컴포넌트는 오버레이를 렌더링합니다.
  * overlay들이 렌더링 되는 영역은 뷰포트 크기를 가진 div 입니다.
  * 따라서 overlay들은 뷰포트를 기준으로 하여 top, left, right, bottom 값으로 위치를 조정합니다.
+ *
+ * 오버레이가 열린 채로 라우팅이 일어나면 모든 오버레이를 제거 합니다.
  */
 export const OverlayPortal = () => {
+  const { pathname } = useLocation();
   const overlays = useOverlayStore((state) => state.overlays);
+  const resetOverlays = useOverlayStore((state) => state.resetOverlays);
 
   const shouldDisableInteraction = overlays.some(
     ({ options: { disableInteraction } }) => disableInteraction === true,
@@ -55,6 +60,11 @@ export const OverlayPortal = () => {
       document.body.style.overflow = "auto";
     };
   }, [shouldDisableInteraction]);
+
+  // 페이지 이동 시 모든 오버레이를 제거합니다.
+  useEffect(() => {
+    resetOverlays();
+  }, [pathname, resetOverlays]);
 
   const overlayAreaBackground = shouldDisableInteraction ? "h-screen" : "";
 

--- a/src/features/auth/ui/RegionModal.tsx
+++ b/src/features/auth/ui/RegionModal.tsx
@@ -301,9 +301,12 @@ export const RegionModal = ({ onClose }: { onClose: () => Promise<void> }) => {
     (state) => state.resetRegionModalStore,
   );
 
+  useEffect(() => {
+    return () => resetRegionModalStore();
+  }, [resetRegionModalStore]);
+
   const handleRegionModalClose = async () => {
     await onClose();
-    resetRegionModalStore();
   };
   return (
     <Modal modalType="fullPage">

--- a/src/features/setting/lib/account.tsx
+++ b/src/features/setting/lib/account.tsx
@@ -6,7 +6,7 @@ import { CancellationCheckModal } from "../ui/_CancellationCheckModal";
 import { PasswordChangeModal } from "../ui/_PasswordChangeModal";
 
 export const useCancellationCheckModal = () => {
-  const resetCancellationForm = useAccountCancellationFormStore(
+  const resetAccountCancellationForm = useAccountCancellationFormStore(
     (state) => state.reset,
   );
 
@@ -16,8 +16,7 @@ export const useCancellationCheckModal = () => {
   } = useModal(() => (
     <ExitConfirmModal
       onConfirm={() => {
-        resetCancellationForm();
-        onCloseConfirmModal();
+        resetAccountCancellationForm();
         onCloseCancellationCheckModal();
       }}
       onClose={onCloseConfirmModal}
@@ -53,7 +52,6 @@ export const useChangePasswordModal = () => {
         onClose={onCloseExitModal}
         onConfirm={() => {
           resetPasswordChangeForm();
-          onCloseExitModal();
           onClosePasswordChangeModal();
         }}
       />

--- a/src/features/setting/ui/_CancellationCheckModal.tsx
+++ b/src/features/setting/ui/_CancellationCheckModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { PasswordInput } from "@/entities/auth/ui";
 import { Button } from "@/shared/ui/button";
 import { CloseIcon, InfoIcon } from "@/shared/ui/icon";
@@ -65,6 +66,14 @@ export const CancellationCheckModal = ({
 }: {
   onClose: () => Promise<void>;
 }) => {
+  const resetAccountCancellationForm = useAccountCancellationFormStore(
+    (state) => state.reset,
+  );
+
+  useEffect(() => {
+    return () => resetAccountCancellationForm();
+  }, [resetAccountCancellationForm]);
+
   return (
     // TODO FormModal 생성 되면 적용하기
     <Modal modalType="center">

--- a/src/features/setting/ui/_PasswordChangeModal.tsx
+++ b/src/features/setting/ui/_PasswordChangeModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { PasswordInput } from "@/entities/auth/ui";
 import { Button } from "@/shared/ui/button";
 import { CloseIcon } from "@/shared/ui/icon";
@@ -174,6 +175,14 @@ export const PasswordChangeModal = ({
 }: {
   onClose: () => Promise<void>;
 }) => {
+  const resetPasswordChangeForm = usePasswordChangeFormStore(
+    (state) => state.reset,
+  );
+
+  useEffect(() => {
+    return () => resetPasswordChangeForm();
+  }, [resetPasswordChangeForm]);
+
   return (
     <Modal modalType="center">
       <section className="flex justify-between self-stretch">

--- a/src/shared/store/overlay.ts
+++ b/src/shared/store/overlay.ts
@@ -21,6 +21,7 @@ interface OverlayStore {
   overlays: OverlayInfo[];
   addOverlay: (newOverlay: OverlayInfo) => void;
   removeOverlay: (id: number) => void;
+  resetOverlays: () => void;
 }
 
 export const useOverlayStore = create<OverlayStore>((set) => ({
@@ -35,4 +36,6 @@ export const useOverlayStore = create<OverlayStore>((set) => ({
     set(({ overlays }) => ({
       overlays: overlays.filter((overlay) => overlay.id !== id),
     })),
+
+  resetOverlays: () => set({ overlays: [] }),
 }));


### PR DESCRIPTION
# 관련 이슈 번호
close #215
# 설명

## 버그 설명

![modal bug](https://github.com/user-attachments/assets/e6be1551-51f3-44af-a449-7a673556f23b)

### 버그가 발생한 상황

모달이 뜬 채로 브라우저의 뒤로가기를 클릭 하는 경우 모달이 남아있는 채로 라우팅 되는 버그가 존재합니다. 

인터렉션이 막히는 부분은 렌더링 된 웹앱 내부이지 PC의 브라우저 상단 영역 이나 모바일에서 브라우저를 직접적으로 조작하는 행위 (뒤로가기 버튼 클릭 , 좌우로 스와이프) 까지는 막지 못하게 됩니다.

이에 __라우팅 경로가 변경되면 모달이 닫히도록 버그를 해결 해야 합니다.__

# 왜 이런 버그가 나타났는가 ? 

오버레이들을 닫는 행위는 오로지 오버레이 외부 영역이나 , X 버튼 , ConfirmModal 의 나가기를 뜻 하는 버튼을 눌러야만 닫힙니다. 

오버레이는 현재 경로가 변경 된다고 해서 닫히지 않습니다. 

특정 경로에 종속되지 않고 루트 경로의 레이아웃에서 렌더링 되고 있기 때문입니다. 🥹 

따라서 경로가 변경 됐을 때 오버레이들을 삭제하는 로직이 필요 합니다. 

# `OverlayPortal` 에서 라우팅 경로를 추적하는 로직 추가 
![fixed](https://github.com/user-attachments/assets/9aba6db8-6086-4dde-b68c-63ac68e23b0a)

```tsx
export const OverlayPortal = () => {
  ...
  const { pathname , search } = useLocation();
  const overlays = useOverlayStore((state) => state.overlays);
  const resetOverlays = useOverlayStore((state) => state.resetOverlays);
  ...
  // 페이지 이동 시 모든 오버레이를 제거합니다.
  useEffect(() => {
    resetOverlays();
  }, [pathname, search, resetOverlays]);
```

`OverlayPortal` 에서 `pathname` 이 변경 될 때 마다 모든 오버레이들을 제거하는 로직을 추가했습니다.

이로 인해 오버레이가 닫히는 경우는 이 전에 말한 것에서 경로가 변경 되었을 때 까지 추가 되었습니다.

# 스토어를 사용하는 모달에서 클린업 메소드 추가 

```tsx
export const PasswordChangeModal = ({
  onClose,
}: {
  onClose: () => Promise<void>;
}) => {
  const resetPasswordChangeForm = usePasswordChangeFormStore(
    (state) => state.reset,
  );

  useEffect(() => {
    return () => resetPasswordChangeForm();
  }, [resetPasswordChangeForm]);
```

각 스토어를 구독하고 있는 모달에서 클린업 메소드를 넣어줬습니다.

> TODO
>  마킹 폼 모달은 논외로 합니다. 마킹 폼 모달은 모드가 `edit`  에서  `view` 로 변경 됐을 때에만 초기화 하도록 합니다.  
> 현재는 마킹폼 모달을 명시적으로 X 버튼을 눌러 닫을 때 에만 초기화 됩니다. 

클린업 메소드가 필요한 이유는 `onClose` 메소드로 닫히지 않고 , `OverlayPortal` 에서 경로가 변경 됐을 때 강제로 `overlays` 배열을 지울 때 시행되기 위함입니다. 

# 클린업 메소드가 있으면 컨펌 모달에서 스토어를 초기화 하지 않아도 되는거 아닌가?

```tsx
export const useChangePasswordModal = () => {
  const resetPasswordChangeForm = usePasswordChangeFormStore(
    (state) => state.reset,
  );

  const { handleOpen: handleOpenExitConfirmModal, onClose: onCloseExitModal } =
    useModal(() => (
      <ExitConfirmModal
        onClose={onCloseExitModal}
        onConfirm={() => {
          resetPasswordChangeForm(); // 컨펌모달이 컨펌 됐을 때 스토어를 초기화 하는 과정이 존재 한다. 
          onClosePasswordChangeModal();
        }}
      />
    ));
``` 

처음 클린업 메소드를 넣고 나서 `onConfirm` 에서 스토어를 초기화 하지 않아도 되겠다! 라고 생각했습니다.

하지만 그렇지 않습니다.

`onConfirm` 에서 스토어를 초기화 하지 않으면 `onConfirm` 에서 `onClosePassword ...` 과정에서 반복적으로 `beforeClose` 가 시행되어 컨펌 모달이 지속적으로 나타나게 됩니다.

> `beforeClose` 에서 스토어가 비어있지 않다면 컨펌모달이 열립니다. 

따라서 컨펌 모달에서 스토어를 초기화 하는 로직과 함께 클린업 메소드도 사용 되어야 합니다. 

# 현재 코드의 한계점 

현재 코드의 한계점은 컨펌 모달을 통해 모달을 닫을 때 컨펌 모달에서 스토어 초기화가 일어나고 , 언마운트 되면서 스토어 초기화가 한 번 더 일어난다는 점입니다. 

이를 해결 하기 위한 방법을 추후 고려해봐야 할 것으로 생각 됩니다. 

현재 베스트 프랙틱스를 연구하기엔 해당 픽스 내용이 더 급하기에 먼저 PR 올립니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
