### PR TITLE
[Hotfix] 개발 모드에선 쿠키를 include 로 보내도록 수정

### DIFF
--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -20,7 +20,8 @@ export const getNewAccessToken = async ({
   // 해당 try-catch 문은 access token 을 refresh token 을 이용해 재발급 받는 로직입니다.
   try {
     const response = await fetch(APP_END_POINT.REFRESH_ACCESS_TOKEN, {
-      credentials: "same-origin",
+      credentials:
+        process.env.NODE_ENV === "development" ? "include" : "same-origin",
     });
 
     const data = await response.json();

--- a/src/features/auth/api/postPetInfo.ts
+++ b/src/features/auth/api/postPetInfo.ts
@@ -58,7 +58,8 @@ const postPetInfo = async ({
     headers: {
       Authorization: token,
     },
-    credentials: "same-origin",
+    credentials:
+      process.env.NODE_ENV === "development" ? "include" : "same-origin",
     body: formData,
   });
 

--- a/src/features/setting/api/postLogout.ts
+++ b/src/features/setting/api/postLogout.ts
@@ -12,7 +12,8 @@ const postLogout = async (token: NonNullable<AuthStore["token"]>) => {
     headers: {
       Authorization: token,
     },
-    credentials: "same-origin",
+    credentials:
+      process.env.NODE_ENV === "development" ? "include" : "same-origin",
   });
 
   const data = await response.json();


### PR DESCRIPTION
# 관련 이슈 번호
close #264 
# 설명
#249  , #256 , #254  에서 쿠키를 `same-origin` 으로만 보냈습니다. 

`credentials` 에서 말하는 `same-origin` 은 다음과 같은 값들이 같아야 합니다.

- 프로토콜 (http ? https?)
- 도메인 (www. ...... .com)
- 포트 (:80 ? :5173 ? )

개발 모드에선 `msw` 를 사용하며 `msw` 에서 모킹 된 포트는 80 입니다. 따라서 모든 `msw` 를 사용하는 개발 모드에선 쿠키를 `include` 로 보내도록 수정 합니다. 

> 개발 모드에선 `htttp://localhost:80` 을 형해 보내고 있습니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
