### PR TITLE
[Feat] Mutation에 대한 Access Token 재발급 에러 핸들링 로직 추가

### DIFF
--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -1,20 +1,17 @@
-import type { Query, QueryClient, QueryKey } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import { AuthStore } from "@/shared/store";
 import { APP_END_POINT, ERROR_MESSAGE } from "./constants";
 
 export const getNewAccessToken = async ({
-  query,
   setterMethods,
   queryClient,
 }: {
-  query: Query<unknown, unknown, unknown, QueryKey>;
   setterMethods: {
     setToken: AuthStore["setToken"];
     resetAuthStore: AuthStore["reset"];
   };
   queryClient: QueryClient;
 }) => {
-  const { queryKey } = query;
   const { setToken, resetAuthStore } = setterMethods;
 
   // 해당 try-catch 문은 access token 을 refresh token 을 이용해 재발급 받는 로직입니다.
@@ -41,11 +38,9 @@ export const getNewAccessToken = async ({
       /**
        * refresh 토큰이 유효하지 않다면 다음과 같은 일들을 처리 합니다.
        * 1. AuthStore 의 token, role, nickname 을 초기화 합니다.
-       * 2. queryClient 의 queryKey 를 통해 해당 쿼리를 취소합니다. 리소스를 절약하고 잘못된 데이터가 저장되는 행위를 방지하기 위함입니다.
-       * 3. 캐싱 된 쿼리를 모두 초기화 합니다.
+       * 2. 캐싱 된 쿼리를 모두 초기화 합니다.
        */
       resetAuthStore();
-      queryClient.cancelQueries({ queryKey: queryKey });
       queryClient.clear();
 
       // 스토리북 환경의 경우엔 이하 코드를 실행 시키지 않습니다.

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -54,9 +54,7 @@ export const useCreateQueryClient = () => {
               });
 
               const { options, state } = mutation;
-              if (!options?.mutationFn) {
-                return;
-              }
+
               /**
                * 이전에 시도 했던 mutationFn 을 업데이트 된 액세스 토큰을 이용해 다시 시도합니다.
                * options.mutationFn 으로 재시도 하는 mutation의 경우엔 onSuccess, onError를 자동으로 호출하지 않습니다.
@@ -65,7 +63,7 @@ export const useCreateQueryClient = () => {
               try {
                 const { token } = useAuthStore.getState();
                 const updatedVariables = { ...(variables as object), token };
-                await options.mutationFn(updatedVariables);
+                await options.mutationFn?.(updatedVariables);
                 options.onSuccess?.(state.data, updatedVariables, context);
               } catch (error) {
                 options.onError?.(error, variables, context);

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -30,11 +30,10 @@ export const useCreateQueryClient = () => {
       },
 
       queryCache: new QueryCache({
-        onError: async (error, query) => {
+        onError: async (error) => {
           switch (error.message) {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getNewAccessToken({
-                query,
                 setterMethods: { setToken, resetAuthStore },
                 queryClient,
               });

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { QueryClient, QueryCache } from "@tanstack/react-query";
+import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
 import { useAuthStore } from "@/shared/store";
 import { ERROR_MESSAGE } from "./constants";
 import { getNewAccessToken } from "./errorHandlers";
@@ -37,6 +37,39 @@ export const useCreateQueryClient = () => {
                 setterMethods: { setToken, resetAuthStore },
                 queryClient,
               });
+              break;
+            }
+            default:
+              throw error;
+          }
+        },
+      }),
+      mutationCache: new MutationCache({
+        onError: async (error, variables, context, mutation) => {
+          switch (error.message) {
+            case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
+              await getNewAccessToken({
+                setterMethods: { setToken, resetAuthStore },
+                queryClient,
+              });
+
+              const { options, state } = mutation;
+              if (!options?.mutationFn) {
+                return;
+              }
+              /**
+               * 이전에 시도 했던 mutationFn 을 업데이트 된 액세스 토큰을 이용해 다시 시도합니다.
+               * options.mutationFn 으로 재시도 하는 mutation의 경우엔 onSuccess, onError를 자동으로 호출하지 않습니다.
+               * 이에 try,catch 문을 이용해 onSuccess, onError 를 수동으로 호출합니다.
+               */
+              try {
+                const { token } = useAuthStore.getState();
+                const updatedVariables = { ...(variables as object), token };
+                await options.mutationFn(updatedVariables);
+                options.onSuccess?.(state.data, updatedVariables, context);
+              } catch (error) {
+                options.onError?.(error, variables, context);
+              }
               break;
             }
             default:

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -216,7 +216,23 @@ export const markingModalHandlers = [
       });
     },
   ),
