### PR TITLE
[Feat] StackedButtonModal 컴포넌트 생성

### DIFF
--- a/src/shared/ui/modal/StackedButtonModal.stories.tsx
+++ b/src/shared/ui/modal/StackedButtonModal.stories.tsx
@@ -1,5 +1,8 @@
 import { StoryObj } from "@storybook/react";
 import { EmailInput } from "@/entities/auth/ui";
+import { useModal } from "@/shared/lib";
+import { OverlayPortal } from "@/app";
+import { ConfirmModal } from "./ConfirmModal";
 import { StackedButtonModal } from "./StackedButtonModal";
 
 export default {
@@ -45,7 +48,8 @@ type Story = StoryObj<typeof StackedButtonModal>;
 export const Default: Story = {
   decorators: [
     (Story) => (
-      <div className="w-96 h-96">
+      <div className="w-96 h-96" id="root">
+        <OverlayPortal />
         <Story />
       </div>
     ),
@@ -55,4 +59,65 @@ export const Default: Story = {
       <EmailInput id="." label="이메일 입력하기" essential />
     </StackedButtonModal>
   ),
+};
+
+const WithConfirmFlagTemplate = ({
+  onClose,
+}: {
+  onClose: () => Promise<void>;
+}) => {
+  const handleConfirm = () => {
+    alert("서버로 요청을 보냈습니다!");
+    onClose();
+  };
+
+  const { onClose: onCloseConfirmModal, handleOpen: handleOpenConfirmModal } =
+    useModal(() => (
+      <ConfirmModal
+        onClose={onCloseConfirmModal}
+        confirmText="진짜 저장"
+        onConfirm={handleConfirm}
+        title="onClose를 중지 시키고 나타난 ConfirmModal"
+      >
+        닉네임 변경 후 한 달간은 재변경이 불가능합니다. 정말 변경하시겠습니까?
+      </ConfirmModal>
+    ));
+
+  return (
+    <StackedButtonModal
+      onClose={onClose}
+      onConfirm={() => {
+        handleOpenConfirmModal();
+        return true;
+      }}
+      title="이메일 변경"
+    >
+      <EmailInput
+        id="."
+        label="이메일 입력하기"
+        essential
+        defaultValue="example@naver.com"
+      />
+    </StackedButtonModal>
+  );
+};
+
+export const WithConfirmFlag: Story = {
+  decorators: Default.decorators,
+  render: () => {
+    /* eslint-disable */
+    const { handleOpen, onClose } = useModal(() => (
+      <WithConfirmFlagTemplate onClose={onClose} />
+    ));
+
+    return (
+      <button
+        className="btn-3 bg-tangerine-200 px-2 py-2 roudned-2xl"
+        onClick={handleOpen}
+      >
+        {" "}
+        모달 열기 !
+      </button>
+    );
+  },
 };

--- a/src/shared/ui/modal/StackedButtonModal.stories.tsx
+++ b/src/shared/ui/modal/StackedButtonModal.stories.tsx
@@ -28,27 +28,20 @@ export default {
     title: {
       description: "모달의 제목을 설정합니다.",
     },
-    ConfirmButton: {
-      description:
-        "확인 버튼에 특별을 커스텀하여 사용 합니다. 만약 주입되지 않은 경우엔 DefaultConfirmButton을 사용합니다.",
-    },
-    CloseButton: {
-      description:
-        "취소 버튼에 특별을 커스텀하여 사용 합니다. 만약 주입되지 않은 경우엔 DefaultCloseButton을 사용합니다.",
-    },
     onConfirm: {
       description:
-        "DefaultConfirmButton의 버튼 클릭 시 실행할 함수를 받습니다. ConfirmButton 이 주입되지 않았을 경우에만 전달 가능 합니다.",
+        "DefaultConfirmButton의 버튼 클릭 시 실행할 함수를 받습니다. onConfirm 의 경우 반환 값으로 truthy 값을 반환하는 경우 onClose 메소드의 실행을 중지 시킬 수 있습니다.",
     },
     closeText: {
-      description: "DefaultCloseButton의 텍스트를 설정합니다.",
+      description: "취소 버튼의 텍스트를 설정합니다. 기본 값은 취소 입니다.",
     },
     confirmText: {
-      description: "DefaultConfirmButton의 텍스트를 설정합니다.",
+      description: "저장 버튼의 텍스트를 설정합니다. 기본 값은 저장 입니다.",
     },
   },
 };
 type Story = StoryObj<typeof StackedButtonModal>;
+
 export const Default: Story = {
   decorators: [
     (Story) => (

--- a/src/shared/ui/modal/StackedButtonModal.stories.tsx
+++ b/src/shared/ui/modal/StackedButtonModal.stories.tsx
@@ -1,0 +1,65 @@
+import { StoryObj } from "@storybook/react";
+import { EmailInput } from "@/entities/auth/ui";
+import { StackedButtonModal } from "./StackedButtonModal";
+
+export default {
+  title: "shared/modal/StackedButtonModal",
+  component: StackedButtonModal,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "ConfirmModal과 동일한 기능을 가지고 있으며 버튼들의 UI가 다릅니다. StackedButtonModal의 버튼은 Stack 형태로 존재하며 버튼의 순서와 디자인 시스템 상 버튼의 타입이 다릅니다.",
+      },
+    },
+  },
+  argTypes: {
+    onClose: {
+      description:
+        "모달을 닫는 함수로 useModal을 통해 생성된 onClose 메소드를 받습니다.",
+    },
+    children: {
+      description: "버튼과 타이틀을 제외 한 모달 내부 컨텐츠를 받습니다.",
+    },
+    closeIconAriaLabel: {
+      description: "닫기 아이콘의 aria-label을 설정합니다.",
+    },
+    title: {
+      description: "모달의 제목을 설정합니다.",
+    },
+    ConfirmButton: {
+      description:
+        "확인 버튼에 특별을 커스텀하여 사용 합니다. 만약 주입되지 않은 경우엔 DefaultConfirmButton을 사용합니다.",
+    },
+    CloseButton: {
+      description:
+        "취소 버튼에 특별을 커스텀하여 사용 합니다. 만약 주입되지 않은 경우엔 DefaultCloseButton을 사용합니다.",
+    },
+    onConfirm: {
+      description:
+        "DefaultConfirmButton의 버튼 클릭 시 실행할 함수를 받습니다. ConfirmButton 이 주입되지 않았을 경우에만 전달 가능 합니다.",
+    },
+    closeText: {
+      description: "DefaultCloseButton의 텍스트를 설정합니다.",
+    },
+    confirmText: {
+      description: "DefaultConfirmButton의 텍스트를 설정합니다.",
+    },
+  },
+};
+type Story = StoryObj<typeof StackedButtonModal>;
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-96 h-96">
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <StackedButtonModal onClose={async () => {}} title="이메일 변경">
+      <EmailInput id="." label="이메일 입력하기" essential />
+    </StackedButtonModal>
+  ),
+};

