### PR TITLE
[Feat] 디자인 변경에 따른 Age 바텀 시트 내용 변경

### DIFF
--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -200,7 +200,7 @@ interface UserInfoRegistrationRequest {
   token: string;
   nickname: string;
   gender: "FEMALE" | "MALE";
-  age: 10 | 20 | 30 | 40 | 50;
+  age: 10 | 20 | 30 | 40 | 50 | 60;
   region: number[];
   marketingYn: boolean;
 }

--- a/src/features/auth/constants/form.ts
+++ b/src/features/auth/constants/form.ts
@@ -31,18 +31,22 @@ export const ageRangeOptionList = [
   },
   {
     value: 20,
-    name: "20~30대",
+    name: "20대",
   },
   {
     value: 30,
-    name: "30~40대",
+    name: "30대",
   },
   {
     value: 40,
-    name: "50~60대",
+    name: "40대",
   },
   {
     value: 50,
+    name: "50대",
+  },
+  {
+    value: 60,
     name: "60대 이상",
   },
 ] as const;

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -79,7 +79,7 @@ export const useLoginFormStore = create<LoginFormStore>((set) => ({
 }));
 
 type Gender = "FEMALE" | "MALE" | null;
-type AgeRange = 10 | 20 | 30 | 40 | 50 | null;
+type AgeRange = 10 | 20 | 30 | 40 | 50 | 60 | null;
 type CheckedList = boolean[];
 type Region = { address: string; id: number };
 

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -98,6 +98,7 @@ export const userInfoRegistrationHandlers = [
       content: {
         nickname,
         role: "ROLE_GUEST",
+        authorization: "Bearer token for ROLE_GUEST",
       },
     });
   }),


### PR DESCRIPTION
# 관련 이슈 번호
close #225 
# 설명

유저 인포쪽 바텀 시트의 내용이 변경 되었습니다.
![image](https://github.com/user-attachments/assets/855cea2e-bfc6-4352-ac7a-71022c4e4e58)
변경 전 
![image](https://github.com/user-attachments/assets/fa0fa142-938b-4ca8-be14-6189257bed8e)
변경 후 

따라서 렌더링 되는 값과 서버 응답에 `60` 이란 값을 추가했습니다.

> 60대 이상은 60이란 값으로 보내기로 백엔드와 확인 되었습니다 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
