### PR TITLE
[Hotfix] postUserInfo 백엔드 요구 사항에 맞춰 기능 변경

### DIFF
--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -228,6 +228,7 @@ const putUserInfoRegister = async ({
       "Content-Type": "application/json",
       Authorization: token,
     },
+    credentials: "same-origin",
     body: JSON.stringify(userInfo),
   });
 

--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ROUTER_PATH } from "@/shared/constants";
-import { useAuthStore } from "@/shared/store";
+import { AuthStore, useAuthStore } from "@/shared/store";
 import { SIGN_UP_END_POINT } from "../constants";
 
 interface VerificationCodeRequestData {
@@ -154,7 +154,8 @@ export const usePostSignUpByEmail = () => {
 };
 
 export interface DuplicateNicknameRequestData {
-  nickname: string;
+  nickname: NonNullable<AuthStore["nickname"]>;
+  token: NonNullable<AuthStore["token"]>;
 }
 
 export interface DuplicateNicknameResponse {
@@ -164,11 +165,13 @@ export interface DuplicateNicknameResponse {
 
 const postDuplicateNickname = async ({
   nickname,
+  token,
 }: DuplicateNicknameRequestData) => {
   const response = await fetch(SIGN_UP_END_POINT.DUPLICATE_NICKNAME, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      Authorization: token,
     },
     body: JSON.stringify({ nickname }),
   });

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -51,8 +51,12 @@ const NicknameInput = () => {
 
   const handleBlur = () => {
     if (!isValidNickname || isNicknameEmpty) return;
+    const { token } = useAuthStore.getState();
 
-    postDuplicateNickname({ nickname });
+    if (!token) {
+      throw new Error("로그인 후 이용해 주세요");
+    }
+    postDuplicateNickname({ nickname, token });
   };
 
   let statusText = "20자 이내의 한글 영어 숫자만 사용 가능합니다.";


### PR DESCRIPTION
# 관련 이슈 번호
close #250 

# 설명

2024/10/06 에 시행한 테스트 결과에 맞춰 다음과 같은 기능을 추가 합니다.

- 닉네임 중복 검사 시 토큰도 함께 전송 하도록 수정
- user-info 제출 시 `refresh-token` 제출 위해 쿠키도 함께 제출 하도록 수정 (`crendential : same-origin`)

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