--- a/src/shared/ui/modal/StackedButtonModal.tsx
+++ b/src/shared/ui/modal/StackedButtonModal.tsx
@@ -3,21 +3,16 @@ import { Button } from "../button";
 import { CloseIcon } from "../icon";
 import { Modal } from "./Modal";
 
-type StackedButton = (onClose: () => Promise<void>) => JSX.Element;
-interface StackedButtonModalProps<
-  T extends StackedButton | undefined,
-  K extends StackedButton | undefined,
-> {
+interface StackedButtonModalProps {
   onClose: ReturnType<typeof useOverlay>["onClose"];
   children: React.ReactNode;
   closeIconAriaLabel?: string;
   title?: string;
-  ConfirmButton?: T;
-  CloseButton?: K;
-  onConfirm?: T extends StackedButton ? never : () => void | Promise<void>;
-  confirmText?: T extends StackedButton ? never : string;
-  closeText?: K extends StackedButton ? never : string;
+  onConfirm?: () => unknown | Promise<unknown>;
+  confirmText?: string;
+  closeText?: string;
 }
+
 const DefaultConfirmButton = ({
   onConfirm,
   confirmText,
@@ -55,20 +50,16 @@ const DefaultCloseButton = ({
     </Button>
   );
 };
-export const StackedButtonModal = <
-  T extends StackedButton | undefined,
-  K extends StackedButton | undefined,
->({
+
+export const StackedButtonModal = ({
   closeIconAriaLabel = "모달창 닫기",
   title = "",
   onClose,
   children,
-  confirmText,
-  closeText,
+  confirmText = "저장",
+  closeText = "취소",
   onConfirm,
-  ConfirmButton,
-  CloseButton,
-}: StackedButtonModalProps<T, K>) => {
+}: StackedButtonModalProps) => {
   const navClassName = title ? "flex justify-between" : "flex justify-end";
   return (
     <Modal modalType="center">
@@ -80,25 +71,17 @@ export const StackedButtonModal = <
       </div>
       <section className="text-grey-700 body-2">{children}</section>
       <div className="flex flex-col gap-2 self-stretch">
-        {ConfirmButton ? (
-          ConfirmButton(onClose)
-        ) : (
-          <DefaultConfirmButton
-            onConfirm={async () => {
-              await onConfirm?.();
-              onClose();
-            }}
-            confirmText={confirmText || "저장"}
-          />
-        )}
-        {CloseButton ? (
-          CloseButton(onClose)
-        ) : (
-          <DefaultCloseButton
-            onClose={onClose}
-            closeText={closeText || "취소"}
-          />
-        )}
+        <DefaultConfirmButton
+          onConfirm={async () => {
+            const confirmFlag = await onConfirm?.();
+            if (confirmFlag) {
+              return;
+            }
+            onClose();
+          }}
+          confirmText={confirmText}
+        />
+        <DefaultCloseButton onClose={onClose} closeText={closeText} />
       </div>
     </Modal>
   );

--- a/src/shared/ui/modal/StackedButtonModal.tsx
+++ b/src/shared/ui/modal/StackedButtonModal.tsx
@@ -1,0 +1,105 @@
+import type { useOverlay } from "@/shared/lib";
+import { Button } from "../button";
+import { CloseIcon } from "../icon";
+import { Modal } from "./Modal";
+
+type StackedButton = (onClose: () => Promise<void>) => JSX.Element;
+interface StackedButtonModalProps<
+  T extends StackedButton | undefined,
+  K extends StackedButton | undefined,
+> {
+  onClose: ReturnType<typeof useOverlay>["onClose"];
+  children: React.ReactNode;
+  closeIconAriaLabel?: string;
+  title?: string;
+  ConfirmButton?: T;
+  CloseButton?: K;
+  onConfirm?: T extends StackedButton ? never : () => void | Promise<void>;
+  confirmText?: T extends StackedButton ? never : string;
+  closeText?: K extends StackedButton ? never : string;
+}
+const DefaultConfirmButton = ({
+  onConfirm,
+  confirmText,
+}: {
+  onConfirm: () => Promise<void>;
+  confirmText: string;
+}) => {
+  return (
+    <Button
+      variant="filled"
+      colorType="primary"
+      size="medium"
+      onClick={onConfirm}
+    >
+      {confirmText}
+    </Button>
+  );
+};
+const DefaultCloseButton = ({
+  onClose,
+  closeText,
+}: {
+  onClose: () => void;
+  closeText: string;
+}) => {
+  return (
+    <Button
+      colorType="tertiary"
+      size="medium"
+      variant="text"
+      type="button"
+      onClick={onClose}
+    >
+      {closeText}
+    </Button>
+  );
+};
+export const StackedButtonModal = <
+  T extends StackedButton | undefined,
+  K extends StackedButton | undefined,
+>({
+  closeIconAriaLabel = "모달창 닫기",
+  title = "",
+  onClose,
+  children,
+  confirmText,
+  closeText,
+  onConfirm,
+  ConfirmButton,
+  CloseButton,
+}: StackedButtonModalProps<T, K>) => {
+  const navClassName = title ? "flex justify-between" : "flex justify-end";
+  return (
+    <Modal modalType="center">
+      <div className={navClassName}>
+        {title && <h1 className="title-1 text-grey-900">{title}</h1>}
+        <button aria-label={closeIconAriaLabel} onClick={onClose}>
+          <CloseIcon />
+        </button>
+      </div>
+      <section className="text-grey-700 body-2">{children}</section>
+      <div className="flex flex-col gap-2 self-stretch">
+        {ConfirmButton ? (
+          ConfirmButton(onClose)
+        ) : (
+          <DefaultConfirmButton
+            onConfirm={async () => {
+              await onConfirm?.();
+              onClose();
+            }}
+            confirmText={confirmText || "저장"}
+          />
+        )}
+        {CloseButton ? (
+          CloseButton(onClose)
+        ) : (
+          <DefaultCloseButton
+            onClose={onClose}
+            closeText={closeText || "취소"}
+          />
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/src/shared/ui/modal/index.ts
+++ b/src/shared/ui/modal/index.ts
@@ -1,3 +1,4 @@
 export * from "./Modal";
 export * from "./ConfirmModal";
 export * from "./ExitConfirmModal";
+export * from "./StackedButtonModal";


### PR DESCRIPTION
# 관련 이슈 번호
close #260 

# 설명

![image](https://github.com/user-attachments/assets/8e557538-07b5-44d0-a824-045f6bca968e)

이전 작업 단위가 너무 커 close 했던 PR인 #212 의 작업 일부 입니다. 

해당 모달 컴포넌트로 기존 모달 들을 리팩토링 하기 위해 `PR` 올립니다.

## #212 와 다른 변경 사항 

### `ConfirmButton , CloseButton` props 제거
 
#212 에서 작업했던 작업과 달라진 점은 `ConfirmButton  ,CloseButton` props 가 제거 되었습니다.

```tsx
interface StackedButtonModalProps {
  onClose: ReturnType<typeof useOverlay>["onClose"];
  children: React.ReactNode;
  closeIconAriaLabel?: string;
  title?: string;
  onConfirm?: () => unknown | Promise<unknown>;
  confirmText?: string;
  closeText?: string;
}
```

따라서 이전 처럼 제네릭 타입을 통한 복잡한 타입 선언 없이 인터페이스를 선언했으며 해당 시스템을 사용 할 때에도 단순히 내부에 들어갈 텍스트나 메소드만 정의해주면 됩니다. 

버튼을 `props` 로 제공하는 `render props` 패턴을 선택하지 않은 이유는 `StackedButtonModal` 에서 맨 위 버튼은 `fiiled , primary` 형태의 버튼 , 아래 버튼은 `tertiary , text`  이여야 한다는 구제적인 디자인적 약속이 존재한다고 생각했기 때문입니다. 

대부분의 디자인 시스템에서 버튼을 `Stacked` 형태로 쌓은 모달에선 그런 순서를 가지기 때문에 외부에서 버튼을 삽입하는 행위를 제거 했습니다. 

### `onConfirm` 타입 변경

예전 작업에서는 `onConfirm` 은 항상 `void , Promise<void>` 만을 반환하게 했기에 항상 `Confirm` 작업이 일어나고 나면 

`onClose` 메소드가 호출 되었습니다. 

하지만 예전 모달에서 `confirmFlag` 를 통해 `onClose` 메소드의 호출을 중지 시켰듯이 해당 모달에서도 `onConfirm` 에서 `confirmFlag` 를 통해 `onClose` 의 호출을 중지 시킬 수 있습니다. 


--- 

# ConfirmFlag 사용 예시 입니다.

![confirm](https://github.com/user-attachments/assets/b6fe4803-28aa-46b8-b221-1bca31b05b8a)
```tsx
const WithConfirmFlagTemplate = ({
  onClose,
}: {
  onClose: () => Promise<void>;
}) => {
  const handleConfirm = () => {
    alert("서버로 요청을 보냈습니다!");
    onClose();
  };

  const { onClose: onCloseConfirmModal, handleOpen: handleOpenConfirmModal } =
    useModal(() => (
      <ConfirmModal
        onClose={onCloseConfirmModal}
        confirmText="진짜 저장"
        onConfirm={handleConfirm}
        title="onClose를 중지 시키고 나타난 ConfirmModal"
      >
        닉네임 변경 후 한 달간은 재변경이 불가능합니다. 정말 변경하시겠습니까?
      </ConfirmModal>
    ));

  return (
    <StackedButtonModal
      onClose={onClose}
      onConfirm={() => {
        handleOpenConfirmModal();
        return true;
      }}
      title="이메일 변경"
    >
      <EmailInput
        id="."
        label="이메일 입력하기"
        essential
        defaultValue="example@naver.com"
      />
    </StackedButtonModal>
  );
};

export const WithConfirmFlag: Story = {
  decorators: Default.decorators,
  render: () => {
    /* eslint-disable */
    const { handleOpen, onClose } = useModal(() => (
      <WithConfirmFlagTemplate onClose={onClose} />
    ));

    return (
      <button
        className="btn-3 bg-tangerine-200 px-2 py-2 roudned-2xl"
        onClick={handleOpen}
      >
        {" "}
        모달 열기 !
      </button>
    );
  },
};
```


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