-  http.post<PathParams>(MARKING_REQUEST_URL.ADD, async () => {
+  http.post<PathParams>(MARKING_REQUEST_URL.ADD, async ({ request }) => {
+    /**
+     * 2024/10/07 access token에 대한 테스트 로직을 추가 합니다.
+     */
+    const token = request.headers.get("Authorization");
+    if (token === "staleAccessToken") {
+      return HttpResponse.json(
+        {
+          code: 401,
+          message: ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED,
+        },
+        {
+          status: 401,
+        },
+      );
+    }
+
     return HttpResponse.json({
       code: 200,
       message: "success",
@@ -292,7 +308,22 @@ export const markingModalHandlers = [
       });
     },
   ),
-  http.post<PathParams>(MARKING_REQUEST_URL.SAVE_TEMP, async () => {
+  http.post<PathParams>(MARKING_REQUEST_URL.SAVE_TEMP, async ({ request }) => {
+    /**
+     * 2024/10/07 access token에 대한 테스트 로직을 추가 합니다.
+     */
+    const token = request.headers.get("Authorization");
+    if (token === "staleAccessToken") {
+      return HttpResponse.json(
+        {
+          code: 401,
+          message: ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED,
+        },
+        {
+          status: 401,
+        },
+      );
+    }
     return HttpResponse.json({
       code: 200,
       message: "success",


### PR DESCRIPTION
# 관련 이슈 번호
close #263 
# 설명

#249  에 이어서 mutation 에 대한 에러 핸들링 로직을 추가 했습니다. 

## 리팩토링

기존 `getNewAccessToken` 에서 불필요하게 `queryClient.cancel(query ..) ` 와 같은 부분이 존재했습니다. 

`queryClient.clear()` 이후 호출 되는 불필요한 `cancel` 부분을 제거해주었고 그로 인해 `getNewAccessToken` 의 인수에서 `query` 를 제거 할 수 있게 되었습니다. 

## mutationCache 추가


```tsx
export const useCreateQueryClient = () => {
  const setToken = useAuthStore((state) => state.setToken);
  const resetAuthStore = useAuthStore((state) => state.reset);

  const queryClient = useRef(
     ....
      mutationCache: new MutationCache({
        onError: async (error, variables, context, mutation) => {
          switch (error.message) {
            case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
              await getNewAccessToken({
                setterMethods: { setToken, resetAuthStore },
                queryClient,
              });

              const { options, state } = mutation;
              if (!options?.mutationFn) {
                return;
              }
              /**
               * 이전에 시도 했던 mutationFn 을 업데이트 된 액세스 토큰을 이용해 다시 시도합니다.
               * options.mutationFn 으로 재시도 하는 mutation의 경우엔 onSuccess, onError를 자동으로 호출하지 않습니다.
               * 이에 try,catch 문을 이용해 onSuccess, onError 를 수동으로 호출합니다.
               */
              try {
                const { token } = useAuthStore.getState();
                const updatedVariables = { ...(variables as object), token };
                await options.mutationFn(updatedVariables);
                options.onSuccess?.(state.data, updatedVariables, context);
              } catch (error) {
                options.onError?.(error, variables, context);
              }
              break;
            }
            default:
              throw error;
          }
        },
      }),
    }),
  ).current;
```

크게 추가 된 부분은 없습니다. 

`mutation` 또한 `MutationCache` 를 이용해 에러 핸들링을 하더군요 ! 

기존 `useMutation.onError`  과 다른 점은 `mutationCache` 에선 에러를 만난 `mutation` 을 참조 가능하단 점입니다. 

![image](https://github.com/user-attachments/assets/8d0cddbb-4d2c-403a-bd73-58d4dda74264)

`mutataion` 의 모습은 다음과 같이 생겼습니다. 

액세스 토큰에 대한 에러 처리로 `getNewAccessToken` 을 호출해 새로운 토큰을 받아온 후 

에러를 맞이했던 `mutataion` 에서 인수로 건내줬던 `stale access token` 을 `fresh access token` 으로 교체해서 `mutatiaonFn` 을 재호출합니다. 

`mutataionFn` 을 수동으로 호출하게 되면 `onSuccess , onError` 가 함께 자동으로 호출되지 않더군요 

그래서 수동으로 불러와 호출해줬습니다. 

# 테스트 하는 법

`mutation` 에 대한 `msw` 핸들러를 마킹 모달 저장 , 임시저장에 대해 설정해뒀습니다. 

![image](https://github.com/user-attachments/assets/41dfbfb0-66e3-4d36-a126-040cfc2d9613)

를 눌러 사용 가능합니다만 테스트 할 땐 `useCreateQueryClient.ts` 에서 `query` 에 대한 에러 핸들링 로직을 주석 처리 해줘야 합니다. 

현재 `MainFooter` 에서 토큰을 필요로 하는 `query` 문을 호출하기에  액세스 토큰이 `staleAccessToken` 으로 변하는 순간 자동으로 다시 받아오게 됩니다. (stale refresh token 제외)

따라서 테스트 할 땐 query 에 대한 에러 핸들링 로직을 주석 처리 하고 수정 가능합니다. 

# PS 

## 추후 개발이 필요한 부분 

현재 stale refresh token 시 마킹 모달이 닫히지 않습니다.  그 이유는 `stale refresh token` 일 경우 `/login` 페이지로 리다이렉션 되며 모달이 닫혀야 하는데 

현재 네비게이팅이 존재하지 않기 때문입니다. 이는 `router.ts` 구조 리팩토링 이후 `/` 경로에 `QueryClientProvider` 를 옮겨준 후 작업이 필요 합니다. 

## 신경써야 할 부분

`onError` 의 호출 순서는 `useMutataion.onError -> mutataionCache.onError` 입니다. 따라서 에러 바운더리는 `QueryClientProvider` 상단에 존재해야 할 것입니다. 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
