### PR TITLE
[Feat] 서버로 제출하는 Image 용량 압축하여 제출 기능 추가

### DIFF
--- a/src/features/auth/constants/form.ts
+++ b/src/features/auth/constants/form.ts
@@ -1,4 +1,4 @@
-export const characterList = [
+export const personalities = [
   "호기심 많은",
   "활동적인",
   "사교적인",

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -5,6 +5,7 @@ import type { LatLng } from "../api/region";
 interface PetInfoFormStates extends Omit<PetInfoFormData, "profile"> {
   isValidName: boolean;
   profile: Promise<File | null>;
+  isCompressing: boolean;
 }
 
 interface PetInfoFormActions {
@@ -23,6 +24,7 @@ const petInfoFormInitialState: PetInfoFormStates = {
   breed: "",
   personalities: [],
   description: "",
+  isCompressing: false,
 };
 
 /**
@@ -33,7 +35,10 @@ export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
   (set) => ({
     ...petInfoFormInitialState,
 
-    setProfile: (profile: Promise<File | null>) => set({ profile }),
+    setProfile: (profile: Promise<File | null>) => {
+      set({ profile, isCompressing: true });
+      profile.then(() => set({ isCompressing: false }));
+    },
     setName: (name: string) => set({ name }),
     setIsValidName: (name: string) =>
       set(() => {

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -33,17 +33,28 @@ const petInfoFormInitialState: PetInfoFormStates = {
   isCompressing: false,
 };
 
-/**
- * public 폴더에 존재하는 기본 프로필 이미지를 사용합니다.
- * origin/{파일명} 을 통해 public 폴더에 접근하는 파일에 접근 할 수 있습니다.
- */
 export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
-  (set) => ({
+  (set, get) => ({
     ...petInfoFormInitialState,
 
+    /**
+     * profile 을 설정하던 중 압축 과정이 진행 중일 경우 isCompressing 을 true, 종료 시 false 로 변경 합니다.
+     * 이 때 profile의 압축이 실패한 경우엔 실패한 profile이 아닌 기존 존재하던 profile 로 변경합니다.
+     */
     setProfile: (profile: FileInfo) => {
+      const { profile: prevProfile } = get();
       set({ profile, isCompressing: true });
-      profile.file.then(() => set({ isCompressing: false }));
+
+      profile.file
+        .catch((error) => {
+          // TODO 에러 바운더리 로직 나오면 변경하기
+          console.error(error);
+          set(() => ({
+            profile: prevProfile,
+            isCompressing: false,
+          }));
+        })
+        .finally(() => set(() => ({ isCompressing: false })));
     },
     setName: (name: string) => set({ name }),
     setIsValidName: (name: string) =>

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -2,14 +2,20 @@ import { create } from "zustand";
 import type { PetInfoFormData } from "../api";
 import type { LatLng } from "../api/region";
 
+export interface FileInfo {
+  name: string;
+  url: string;
+  file: Promise<File | null>;
+}
+
 interface PetInfoFormStates extends Omit<PetInfoFormData, "profile"> {
   isValidName: boolean;
-  profile: Promise<File | null>;
+  profile: FileInfo;
   isCompressing: boolean;
 }
 
 interface PetInfoFormActions {
-  setProfile: (profile: Promise<File | null>) => void;
+  setProfile: (profile: FileInfo) => void;
   setName: (name: string) => void;
   setIsValidName: (name: string) => void;
   setBreed: (breed: string) => void;
@@ -18,7 +24,7 @@ interface PetInfoFormActions {
 }
 
 const petInfoFormInitialState: PetInfoFormStates = {
-  profile: Promise.resolve(null),
+  profile: { name: "", url: "/default-image.png", file: Promise.resolve(null) },
   name: "",
   isValidName: true,
   breed: "",
@@ -35,9 +41,9 @@ export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
   (set) => ({
     ...petInfoFormInitialState,
 
-    setProfile: (profile: Promise<File | null>) => {
+    setProfile: (profile: FileInfo) => {
       set({ profile, isCompressing: true });
-      profile.then(() => set({ isCompressing: false }));
+      profile.file.then(() => set({ isCompressing: false }));
     },
     setName: (name: string) => set({ name }),
     setIsValidName: (name: string) =>

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -1,54 +1,59 @@
 import { create } from "zustand";
+import type { PetInfoFormData } from "../api";
 import type { LatLng } from "../api/region";
 
-interface PetInfoStore {
-  profileImage: File | null;
-  name: string;
+interface PetInfoFormStates extends Omit<PetInfoFormData, "profile"> {
   isValidName: boolean;
-  breed: string;
-  characterList: string[];
-  introduce: string;
+  profile: Promise<File | null>;
+}
 
-  setProfileImage: (profileImage: File | null) => void;
+interface PetInfoFormActions {
+  setProfile: (profile: Promise<File | null>) => void;
   setName: (name: string) => void;
   setIsValidName: (name: string) => void;
-  setBreed: (greed: string) => void;
-  setCharacterList: (character: string) => void;
-  setIntroduce: (introduce: string) => void;
+  setBreed: (breed: string) => void;
+  setPersonalities: (personality: string) => void;
+  setDescription: (description: string) => void;
 }
+
+const petInfoFormInitialState: PetInfoFormStates = {
+  profile: Promise.resolve(null),
+  name: "",
+  isValidName: true,
+  breed: "",
+  personalities: [],
+  description: "",
+};
 
 /**
  * public 폴더에 존재하는 기본 프로필 이미지를 사용합니다.
  * origin/{파일명} 을 통해 public 폴더에 접근하는 파일에 접근 할 수 있습니다.
  */
-export const usePetInfoStore = create<PetInfoStore>((set) => ({
-  profileImage: null,
-  name: "",
-  isValidName: true,
-  breed: "",
-  characterList: [],
-  introduce: "",
+export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
+  (set) => ({
+    ...petInfoFormInitialState,
 
-  setProfileImage: (profileImage: File | null) => set({ profileImage }),
-  setName: (name: string) => set({ name }),
-  setIsValidName: (name: string) =>
-    set(() => {
-      const isValidName = new RegExp("^[가-힣a-zA-Z]{1,20}$").test(name);
-      return { isValidName };
-    }),
-  setBreed: (breed: string) => set({ breed }),
-  setCharacterList: (character: string) =>
-    set((state) => {
-      // 배열에 character 값이 존재 할 경우 제거하고, 존재하지 않을 경우 추가합니다.
-      const isAlreadySelected = state.characterList.includes(character);
+    setProfile: (profile: Promise<File | null>) => set({ profile }),
+    setName: (name: string) => set({ name }),
+    setIsValidName: (name: string) =>
+      set(() => {
+        const isValidName = new RegExp("^[가-힣a-zA-Z]{1,20}$").test(name);
+        return { isValidName };
+      }),
+    setBreed: (breed: string) => set({ breed }),
+    setPersonalities: (character: string) =>
+      set((state) => {
+        // 배열에 character 값이 존재 할 경우 제거하고, 존재하지 않을 경우 추가합니다.
+        const isAlreadySelected = state.personalities.includes(character);
 
-      const newCharacter = isAlreadySelected
-        ? state.characterList.filter((c) => c !== character)
-        : [...state.characterList, character];
-      return { characterList: newCharacter };
-    }),
-  setIntroduce: (introduce: string) => set({ introduce }),
-}));
+        const newCharacter = isAlreadySelected
+          ? state.personalities.filter((c) => c !== character)
+          : [...state.personalities, character];
+        return { personalities: newCharacter };
+      }),
+    setDescription: (description: string) => set({ description }),
+  }),
+);
 
 interface LoginFormStore {
   email: string;

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -12,6 +12,7 @@ interface PetInfoFormStates extends Omit<PetInfoFormData, "profile"> {
   isValidName: boolean;
   profile: FileInfo;
   isCompressing: boolean;
+  inputKey: number;
 }
 
 interface PetInfoFormActions {
@@ -31,6 +32,7 @@ const petInfoFormInitialState: PetInfoFormStates = {
   personalities: [],
   description: "",
   isCompressing: false,
+  inputKey: 0,
 };
 
 export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
@@ -43,7 +45,7 @@ export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
      */
     setProfile: (profile: FileInfo) => {
       const { profile: prevProfile } = get();
-      set({ profile, isCompressing: true });
+      set({ profile, isCompressing: true, inputKey: get().inputKey + 1 });
 
       profile.file
         .catch((error) => {
@@ -52,6 +54,7 @@ export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
           set(() => ({
             profile: prevProfile,
             isCompressing: false,
+            inputKey: get().inputKey + 1,
           }));
         })
         .finally(() => set(() => ({ isCompressing: false })));

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -46,13 +46,19 @@ export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
      */
     setProfile: async (profile: FileInfo) => {
       const { profile: prevProfile } = get();
+
+      if (!profile.file) {
+        set({
+          profile: prevProfile,
+          isCompressing: false,
+          inputKey: get().inputKey + 1,
+        });
+        return;
+      }
+
       set({ profile, isCompressing: true, inputKey: get().inputKey + 1 });
 
       try {
-        if (!profile.file) {
-          set({ isCompressing: false });
-          return;
-        }
         const compressedImage = await compressFileImage(profile.file);
         set({ profile: { ...profile, file: compressedImage } });
       } catch (error) {

--- a/src/features/auth/ui/PetInfoForm.stories.tsx
+++ b/src/features/auth/ui/PetInfoForm.stories.tsx
@@ -52,8 +52,8 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       name: "",
       isValidName: true,
       breed: "",
-      characterList: [],
-      introduce: "",
+      personalities: [],
+      description: "",
     });
 
     useAuthStore.setState({
@@ -101,12 +101,12 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       await userEvent.clear($name);
       await userEvent.clear($textarea);
 
-      const { characterList } = usePetInfoStore.getState();
-      characterList.forEach((character) => {
-        if (character === "호기심 많은") {
+      const { personalities } = usePetInfoStore.getState();
+      personalities.forEach((personality) => {
+        if (personality === "호기심 많은") {
           userEvent.click($characterButton1!);
         }
-        if (character === "애착이 강한") {
+        if (personality === "애착이 강한") {
           userEvent.click($characterButton2!);
         }
       });
@@ -370,11 +370,11 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
           );
           await userEvent.click($submit);
 
-          const { name, breed, introduce } = usePetInfoStore.getState();
+          const { name, breed, description } = usePetInfoStore.getState();
 
           expect(name).toBe("초코");
           expect(breed).toBe("푸들");
-          expect(introduce).toBe("안녕하세요 너무 귀여운 강아지 입니다.");
+          expect(description).toBe("안녕하세요 너무 귀여운 강아지 입니다.");
         },
       );
 
@@ -389,26 +389,26 @@ export const Default: StoryObj<typeof _PetInfoForm> = {
       await step(
         "성격란을 클릭하지 않았을 때 상태에는 아무런 값도 저장되지 않는다.",
         async () => {
-          const { characterList } = usePetInfoStore.getState();
-          expect(characterList).toEqual([]);
+          const { personalities } = usePetInfoStore.getState();
+          expect(personalities).toEqual([]);
         },
       );
 
       await step("성격란을 클릭하면 상태엔 값이 적절히 저장된다.", async () => {
         await userEvent.click($characterButton1!);
 
-        await expect(usePetInfoStore.getState().characterList[0]).toEqual(
+        await expect(usePetInfoStore.getState().personalities[0]).toEqual(
           "호기심 많은",
         );
 
         await userEvent.click($characterButton2!);
-        await expect(usePetInfoStore.getState().characterList[1]).toEqual(
+        await expect(usePetInfoStore.getState().personalities[1]).toEqual(
           "애착이 강한",
         );
 
         // 이미 있는 것을 클릭 한 경우엔 폼에서 해당 값이 사라진다.
         await userEvent.click($characterButton1!);
-        await expect(usePetInfoStore.getState().characterList).toEqual([
+        await expect(usePetInfoStore.getState().personalities).toEqual([
           "애착이 강한",
         ]);
 

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -265,8 +265,22 @@ export const SubmitButton = () => {
 
   const handleClick = async () => {
     const petInfoForm = usePetInfoStore.getState();
-    const { isValidName, name, breed, personalities, description, profile } =
-      petInfoForm;
+    const {
+      isValidName,
+      name,
+      breed,
+      personalities,
+      description,
+      profile,
+      isCompressing,
+    } = petInfoForm;
+
+    if (isCompressing) {
+      // TODO 에러 바운더리 생성되면 로직 변경하기
+      console.error("사진을 압축 중입니다. 잠시 후 다시 시도해주세요");
+      return;
+    }
+
     const resolvedProfile = await profile;
     const { token } = useAuthStore.getState();
 

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -254,11 +254,6 @@ export const IntroduceTextArea = () => {
 };
 
 export const SubmitButton = () => {
-  /**
-   * 유효성 검사를 위해 form 데이터에 존재하는 상태를 객체 형태로 가져옵니다.
-   * getState() 는 호출 시점의 store 를 가져오기 떄문에 클릭이 일어난 시점의 상태 값들을 가져 올 수 있습니다.
-   * getState() 로 인해 반환되는 store 자체는 불변하기 때문에 store 내부 상태들이 변경되어도 리렌더링이 일어나지 않습니다.
-   */
   const { mutate: postPetInfo } = usePostPetInfo();
 
   // 필수 항목을 모두 입력하지 않은 경우 나타 날 스낵바
@@ -284,7 +279,6 @@ export const SubmitButton = () => {
       return;
     }
 
-    const resolvedProfile = await profile.file;
     const { token } = useAuthStore.getState();
 
     const isNameEmpty = name.length === 0;
@@ -296,14 +290,10 @@ export const SubmitButton = () => {
       return;
     }
 
-    if (!token) {
-      throw new Error(
-        "토큰이 없다면 해당 페이지에 접근할 수 없습니다. 토큰이 존재하는지 확인해주세요",
-      );
-    }
+    const resolvedProfile = await profile.file;
 
     postPetInfo({
-      token,
+      token: token!,
       formObject: {
         name,
         breed,

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -66,7 +66,11 @@ export const ProfileInput = () => {
     if (!file) {
       return;
     }
-    // compressFile 이 시행되는 동안 발생 할 수 있는 race-condition 문제를 방지하기 위한 로직
+    /**
+     * 압축 과정 동안 이미지가 변경되지 않는 것을 방지하기 위해 낙관적 업데이트를 사용합니다.
+     */
+    setProfileUrl(URL.createObjectURL(file));
+    /* compressFile 이 시행되는 동안 발생 할 수 있는 race-condition 문제를 방지하기 위한 로직 */
     compressedFileRef.current = file;
     const compressedFile = await compressFile(file);
     if (file !== compressedFileRef.current) {
@@ -74,7 +78,6 @@ export const ProfileInput = () => {
     }
 
     setProfileImage(compressedFile);
-    setProfileUrl(URL.createObjectURL(compressedFile));
   };
 
   // 바텀 시트를 여닫는 핸들러

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef } from "react";
 import { SelectOpener } from "@/entities/auth/ui";
-import { compressFileImage } from "@/shared/lib";
 import { useSnackBar } from "@/shared/lib/overlay";
 import { useAuthStore } from "@/shared/store/auth";
 import { Button } from "@/shared/ui/button";
@@ -64,7 +63,7 @@ export const ProfileInput = () => {
      * 압축 과정 동안 이미지가 변경되지 않는 것을 방지하기 위해 낙관적 업데이트를 사용합니다.
      */
     setProfile({
-      file: compressFileImage(file),
+      file,
       name: file.name,
       url: URL.createObjectURL(file),
     });
@@ -77,7 +76,7 @@ export const ProfileInput = () => {
   // 사진을 삭제하는 핸들러
   const handleDelete = () => {
     setProfile({
-      file: Promise.resolve(null),
+      file: null,
       name: "",
       url: DEFAULT_PROFILE_IMAGE,
     });
@@ -260,7 +259,7 @@ export const SubmitButton = () => {
     <Snackbar onClose={onClose}>필수 항목을 모두 입력해 주세요</Snackbar>
   ));
 
-  const handleClick = async () => {
+  const handleClick = () => {
     const petInfoForm = usePetInfoStore.getState();
     const {
       isValidName,
@@ -289,8 +288,6 @@ export const SubmitButton = () => {
       return;
     }
 
-    const resolvedProfile = await profile.file;
-
     postPetInfo({
       token: token!,
       formObject: {
@@ -298,7 +295,7 @@ export const SubmitButton = () => {
         breed,
         personalities,
         description,
-        profile: resolvedProfile,
+        profile: profile.file,
       },
     });
   };

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -54,8 +54,8 @@ export const ProfileInput = () => {
   // actual dom 의 input 태그를 조작하기 위한 ref , state
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [inputKey, setInputKey] = useState<number>(0);
-  // 프로필 이미지를 보여주기 위한 state
-  const [profileUrl, setProfileUrl] = useState(() =>
+  // 프로필 이미지를 보여주기 위한 optimistic image Url state
+  const [optimisticUrl, setOptimisticUrl] = useState(() =>
     profileImage ? URL.createObjectURL(profileImage) : DEFAULT_PROFILE_IMAGE,
   );
   // compressFile 의 race-condition 을 방지하기 위한 ref
@@ -69,7 +69,7 @@ export const ProfileInput = () => {
     /**
      * 압축 과정 동안 이미지가 변경되지 않는 것을 방지하기 위해 낙관적 업데이트를 사용합니다.
      */
-    setProfileUrl(URL.createObjectURL(file));
+    setOptimisticUrl(URL.createObjectURL(file));
     /* compressFile 이 시행되는 동안 발생 할 수 있는 race-condition 문제를 방지하기 위한 로직 */
     compressedFileRef.current = file;
     const compressedFile = await compressFile(file);
@@ -87,7 +87,7 @@ export const ProfileInput = () => {
   // 사진을 삭제하는 핸들러
   const handleDelete = () => {
     setProfileImage(null);
-    setProfileUrl(DEFAULT_PROFILE_IMAGE);
+    setOptimisticUrl(DEFAULT_PROFILE_IMAGE);
     setInputKey((prev) => prev + 1);
   };
 
@@ -101,7 +101,7 @@ export const ProfileInput = () => {
       <button
         className="flex h-20 w-20 flex-shrink items-end justify-end rounded-[28px] bg-cover bg-center bg-no-repeat"
         style={{
-          backgroundImage: `url(${profileUrl})`,
+          backgroundImage: `url(${optimisticUrl})`,
         }}
         onClick={onOpen}
         aria-label="profile-image-button"

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from "react";
 import { SelectOpener } from "@/entities/auth/ui";
-import { compressFile } from "@/shared/lib";
+import { compressFileImage } from "@/shared/lib";
 import { useSnackBar } from "@/shared/lib/overlay";
 import { useAuthStore } from "@/shared/store/auth";
 import { Button } from "@/shared/ui/button";
@@ -64,7 +64,7 @@ export const ProfileInput = () => {
      * 압축 과정 동안 이미지가 변경되지 않는 것을 방지하기 위해 낙관적 업데이트를 사용합니다.
      */
     setProfile({
-      file: compressFile(file),
+      file: compressFileImage(file),
       name: file.name,
       url: URL.createObjectURL(file),
     });

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -84,6 +84,7 @@ export const ProfileInput = () => {
   // 사진을 삭제하는 핸들러
   const handleDelete = () => {
     setProfileImage(null);
+    setProfileUrl(DEFAULT_PROFILE_IMAGE);
     setInputKey((prev) => prev + 1);
   };
 

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -49,11 +49,11 @@ export const Form = ({ children }: { children: React.ReactNode }) => {
 export const ProfileInput = () => {
   const profile = usePetInfoStore((state) => state.profile);
   const setProfile = usePetInfoStore((state) => state.setProfile);
+  const inputKey = usePetInfoStore((state) => state.inputKey);
   // 바텀시트를 조작하기 위한 state
   const [isOpen, setOpen] = useState<boolean>(false);
   // actual dom 의 input 태그를 조작하기 위한 ref , state
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [inputKey, setInputKey] = useState<number>(0);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -81,7 +81,6 @@ export const ProfileInput = () => {
       name: "",
       url: DEFAULT_PROFILE_IMAGE,
     });
-    setInputKey((prev) => prev + 1);
   };
 
   // 사진 선택하기 버튼을 클릭했을 때 input을 클릭하는 핸들기

--- a/src/features/auth/ui/PetInfoForm.tsx
+++ b/src/features/auth/ui/PetInfoForm.tsx
@@ -60,8 +60,13 @@ export const ProfileInput = () => {
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    setProfileImage(file!);
-    setProfileUrl(URL.createObjectURL(file!));
+
+    if (!file) {
+      return;
+    }
+
+    setProfileImage(file);
+    setProfileUrl(URL.createObjectURL(file));
   };
 
   // 바텀 시트를 여닫는 핸들러

--- a/src/features/marking/constants/index.ts
+++ b/src/features/marking/constants/index.ts
@@ -6,3 +6,5 @@ export const POST_VISIBILITY_MAP = {
 
 export * from "./requestUrl";
 export * from "./message";
+
+export const MAX_IMAGE_LENGTH = 5;

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -49,13 +49,15 @@ export const useMarkingFormStore = create<
    * actual DOM의 input을 새로 마운트 시킴으로서 액츄얼 돔의 input이 업데이트 된 이미지를 정상적으로 바라 볼 수 있도록 합니다.
    */
   setImages: async (images) => {
-    /* 동기적으로 압축 예정인 이미지 파일을 업데이트 합니다. */
-    set({ images, isCompressing: true, inputKey: get().inputKey + 1 });
-
-    if (images.length === 0) {
-      set({ isCompressing: false });
+    /**
+     * 사진이 추가되지 않고  사진이 삭제 된 경우엔 압축을 시작하지 않고 종료합니다.
+     */
+    if (images.length < get().images.length) {
+      set({ isCompressing: false, inputKey: get().inputKey + 1 });
       return;
     }
+    /* 동기적으로 압축 예정인 이미지 파일을 업데이트 합니다. */
+    set({ images, isCompressing: true, inputKey: get().inputKey + 1 });
 
     const compressedFiles = await Promise.allSettled(
       images.map(({ file }) => compressFileImage(file)),

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -5,14 +5,15 @@ interface MarkingFormState {
   region: string;
   visibility: keyof typeof POST_VISIBILITY_MAP | "";
   content: string;
-  images: File[];
+  images: { name: string; file: Promise<File> }[];
+  isCompressing: boolean;
 }
 
 interface MarkingFormActions {
   setRegion: (region: string) => void;
   setVisibility: (visibility: keyof typeof POST_VISIBILITY_MAP) => void;
   setContent: (content: string) => void;
-  setImages: (images: File[]) => void;
+  setImages: (images: { name: string; file: Promise<File> }[]) => void;
   resetMarkingFormStore: () => void;
 }
 
@@ -21,6 +22,7 @@ const MarkingFormInitialState: MarkingFormState = {
   visibility: "",
   content: "",
   images: [],
+  isCompressing: false,
 };
 
 export const useMarkingFormStore = create<
@@ -31,6 +33,12 @@ export const useMarkingFormStore = create<
   setRegion: (region) => set({ region }),
   setVisibility: (visibility) => set({ visibility }),
   setContent: (content) => set({ content }),
-  setImages: (images) => set({ images }),
+  setImages: (images) => {
+    set({ images });
+
+    Promise.all(images.map(({ file }) => file)).then(() => {
+      set({ isCompressing: false });
+    });
+  },
   resetMarkingFormStore: () => set(MarkingFormInitialState),
 }));

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -1,11 +1,16 @@
 import { create } from "zustand";
+import type { FileInfo } from "@/features/auth/store";
 import { POST_VISIBILITY_MAP } from "../constants";
+
+interface MarkingFileInfo extends FileInfo {
+  file: Promise<File>;
+}
 
 interface MarkingFormState {
   region: string;
   visibility: keyof typeof POST_VISIBILITY_MAP | "";
   content: string;
-  images: { name: string; file: Promise<File> }[];
+  images: MarkingFileInfo[];
   isCompressing: boolean;
 }
 
@@ -13,7 +18,7 @@ interface MarkingFormActions {
   setRegion: (region: string) => void;
   setVisibility: (visibility: keyof typeof POST_VISIBILITY_MAP) => void;
   setContent: (content: string) => void;
-  setImages: (images: { name: string; file: Promise<File> }[]) => void;
+  setImages: (images: MarkingFileInfo[]) => void;
   resetMarkingFormStore: () => void;
 }
 

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -12,6 +12,7 @@ interface MarkingFormState {
   content: string;
   images: MarkingFileInfo[];
   isCompressing: boolean;
+  inputKey: number;
 }
 
 interface MarkingFormActions {
@@ -28,6 +29,7 @@ const MarkingFormInitialState: MarkingFormState = {
   content: "",
   images: [],
   isCompressing: false,
+  inputKey: 0,
 };
 
 export const useMarkingFormStore = create<
@@ -40,15 +42,18 @@ export const useMarkingFormStore = create<
   setContent: (content) => set({ content }),
   setImages: (images) => {
     /* 동기적으로 압축 예정인 이미지 파일을 업데이트 합니다. */
-    set({ images, isCompressing: true });
+    set({ images, isCompressing: true, inputKey: get().inputKey + 1 });
 
-    const { images: optimisticImages } = get();
     /** 압축이 모두 종료 된 경우 비동기적으로 상태를 다시 업데이트 합니다.
      * 이 때 모든 file 들이 settled 된 이후 압축이 완료된 이미지만 남깁니다.
-     * 압축ㅇ이 실패한 이미지는 콘솔에 에러를 출력하고 제외합니다
+     * 압축이 실패한 이미지는 콘솔에 에러를 출력하고 제외합니다.
+     *
+     * 이 때 actual DOM에 마운트 된 input을 업데이트 하기 위해 inputKey를 증가시킵니다.
+     * actual DOM의 input을 새로 마운트 시킴으로서 액츄얼 돔의 input이 업데이트 된 이미지를 정상적으로 바라 볼 수 있도록 합니다.
      */
     Promise.allSettled(images.map(({ file }) => file))
       .then((settledResult) => {
+        const optimisticImages = get().images;
         const compressedImages = optimisticImages.filter((_, index) => {
           const compressionResult = settledResult[index];
           if (compressionResult.status === "rejected") {
@@ -60,7 +65,7 @@ export const useMarkingFormStore = create<
         });
 
         if (compressedImages.length < images.length) {
-          set({ images: compressedImages });
+          set({ images: compressedImages, inputKey: get().inputKey + 1 });
         }
       })
       .finally(() => {

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -39,9 +39,9 @@ export const useMarkingFormStore = create<
   setVisibility: (visibility) => set({ visibility }),
   setContent: (content) => set({ content }),
   setImages: (images) => {
-    set({ images });
+    set({ images, isCompressing: true });
 
-    Promise.all(images.map(({ file }) => file)).then(() => {
+    Promise.all(images.map(({ file }) => file)).finally(() => {
       set({ isCompressing: false });
     });
   },

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -32,18 +32,40 @@ const MarkingFormInitialState: MarkingFormState = {
 
 export const useMarkingFormStore = create<
   MarkingFormState & MarkingFormActions
->((set) => ({
+>((set, get) => ({
   ...MarkingFormInitialState,
 
   setRegion: (region) => set({ region }),
   setVisibility: (visibility) => set({ visibility }),
   setContent: (content) => set({ content }),
   setImages: (images) => {
+    /* 동기적으로 압축 예정인 이미지 파일을 업데이트 합니다. */
     set({ images, isCompressing: true });
 
-    Promise.all(images.map(({ file }) => file)).finally(() => {
-      set({ isCompressing: false });
-    });
+    const { images: optimisticImages } = get();
+    /** 압축이 모두 종료 된 경우 비동기적으로 상태를 다시 업데이트 합니다.
+     * 이 때 모든 file 들이 settled 된 이후 압축이 완료된 이미지만 남깁니다.
+     * 압축ㅇ이 실패한 이미지는 콘솔에 에러를 출력하고 제외합니다
+     */
+    Promise.allSettled(images.map(({ file }) => file))
+      .then((settledResult) => {
+        const compressedImages = optimisticImages.filter((_, index) => {
+          const compressionResult = settledResult[index];
+          if (compressionResult.status === "rejected") {
+            // TODO 에러 바운더리 로직 나오면 변경하기
+            console.error(compressionResult.reason);
+            return false;
+          }
+          return true;
+        });
+
+        if (compressedImages.length < images.length) {
+          set({ images: compressedImages });
+        }
+      })
+      .finally(() => {
+        set({ isCompressing: false });
+      });
   },
   resetMarkingFormStore: () => set(MarkingFormInitialState),
 }));

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -1,9 +1,10 @@
 import { create } from "zustand";
 import type { FileInfo } from "@/features/auth/store";
+import { compressFileImage } from "@/shared/lib";
 import { POST_VISIBILITY_MAP } from "../constants";
 
 interface MarkingFileInfo extends FileInfo {
-  file: Promise<File>;
+  file: NonNullable<FileInfo["file"]>;
 }
 
 interface MarkingFormState {
@@ -40,37 +41,54 @@ export const useMarkingFormStore = create<
   setRegion: (region) => set({ region }),
   setVisibility: (visibility) => set({ visibility }),
   setContent: (content) => set({ content }),
-  setImages: (images) => {
+  /** 압축이 모두 종료 된 경우 비동기적으로 상태를 다시 업데이트 합니다.
+   * 이 때 모든 file 들이 settled 된 이후 압축이 완료된 이미지만 남깁니다.
+   * 압축이 실패한 이미지는 콘솔에 에러를 출력하고 제외합니다.
+   *
+   * 이 때 actual DOM에 마운트 된 input을 업데이트 하기 위해 inputKey를 증가시킵니다.
+   * actual DOM의 input을 새로 마운트 시킴으로서 액츄얼 돔의 input이 업데이트 된 이미지를 정상적으로 바라 볼 수 있도록 합니다.
+   */
+  setImages: async (images) => {
     /* 동기적으로 압축 예정인 이미지 파일을 업데이트 합니다. */
     set({ images, isCompressing: true, inputKey: get().inputKey + 1 });
 
-    /** 압축이 모두 종료 된 경우 비동기적으로 상태를 다시 업데이트 합니다.
-     * 이 때 모든 file 들이 settled 된 이후 압축이 완료된 이미지만 남깁니다.
-     * 압축이 실패한 이미지는 콘솔에 에러를 출력하고 제외합니다.
-     *
-     * 이 때 actual DOM에 마운트 된 input을 업데이트 하기 위해 inputKey를 증가시킵니다.
-     * actual DOM의 input을 새로 마운트 시킴으로서 액츄얼 돔의 input이 업데이트 된 이미지를 정상적으로 바라 볼 수 있도록 합니다.
-     */
-    Promise.allSettled(images.map(({ file }) => file))
-      .then((settledResult) => {
-        const optimisticImages = get().images;
-        const compressedImages = optimisticImages.filter((_, index) => {
-          const compressionResult = settledResult[index];
-          if (compressionResult.status === "rejected") {
-            // TODO 에러 바운더리 로직 나오면 변경하기
-            console.error(compressionResult.reason);
-            return false;
-          }
-          return true;
-        });
+    if (images.length === 0) {
+      set({ isCompressing: false });
+      return;
+    }
 
-        if (compressedImages.length < images.length) {
-          set({ images: compressedImages, inputKey: get().inputKey + 1 });
-        }
-      })
-      .finally(() => {
-        set({ isCompressing: false });
+    const compressedFiles = await Promise.allSettled(
+      images.map(({ file }) => compressFileImage(file)),
+    );
+
+    const resolvedImages = images.filter(({ name }, index) => {
+      const { status } = compressedFiles[index];
+      if (status === "rejected") {
+        console.error(
+          `${name} 을 압축하는데 실패했습니다.
+          ${(compressedFiles[index] as PromiseRejectedResult).reason}`,
+        );
+        return false;
+      }
+      return true;
+    });
+
+    /**
+     * 압축에 실패한 경우엔 input key를 증가 시켜 다시 마운트 합니다.
+     * input 이 업데이트 되었을 때의 순간과 압축이 완료된 순간이 다를 수 있기 때문입니다.
+     */
+    if (resolvedImages.length < images.length) {
+      set({
+        images: resolvedImages,
+        isCompressing: false,
+        inputKey: get().inputKey + 1,
       });
+      return;
+    }
+    set({
+      images: resolvedImages,
+      isCompressing: false,
+    });
   },
   resetMarkingFormStore: () => set(MarkingFormInitialState),
 }));

--- a/src/features/marking/ui/markingFormModal.stories.tsx
+++ b/src/features/marking/ui/markingFormModal.stories.tsx
@@ -154,9 +154,9 @@ export const Default: Story = {
 
       const dummyFiles = [
         new File([""], "test1.jpg", { type: "image/jpg", lastModified: 1 }),
-        new File([""], "test2.jpg", { type: "image/png", lastModified: 2 }),
-        new File([""], "test3.jpg", { type: "image/jpeg", lastModified: 3 }),
-        new File([""], "test4.jpg", { type: "image/webp", lastModified: 4 }),
+        new File([""], "test2.png", { type: "image/png", lastModified: 2 }),
+        new File([""], "test3.jpeg", { type: "image/jpeg", lastModified: 3 }),
+        new File([""], "test4.webp", { type: "image/webp", lastModified: 4 }),
       ];
 
       await userEvent.upload($fileUploadInput, dummyFiles);
@@ -196,8 +196,8 @@ export const Default: Story = {
 
           await userEvent.upload(
             $fileUploadInput,
-            new File([""], "test3.jpg", {
-              type: "image/jpg",
+            new File([""], "test3.jpeg", {
+              type: "image/jpeg",
               lastModified: 3,
             }),
           );

--- a/src/features/marking/ui/markingFormModal.stories.tsx
+++ b/src/features/marking/ui/markingFormModal.stories.tsx
@@ -176,10 +176,6 @@ export const Default: Story = {
     await step(
       "이미지 파일 업로드는 다음과 같은 결과들을 만족 해야 한다.",
       async () => {
-        const $fileUploadInput = canvasElement.querySelector(
-          "#images",
-        )! as HTMLInputElement;
-
         const $fileUploadButton =
           canvas.getByLabelText("마킹 게시글에 사진 추가하기");
 
@@ -194,10 +190,14 @@ export const Default: Story = {
         );
 
         await step("중복된 이미지 파일은 업로드 되지 않는다.", async () => {
+          const $fileUploadInput = canvasElement.querySelector(
+            "#images",
+          )! as HTMLInputElement;
+
           await userEvent.upload(
             $fileUploadInput,
             new File([""], "test3.jpg", {
-              type: "image/jpeg",
+              type: "image/jpg",
               lastModified: 3,
             }),
           );
@@ -208,7 +208,12 @@ export const Default: Story = {
 
         await step(
           "새로운 파일을 추가로 업로드 하여도 기존 이미지 파일들은 존재 한다.",
+
           async () => {
+            const $fileUploadInput = canvasElement.querySelector(
+              "#images",
+            )! as HTMLInputElement;
+
             const dummyFiles = [
               new File([""], "test5.jpg", {
                 type: "image/jpg",

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -238,7 +238,6 @@ const PhotoInput = () => {
         type="file"
         accept=".jpeg,.jpg,.png,.webp"
         multiple
-        max={5}
         className="sr-only"
         ref={inputRef}
         id="images"

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { SelectOpener } from "@/entities/auth/ui";
 import { MapSnackbar } from "@/entities/map/ui";
-import { compressFile } from "@/shared/lib";
+import { compressFileImage } from "@/shared/lib";
 import { useModal, useSnackBar } from "@/shared/lib/overlay";
 import { useAuthStore } from "@/shared/store";
 import { Badge } from "@/shared/ui/badge";
@@ -205,7 +205,7 @@ const PhotoInput = () => {
       ...AvailableNewFileArray.map((file) => ({
         name: file.name,
         url: URL.createObjectURL(file),
-        file: compressFile(file),
+        file: compressFileImage(file),
       })),
     ]);
   };

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -167,7 +167,6 @@ const PostVisibilitySelect = () => {
 
 interface ImageUrl {
   url: string;
-  lastModified: number;
   name: string;
 }
 
@@ -181,7 +180,6 @@ const PhotoInput = () => {
   const [imageUrls, setImageUrls] = useState<ImageUrl[]>(() =>
     images.map((image) => ({
       url: URL.createObjectURL(image),
-      lastModified: image.lastModified,
       name: image.name,
     })),
   );
@@ -213,7 +211,6 @@ const PhotoInput = () => {
       _images.push(newFile);
       _imageUrls.push({
         url: URL.createObjectURL(newFile),
-        lastModified: newFile.lastModified,
         name: newFile.name,
       });
 
@@ -226,11 +223,9 @@ const PhotoInput = () => {
     setImageUrls([..._imageUrls]);
   };
 
-  const handleRemoveImage = (lastModified: number) => {
-    setImages(images.filter((image) => image.lastModified !== lastModified));
-    setImageUrls(
-      imageUrls.filter((image) => image.lastModified !== lastModified),
-    );
+  const handleRemoveImage = (name: string) => {
+    setImages(images.filter((image) => image.name !== name));
+    setImageUrls(imageUrls.filter((image) => image.name !== name));
 
     setInputKey((prev) => prev + 1);
   };
@@ -269,12 +264,12 @@ const PhotoInput = () => {
             <PlusIcon />
           </ImgSlider.Item>
         )}
-        {imageUrls.map(({ url, name, lastModified }) => (
+        {imageUrls.map(({ url, name }) => (
           <ImgSlider.ImgItem
             src={url}
             alt={name}
-            key={lastModified}
-            onRemove={() => handleRemoveImage(lastModified)}
+            key={name}
+            onRemove={() => handleRemoveImage(name)}
           />
         ))}
       </ImgSlider>

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { SelectOpener } from "@/entities/auth/ui";
 import { MapSnackbar } from "@/entities/map/ui";
-import { compressFileImage } from "@/shared/lib";
 import { useModal, useSnackBar } from "@/shared/lib/overlay";
 import { useAuthStore } from "@/shared/store";
 import { Badge } from "@/shared/ui/badge";
@@ -205,7 +204,7 @@ const PhotoInput = () => {
       ...AvailableNewFileArray.map((file) => ({
         name: file.name,
         url: URL.createObjectURL(file),
-        file: compressFileImage(file),
+        file,
       })),
     ]);
   };
@@ -329,10 +328,6 @@ const SaveButton = ({ onCloseMarkingModal }: MarkingFormModalProps) => {
       throw new Error(MARKING_ADD_ERROR_MESSAGE.MISSING_REQUIRED_FIELDS);
     }
 
-    const compressedFiles = await Promise.all(
-      images.map((image) => image.file),
-    );
-
     const lat = center.lat();
     const lng = center.lng();
 
@@ -343,7 +338,7 @@ const SaveButton = ({ onCloseMarkingModal }: MarkingFormModalProps) => {
         lng,
         region,
         visibility,
-        images: compressedFiles,
+        images: images.map((image) => image.file),
         content,
       },
       {
@@ -394,7 +389,7 @@ const TemporarySaveButton = ({
     },
   });
 
-  const handleSave = async () => {
+  const handleSave = () => {
     const { token } = useAuthStore.getState();
     const { region, visibility, images, content } =
       useMarkingFormStore.getState();
@@ -409,9 +404,7 @@ const TemporarySaveButton = ({
       return;
     }
 
-    const compressedFiles = await Promise.all(
-      images.map((image) => image.file),
-    );
+    const compressedFiles = images.map((image) => image.file);
 
     const center = map.getCenter();
 

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -173,8 +173,8 @@ const PostVisibilitySelect = () => {
 const PhotoInput = () => {
   const images = useMarkingFormStore((state) => state.images);
   const setImages = useMarkingFormStore((state) => state.setImages);
+  const inputKey = useMarkingFormStore((state) => state.inputKey);
 
-  const [inputKey, setInputKey] = useState<number>(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleOpenAlbum = () => {
@@ -212,7 +212,6 @@ const PhotoInput = () => {
 
   const handleRemoveImage = (name: string) => {
     setImages(images.filter((image) => image.name !== name));
-    setInputKey((prev) => prev + 1);
   };
 
   return (

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -182,7 +182,7 @@ const PhotoInput = () => {
   const [inputKey, setInputKey] = useState<number>(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [imageUrls, setImageUrls] = useState<ImageUrl[]>(() =>
+  const [optimisticUrls, setOptimisticUrl] = useState<ImageUrl[]>(() =>
     images.map((image) => ({
       url: URL.createObjectURL(image),
       name: image.name,
@@ -216,8 +216,8 @@ const PhotoInput = () => {
       .filter((newFile) => !images.some((image) => image.name === newFile.name))
       .slice(0, MAX_IMAGE_LENGTH - images.length);
 
-    setImageUrls([
-      ...imageUrls,
+    setOptimisticUrl([
+      ...optimisticUrls,
       ...AvailableNewFileArray.map((file) => ({
         url: URL.createObjectURL(file),
         name: file.name,
@@ -231,7 +231,7 @@ const PhotoInput = () => {
 
   const handleRemoveImage = (name: string) => {
     setImages(images.filter((image) => image.name !== name));
-    setImageUrls(imageUrls.filter((image) => image.name !== name));
+    setOptimisticUrl(optimisticUrls.filter((image) => image.name !== name));
 
     setInputKey((prev) => prev + 1);
   };
@@ -262,7 +262,7 @@ const PhotoInput = () => {
       </label>
       {/* 담긴 사진들 */}
       <ImgSlider>
-        {imageUrls.length < 5 && (
+        {optimisticUrls.length < 5 && (
           <ImgSlider.Item
             onClick={handleOpenAlbum}
             aria-label="마킹 게시글에 사진 추가하기"
@@ -270,7 +270,7 @@ const PhotoInput = () => {
             <PlusIcon />
           </ImgSlider.Item>
         )}
-        {imageUrls.map(({ url, name }) => (
+        {optimisticUrls.map(({ url, name }) => (
           <ImgSlider.ImgItem
             src={url}
             alt={name}

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -322,20 +322,20 @@ const SaveButton = ({ onCloseMarkingModal }: MarkingFormModalProps) => {
 
     const center = map.getCenter();
 
+    if (!region) {
+      throw new Error(MARKING_ADD_ERROR_MESSAGE.REGION_NOT_FOUND);
+    }
+
+    if (!visibility || images.length === 0) {
+      throw new Error(MARKING_ADD_ERROR_MESSAGE.MISSING_REQUIRED_FIELDS);
+    }
+
     const compressedFiles = await Promise.all(
       images.map((image) => image.file),
     );
 
     const lat = center.lat();
     const lng = center.lng();
-
-    if (!region) {
-      throw new Error(MARKING_ADD_ERROR_MESSAGE.REGION_NOT_FOUND);
-    }
-
-    if (!visibility || compressedFiles.length === 0) {
-      throw new Error(MARKING_ADD_ERROR_MESSAGE.MISSING_REQUIRED_FIELDS);
-    }
 
     postMarkingData(
       {

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -199,9 +199,7 @@ const PhotoInput = () => {
     // TODO 이미지 파일 최적화 위해 용량 줄이기
 
     const isImageAlreadyExist = (newFile: File) => {
-      return images.some(
-        (image) => image.lastModified === newFile.lastModified,
-      );
+      return images.some((image) => image === newFile);
     };
 
     const _images = [...images];

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -43,6 +43,11 @@ export const compressFileImage: compressFileImage = async (file, options) => {
    * 2024/10/11 에러 시 reject 처리 추가
    */
   const result = await new Promise<string>((resolve, reject) => {
+    // 테스트용 reject
+    if (Math.random() > 0.5) {
+      reject(new Error("파일이 너무 큽니다."));
+    }
+
     reader.readAsDataURL(file);
     reader.onload = () => resolve(reader.result as string);
     reader.onerror = (error) => reject(error);

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -9,6 +9,13 @@ type CompressFile = (
   options?: CompressFileOptions,
 ) => Promise<File>;
 
+const defaultCompressOptions: CompressFileOptions = {
+  maxSize: 2 ** 20, // 최대 파일 크기 1MB
+  compactSize: 2 ** 10 * 100, // 압축 후 최대 파일 크기 100KB
+  quality: 0.7,
+  extension: "webp",
+};
+
 /**
  * compressFile 은 File 객체를 options 에 설정된 maxSize 보다 작은 크기로 압축합니다.
  * 파일 압축은 JPEG 포맷으로만 가능합니다.
@@ -18,10 +25,7 @@ type CompressFile = (
  */
 export const compressFile: CompressFile = async (file, options) => {
   const { maxSize, compactSize, quality, extension } = {
-    maxSize: 2 ** 20, // 최대 파일 크기 1MB
-    compactSize: 2 ** 10 * 100, // 압축 후 최대 파일 크기 100KB
-    quality: 0.7,
-    extension: "webp",
+    ...defaultCompressOptions,
     ...options,
   };
 
@@ -88,4 +92,20 @@ export const compressFile: CompressFile = async (file, options) => {
   });
 
   return compressedFile;
+};
+
+type CompressFileArray = (
+  files: File[],
+  options?: CompressFileOptions,
+) => Promise<File[]>;
+
+export const compressFileArray: CompressFileArray = (files, options) => {
+  return Promise.all(
+    files.map((file) =>
+      compressFile(file, {
+        ...defaultCompressOptions,
+        ...options,
+      }),
+    ),
+  );
 };

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -93,15 +93,3 @@ export const compressFile: CompressFile = async (file, options) => {
 
   return compressedFile;
 };
-
-type CompressFileArray = (
-  files: File[],
-  options?: CompressFileOptions,
-) => { name: string; file: Promise<File> }[];
-
-export const compressFileArray: CompressFileArray = (files, options) => {
-  return files.map((file) => ({
-    name: file.name,
-    file: compressFile(file, options),
-  }));
-};

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -1,0 +1,91 @@
+interface CompressFileOptions {
+  maxSize: number;
+  compactSize: number;
+  quality: number;
+  extension: "jpeg" | "webp" | "png";
+}
+type CompressFile = (
+  file: File,
+  options?: CompressFileOptions,
+) => Promise<File>;
+
+/**
+ * compressFile 은 File 객체를 options 에 설정된 maxSize 보다 작은 크기로 압축합니다.
+ * 파일 압축은 JPEG 포맷으로만 가능합니다.
+ * canvas 를 이용해 이미지를 압축하며 , 파일의 너비와 높이를 원 사이즈 / compactSize 만큼의 비율로 크기를 줄입니다.
+ * @param file 압축할 파일
+ * @param options maxSize: 압축할 파일의 최대 크기, compactSize: 압축된 파일의 최소 크기 , quality: 압축 품질, extension: 압축할 파일의 확장자
+ */
+export const compressFile: CompressFile = async (file, options) => {
+  const { maxSize, compactSize, quality, extension } = {
+    maxSize: 2 ** 20, // 최대 파일 크기 1MB
+    compactSize: 2 ** 10 * 100, // 압축 후 최대 파일 크기 100KB
+    quality: 0.7,
+    extension: "webp",
+    ...options,
+  };
+
+  if (file.size <= maxSize) {
+    return file;
+  }
+  const image = new Image();
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+
+  /* 만약 canvas 를 사용 못하는 환경이라면 원본 파일을 반환 합니다. */
+  if (!context) {
+    return file;
+  }
+
+  const reader = new FileReader();
+  /**
+   * FileReader 는 비동기적으로 load 되고 비동기적으로 데이터를 읽습니다.
+   * result 는 reader 가 읽은 데이터를 base64 로 인코딩한 문자열 입니다.
+   */
+  const result = await new Promise<string>((resolve) => {
+    reader.onload = () => resolve(reader.result as string);
+    reader.readAsDataURL(file);
+  });
+  /**
+   * 이미지의 src 를 base64 로 인코딩된 문자열로 설정합니다.
+   * 이로 인해 canvas 에 해당 이미지를 그릴 수 있습니다.
+   */
+  image.src = result;
+  /**
+   * 이미지가 load 될 때 까지 프로미스 체인을 진행하지 않고 기다립니다.
+   */
+  await new Promise<void>((resolve) => {
+    image.onload = () => resolve();
+  });
+  /**
+   * 원본 이미지를 인수로 선택한 compactSize 만큼의 비율로 줄입니다.
+   * compactSize 는 인수로 받은 압축된 파일의 최대 용량 입니다.
+   */
+  const ratio = Math.sqrt(compactSize / file.size);
+  const { width, height } = image;
+  canvas.width = width * ratio;
+  canvas.height = height * ratio;
+  context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+  const compressedFile: Promise<File> = new Promise((resolve) => {
+    canvas.toBlob(
+      (blob) => {
+        /* blob 생성에 실패하면 원본 데이터를 resolve 합니다. */
+        if (!blob) {
+          resolve(file);
+          return;
+        }
+        resolve(
+          new File([blob], file.name, {
+            type: `image/${extension}`,
+            lastModified: Date.now(),
+          }),
+        );
+      },
+      `image/${extension}`,
+      quality,
+    );
+  });
+
+  return compressedFile;
+};

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -17,8 +17,7 @@ const defaultCompressOptions: CompressFileOptions = {
 };
 
 /**
- * compressFile 은 File 객체를 options 에 설정된 maxSize 보다 작은 크기로 압축합니다.
- * 파일 압축은 JPEG 포맷으로만 가능합니다.
+ * compressFile 은 File 객체를 options 에 설정된 maxSize 보다 작은 크기로 압축하고 extension 확장자로 변환하여 저장합니다.
  * canvas 를 이용해 이미지를 압축하며 , 파일의 너비와 높이를 원 사이즈 / compactSize 만큼의 비율로 크기를 줄입니다.
  * @param file 압축할 파일
  * @param options maxSize: 압축할 파일의 최대 크기, compactSize: 압축된 파일의 최소 크기 , quality: 압축 품질, extension: 압축할 파일의 확장자
@@ -47,8 +46,8 @@ export const compressFile: CompressFile = async (file, options) => {
    * result 는 reader 가 읽은 데이터를 base64 로 인코딩한 문자열 입니다.
    */
   const result = await new Promise<string>((resolve) => {
-    reader.onload = () => resolve(reader.result as string);
     reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result as string);
   });
   /**
    * 이미지의 src 를 base64 로 인코딩된 문자열로 설정합니다.

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -97,15 +97,11 @@ export const compressFile: CompressFile = async (file, options) => {
 type CompressFileArray = (
   files: File[],
   options?: CompressFileOptions,
-) => Promise<File[]>;
+) => { name: string; file: Promise<File> }[];
 
 export const compressFileArray: CompressFileArray = (files, options) => {
-  return Promise.all(
-    files.map((file) =>
-      compressFile(file, {
-        ...defaultCompressOptions,
-        ...options,
-      }),
-    ),
-  );
+  return files.map((file) => ({
+    name: file.name,
+    file: compressFile(file, options),
+  }));
 };

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -36,14 +36,6 @@ export const compressFileImage: compressFileImage = async (file, options) => {
     return file;
   }
   const image = new Image();
-  const canvas = document.createElement("canvas");
-  const context = canvas.getContext("2d");
-
-  /* 만약 canvas 를 사용 못하는 환경이라면 원본 파일을 반환 합니다. */
-  if (!context) {
-    return file;
-  }
-
   const reader = new FileReader();
   /**
    * FileReader 는 비동기적으로 load 되고 비동기적으로 데이터를 읽습니다.
@@ -55,6 +47,14 @@ export const compressFileImage: compressFileImage = async (file, options) => {
     reader.onload = () => resolve(reader.result as string);
     reader.onerror = (error) => reject(error);
   });
+
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+
+  /* 만약 canvas 를 사용 못하는 환경이라면 원본 파일을 반환 합니다. */
+  if (!context) {
+    return file;
+  }
 
   /**
    * 이미지의 src 를 base64 로 인코딩된 문자열로 설정합니다.

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -1,15 +1,15 @@
-interface CompressFileOptions {
+interface compressFileImageOptions {
   maxSize: number;
   compactSize: number;
   quality: number;
   extension: "jpeg" | "webp" | "png";
 }
-type CompressFile = (
+type compressFileImage = (
   file: File,
-  options?: CompressFileOptions,
+  options?: compressFileImageOptions,
 ) => Promise<File>;
 
-const defaultCompressOptions: CompressFileOptions = {
+const defaultCompressOptions: compressFileImageOptions = {
   maxSize: 2 ** 20, // 최대 파일 크기 1MB
   compactSize: 2 ** 10 * 100, // 압축 후 최대 파일 크기 100KB
   quality: 0.7,
@@ -17,12 +17,12 @@ const defaultCompressOptions: CompressFileOptions = {
 };
 
 /**
- * compressFile 은 File 객체를 options 에 설정된 maxSize 보다 작은 크기로 압축하고 extension 확장자로 변환하여 저장합니다.
+ * compressFileImage 은 File 객체를 options 에 설정된 maxSize 보다 작은 크기로 압축하고 extension 확장자로 변환하여 저장합니다.
  * canvas 를 이용해 이미지를 압축하며 , 파일의 너비와 높이를 원 사이즈 / compactSize 만큼의 비율로 크기를 줄입니다.
  * @param file 압축할 파일
  * @param options maxSize: 압축할 파일의 최대 크기, compactSize: 압축된 파일의 최소 크기 , quality: 압축 품질, extension: 압축할 파일의 확장자
  */
-export const compressFile: CompressFile = async (file, options) => {
+export const compressFileImage: compressFileImage = async (file, options) => {
   const { maxSize, compactSize, quality, extension } = {
     ...defaultCompressOptions,
     ...options,

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -43,11 +43,6 @@ export const compressFileImage: compressFileImage = async (file, options) => {
    * 2024/10/11 에러 시 reject 처리 추가
    */
   const result = await new Promise<string>((resolve, reject) => {
-    // 테스트용 reject
-    if (Math.random() > 0.5) {
-      reject(new Error("파일이 너무 큽니다."));
-    }
-
     reader.readAsDataURL(file);
     reader.onload = () => resolve(reader.result as string);
     reader.onerror = (error) => reject(error);

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -19,6 +19,10 @@ const defaultCompressOptions: compressFileImageOptions = {
 /**
  * compressFileImage 은 File 객체를 options 에 설정된 maxSize 보다 작은 크기로 압축하고 extension 확장자로 변환하여 저장합니다.
  * canvas 를 이용해 이미지를 압축하며 , 파일의 너비와 높이를 원 사이즈 / compactSize 만큼의 비율로 크기를 줄입니다.
+ *
+ * 2024/10/11 업데이트
+ * 파일이 너무 크거나 손상된 경우엔 이미지 업로드를 거부하도록 합니다.
+ * 만약 파일은 문제 없으나 canvas 를 사용하지 못하는 경우엔 원본 파일을 반환합니다.
  * @param file 압축할 파일
  * @param options maxSize: 압축할 파일의 최대 크기, compactSize: 압축된 파일의 최소 크기 , quality: 압축 품질, extension: 압축할 파일의 확장자
  */
@@ -44,11 +48,14 @@ export const compressFileImage: compressFileImage = async (file, options) => {
   /**
    * FileReader 는 비동기적으로 load 되고 비동기적으로 데이터를 읽습니다.
    * result 는 reader 가 읽은 데이터를 base64 로 인코딩한 문자열 입니다.
+   * 2024/10/11 에러 시 reject 처리 추가
    */
-  const result = await new Promise<string>((resolve) => {
+  const result = await new Promise<string>((resolve, reject) => {
     reader.readAsDataURL(file);
     reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
   });
+
   /**
    * 이미지의 src 를 base64 로 인코딩된 문자열로 설정합니다.
    * 이로 인해 canvas 에 해당 이미지를 그릴 수 있습니다.

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 export * from "./cookie";
 export * from "./overlay";
 export * from "./debounce";
-
+export * from "./image";
 // TODO refactoring 시 해당 훅 제거 하기
 /**
  * useDebounce 훅은 입력된 콜백 함수를 지연시간만큼 지연시킨 후 실행합니다.


### PR DESCRIPTION
# 관련 이슈 번호
close #270 

# 설명

우선 웹워커를 이용한 최적화 부분은 다음 PR 에서 진행하도록 합니다. 

사유는 작업 단위가 너무 커지고, 지금 진행해야 하는 일들이 많기 때문입니다. 🥹

이미지 압축이 필요한 이유에 대해선 이슈에 잘 적어놨고 어떻게 구현했는지 , 어떻게 동작하는지에 대한 이야기를 하도록 하겠습니다.


# 얼마나 효과가 좋았는가 ? : `compressFile` 성능 점검 

![image](https://github.com/user-attachments/assets/c648f57d-a149-4049-8d6f-f772a45e08dd)

압축 전 네트워크 요청 시간
![374575409-98f82275-1670-4399-9fc3-f04c503e06b5](https://github.com/user-attachments/assets/268827a8-7455-485a-8b33-269cd1c24537)
압축 후 네트워크 요청 시간
![374576269-2a981150-b9bf-4721-9caa-8bfd5323a566](https://github.com/user-attachments/assets/237beb46-72dd-48c3-a9d0-5052eee50c4f)

- 압축 까지 걸린 시간 : 약 200ms (오차 약 80ms)
- 용량 크기 변화  : `2126719 byte (2076kb)` ->  `49256 byte (48kb)` , 원본보다 용량 0.02배로 압축
- 이미지 화질 변화 : 위 원본 , 아래 압축된 사진
![image](https://github.com/user-attachments/assets/47542b33-8bed-476e-a43b-a1ce7bbd7697)

꽤나 유의미한 변화인 거 같습니다. 이미지 압축 정도를 더 때려봐도 될 거 같기도 하고요 🥹 나중에 실험을 통해 최적의 값을 찾아 봅시다 :) 

## compressFile 

```tsx
// shared/lib/image.ts
/**
 * compressFile 은 File 객체를 options 에 설정된 maxSize 보다 작은 크기로 압축합니다.
 * 파일 압축은 JPEG 포맷으로만 가능합니다.
 * canvas 를 이용해 이미지를 압축하며 , 파일의 너비와 높이를 원 사이즈 / compactSize 만큼의 비율로 크기를 줄입니다.
 * @param file 압축할 파일
 * @param options maxSize: 압축할 파일의 최대 크기, compactSize: 압축된 파일의 최소 크기 , quality: 압축 품질, extension: 압축할 파일의 확장자
 */
export const compressFile: CompressFile = async (file, options) => {
  const { maxSize, compactSize, quality, extension } = {
    ...defaultCompressOptions,
    ...options,
  };

  if (file.size <= maxSize) {
    return file;
  }
  const image = new Image();
  const canvas = document.createElement("canvas");
  const context = canvas.getContext("2d");

  /* 만약 canvas 를 사용 못하는 환경이라면 원본 파일을 반환 합니다. */
  if (!context) {
    return file;
  }

  const reader = new FileReader();
  /**
   * FileReader 는 비동기적으로 load 되고 비동기적으로 데이터를 읽습니다.
   * result 는 reader 가 읽은 데이터를 base64 로 인코딩한 문자열 입니다.
   */
  const result = await new Promise<string>((resolve) => {
    reader.onload = () => resolve(reader.result as string);
    reader.readAsDataURL(file);
  });
  /**
   * 이미지의 src 를 base64 로 인코딩된 문자열로 설정합니다.
   * 이로 인해 canvas 에 해당 이미지를 그릴 수 있습니다.
   */
  image.src = result;
  /**
   * 이미지가 load 될 때 까지 프로미스 체인을 진행하지 않고 기다립니다.
   */
  await new Promise<void>((resolve) => {
    image.onload = () => resolve();
  });
  /**
   * 원본 이미지를 인수로 선택한 compactSize 만큼의 비율로 줄입니다.
   * compactSize 는 인수로 받은 압축된 파일의 최대 용량 입니다.
   */
  const ratio = Math.sqrt(compactSize / file.size);
  const { width, height } = image;
  canvas.width = width * ratio;
  canvas.height = height * ratio;
  context.drawImage(image, 0, 0, canvas.width, canvas.height);

  const compressedFile: Promise<File> = new Promise((resolve) => {
    canvas.toBlob(
      (blob) => {
        /* blob 생성에 실패하면 원본 데이터를 resolve 합니다. */
        if (!blob) {
          resolve(file);
          return;
        }
        resolve(
          new File([blob], file.name, {
            type: `image/${extension}`,
            lastModified: Date.now(),
          }),
        );
      },
      `image/${extension}`,
      quality,
    );
  });

  return compressedFile;
};
```

해당 메소드는 다음과 같은 상황으로 구현 됩니다.

1. 들어온 file 의 size 가 maxSize (기본값 1MB) 보다 작은 경우 원본 이미지를 반환 합니다.
2. 들어온 file 의 size 가 maxSize 보다 큰 경우 다음과 같은 일이 일어납니다.
3. `FileReader` 를 이용해 파일을 읽어 해당 파일이 위치하는 메모리 주소를 `url` 형태로 생성 합니다. 
4. 생성한 `image` 태그에서 파일이 존재하는 메모리의 주소인 `url` 을 맵핑하도록 합니다. 
5. 업로드 된 파일을 가리키고 있는 `image` 를 리사이징 한 `canvas` 에서 그리고 확장자를 `webp` 로 변환 합니다.
> 이 때 리사이징 기준은 `루트 (원하는 사이즈/원본 사이즈)` 입니다. 루트를 해주는 이유는 `width  ,height` 에 모두 곱해주기 때문입니다. 
6. 이후 그린 `canvas` 를 `blob` 형태로 변환하고 파일 형태로 생성하여 `Promise` 형태로 반환 합니다. 

### `async , await` 로 `Promise` 를 `resolve` 한 후에 반환하지 왜 `Promise` 로 반환해 ? 

![image](https://github.com/user-attachments/assets/79199e80-b0ef-45d7-9598-7c9808cc41cf)

해당 메소드에서 작업들이 일어 날 때 걸리는 시간들의 분포입니다. (가장 하위에 존재하는 219ms는 모든 과정의 총 합입니다.)

가장 오래 걸리는 행위는 `Blob -> File` 로 변환 할 때 입니다. `compressFile` 이 배열을 순회하며 호출 될 때 `133ms` 만큼 기다렸다가 다음 `compressFile` 을 호출하기 보다 , 여러 비동기 로직들이 섞여 실행 될 수 있도록 하기 위해 `Promise` 형태로 반환 합니다.

## petInfoFormStore

다음과 같이 타입이 변경 되었습니다.

```tsx
export interface FileInfo {
  name: string;
  url: string;
  file: Promise<File | null>;
}

interface PetInfoFormStates extends Omit<PetInfoFormData, "profile"> {
  isValidName: boolean;
  profile: FileInfo;
  isCompressing: boolean;
}

export const usePetInfoStore = create<PetInfoFormStates & PetInfoFormActions>(
  (set) => ({
    ...petInfoFormInitialState,

    setProfile: (profile: FileInfo) => {
      set({ profile, isCompressing: true });
      profile.file.then(() => set({ isCompressing: false }));
    },
```

`profile` 은 `File | null ` 에서 `FileInfo` 로 , `isCompressing` 이란 상태가 추가 되었습니다. 

`isCompressing` 은 인수로 받은 `Profile` 이 `fulfilled` 되면 `false` 로 변경 됩니다. 즉 `compressFile` 과정이 시작되면 `true` , 완료 되었다면 `false` 가 됩니다.

![374846411-87502a2a-e6a8-4bbd-8796-5a1c644e4cc1](https://github.com/user-attachments/assets/080b9d48-51af-4ebe-a33b-e137c4a37a15)

```tsx

export const ProfileInput = () => {
  const profile = usePetInfoStore((state) => state.profile);
  const setProfile = usePetInfoStore((state) => state.setProfile);
  ...

  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
    const file = e.target.files?.[0];
    if (!file) {
      return;
    }
    /**
     * 압축 과정 동안 이미지가 변경되지 않는 것을 방지하기 위해 낙관적 업데이트를 사용합니다.
     */
    setProfile({
      file: compressFile(file),
      name: file.name,
      url: URL.createObjectURL(file),
    });
  };

  // 사진을 삭제하는 핸들러
  const handleDelete = () => {
    setProfile({
      file: Promise.resolve(null),
      name: "",
      url: DEFAULT_PROFILE_IMAGE,
    });
    setInputKey((prev) => prev + 1);
  };
```

낙관적 렌더링을 제공하기 위해 `file.name , file.url` 은 동기적으로 받고 `Promise` 부분만 따로 프로퍼티로 받았습니다.

이로 인해 파일이 압축되기 전에도 생성된 `url` 을 통해 렌더링이 가능 합니다.

### petInfoForm의 submit 버튼 

```tsx
export const SubmitButton = () => {
 ... 
  const handleClick = async () => {
    const petInfoForm = usePetInfoStore.getState();
    const {
      isValidName,
      name,
      breed,
      personalities,
      description,
      profile,
      isCompressing,
    } = petInfoForm;

    if (isCompressing) {
      // TODO 에러 바운더리 생성되면 로직 변경하기
      console.error("사진을 압축 중입니다. 잠시 후 다시 시도해주세요");
      return;
    }
...
    const resolvedProfile = await profile.file;
  ... 
    postPetInfo({
      token,
      formObject: {
        name,
        breed,
        personalities,
        description,
        profile: resolvedProfile,
      },
    });
  };
```

다음과 같이 제출 이벤트가 발생 했을 때 , 만약 이미지가 아직 압축 중이라면 제출이 되지 않고 에러를 던집니다.

이미지 압축 과정엔 `submit` 버튼은 `disabled` 시킬 수도 있었지만 그렇게 하게 되면 압축이 아무리 짧게 일어나도 버튼이 깜박 거리는 블링크 현상이 발생해서 보기 안좋더군요 

> 🔥 TODO 에러바운더리로 처리하기

## 마킹폼 모달

마킹 폼 모달도 별 차이 없습니다 동일해요 

다만 이쪽은 제출 단계에서 `await` 시키는 곳이 `Promise.all` 이라는 점 정도만 차이 있는 거 같습니다.

```tsx
    const compressedFiles = await Promise.all(
      images.map((image) => image.file),
    );
```



# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
