### PR TITLE
[Hotfix] AppProvider 구조 올바르게 변경

### DIFF
--- a/src/app/AppProviderLayout.tsx
+++ b/src/app/AppProviderLayout.tsx
@@ -10,8 +10,8 @@ export const AppProviderLayout = () => {
   return (
     // TODO 레이아웃 범위 디자이너와 상의 후 픽스하기
     <ReactQueryProvider>
-      <MainLayout>
-        <GoogleMapsProvider>
+      <GoogleMapsProvider>
+        <MainLayout>
           {/* 
       // ! TODO
       // ! 해당 컴포넌트는 개발 환경에서만 사용 되는 컴포넌트 입니다.
@@ -22,8 +22,8 @@ export const AppProviderLayout = () => {
           <HistoryTracker />
           <OverlayPortal />
           <Outlet />
-        </GoogleMapsProvider>
-      </MainLayout>
+        </MainLayout>
+      </GoogleMapsProvider>
     </ReactQueryProvider>
   );
 };

--- a/src/app/AppProviderLayout.tsx
+++ b/src/app/AppProviderLayout.tsx
@@ -1,6 +1,5 @@
 import { Outlet } from "react-router-dom";
 import { DevTools } from "./DevTools";
-import { FooterNavigationBar } from "./FooterNavigationBar";
 import { GoogleMapsProvider } from "./GoogleMapsProvider";
 import { HistoryTracker } from "./HistoryTracker";
 import { MainLayout } from "./MainLayout";
@@ -11,21 +10,20 @@ export const AppProviderLayout = () => {
   return (
     // TODO 레이아웃 범위 디자이너와 상의 후 픽스하기
     <ReactQueryProvider>
-      {/* 
+      <MainLayout>
+        <GoogleMapsProvider>
+          {/* 
       // ! TODO
       // ! 해당 컴포넌트는 개발 환경에서만 사용 되는 컴포넌트 입니다.
       // ! main.ts 파일에서 렌더링 되며 import.meta.DEV 를 통해 개발 환경인지 확인합니다.
       // ! 배포 시엔 해당 컴포넌트가 렌더링 되지 않지만 위험을 방지하기 위해 배포 시 해당 컴포넌트를 제거 해주세요
       */}
-      {import.meta.env.DEV && <DevTools />}
-      <HistoryTracker />
-      <OverlayPortal />
-      <GoogleMapsProvider>
-        <MainLayout>
+          {import.meta.env.DEV && <DevTools />}
+          <HistoryTracker />
+          <OverlayPortal />
           <Outlet />
-        </MainLayout>
-        <FooterNavigationBar />
-      </GoogleMapsProvider>
+        </GoogleMapsProvider>
+      </MainLayout>
     </ReactQueryProvider>
   );
 };

--- a/src/app/MainLayout.tsx
+++ b/src/app/MainLayout.tsx
@@ -1,7 +1,10 @@
+import { FooterNavigationBar } from "./FooterNavigationBar";
+
 export const MainLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="mx-auto my-0 flex h-screen max-w-[37.5rem] flex-col">
       <main className="flex grow flex-col overflow-y-scroll">{children}</main>
+      <FooterNavigationBar />
     </div>
   );
 };


### PR DESCRIPTION
# 관련 이슈 번호

close #275 

# 설명

이전 #269 작업에서 `AppProvider` 컴포넌트의 순서를 별 생각 없이 뒤죽박죽 만들었더니 예기치 못한 버그들이 너무 많이 존재했더라고요 

예를 들어 `FooterNavigationBar` 는 화면에서 보이지 않는다거나 

마킹하기 버튼은  `GoogleMapProvider` 외부에 존재해서 `useMap` 을 호출하지 못한다거나 

다시 이전 작업 참고하여 명확한 구조로 변경했습니다.
# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
