### PR TITLE
[Feat]  RefreshToken 만료 시 로그아웃 후 login 페이지로 라우팅 기능 추가

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,19 +2,10 @@ import { initialize, mswLoader } from "msw-storybook-addon";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import type { Preview } from "@storybook/react";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { useCreateQueryClient } from "../src/app/ReactQueryProvider/useCreateQueryClient";
+import { ReactQueryProvider } from "../src/app/ReactQueryProvider/ReactQueryProvider";
 import "../src/global.css";
 
 initialize();
-
-const ReactQueryProvider = ({ children }: { children: React.ReactNode }) => {
-  const queryClient = useCreateQueryClient();
-
-  return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
-};
 
 const WithProviders = (Story, context) => {
   const { initialEntries, initialIndex } =

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,18 +8,24 @@ import "../src/global.css";
 
 initialize();
 
-const WithProviders = (Story, context) => {
+const ReactQueryProvider = ({ children }: { children: React.ReactNode }) => {
   const queryClient = useCreateQueryClient();
 
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const WithProviders = (Story, context) => {
   const { initialEntries, initialIndex } =
     context.parameters.memoryRouter || {};
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
+    <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
+      <ReactQueryProvider>
         <Story />
-      </MemoryRouter>
-    </QueryClientProvider>
+      </ReactQueryProvider>
+    </MemoryRouter>
   );
 };
 

--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -57,8 +57,6 @@ export const getNewAccessToken = async ({
         return;
       }
 
-      // 현재 ReactQueryProvider 는 ReactRouterDom 내부에 존재하지 않기에 window 를 이용해 직접 라우팅 시킵니다.
-      // TODO : 추후 ReactQueryProvider 를 ReactRouterDom 내부로 이동시키고, useNavigate 를 이용해 라우팅 시키도록 수정합니다.
       navigate(ROUTER_PATH.LOGIN);
       return;
     }

--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -1,18 +1,25 @@
+import { NavigateFunction } from "react-router-dom";
 import type { QueryClient } from "@tanstack/react-query";
+import { ROUTER_PATH } from "@/shared/constants";
 import { AuthStore } from "@/shared/store";
 import { APP_END_POINT, ERROR_MESSAGE } from "./constants";
 
 export const getNewAccessToken = async ({
-  setterMethods,
   queryClient,
+  setterMethods,
+  navigateMethod,
 }: {
   setterMethods: {
     setToken: AuthStore["setToken"];
     resetAuthStore: AuthStore["reset"];
   };
+  navigateMethod: {
+    navigate: NavigateFunction;
+  };
   queryClient: QueryClient;
 }) => {
   const { setToken, resetAuthStore } = setterMethods;
+  const { navigate } = navigateMethod;
 
   // 해당 try-catch 문은 access token 을 refresh token 을 이용해 재발급 받는 로직입니다.
   try {
@@ -56,7 +63,7 @@ export const getNewAccessToken = async ({
 
       // 현재 ReactQueryProvider 는 ReactRouterDom 내부에 존재하지 않기에 window 를 이용해 직접 라우팅 시킵니다.
       // TODO : 추후 ReactQueryProvider 를 ReactRouterDom 내부로 이동시키고, useNavigate 를 이용해 라우팅 시키도록 수정합니다.
-      // window.location.href = ROUTER_PATH.LOGIN;
+      navigate(ROUTER_PATH.LOGIN);
       return;
     }
 

--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -6,20 +6,16 @@ import { APP_END_POINT, ERROR_MESSAGE } from "./constants";
 
 export const getNewAccessToken = async ({
   queryClient,
-  setterMethods,
-  navigateMethod,
+  callbackFunctions,
 }: {
-  setterMethods: {
+  queryClient: QueryClient;
+  callbackFunctions: {
     setToken: AuthStore["setToken"];
     resetAuthStore: AuthStore["reset"];
-  };
-  navigateMethod: {
     navigate: NavigateFunction;
   };
-  queryClient: QueryClient;
 }) => {
-  const { setToken, resetAuthStore } = setterMethods;
-  const { navigate } = navigateMethod;
+  const { setToken, resetAuthStore, navigate } = callbackFunctions;
 
   // 해당 try-catch 문은 access token 을 refresh token 을 이용해 재발급 받는 로직입니다.
   try {

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
 import { useAuthStore } from "@/shared/store";
 import { ERROR_MESSAGE } from "./constants";
@@ -7,6 +8,7 @@ import { getNewAccessToken } from "./errorHandlers";
 export const useCreateQueryClient = () => {
   const setToken = useAuthStore((state) => state.setToken);
   const resetAuthStore = useAuthStore((state) => state.reset);
+  const navigate = useNavigate();
 
   const queryClient = useRef(
     new QueryClient({
@@ -35,6 +37,7 @@ export const useCreateQueryClient = () => {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getNewAccessToken({
                 setterMethods: { setToken, resetAuthStore },
+                navigateMethod: { navigate },
                 queryClient,
               });
               break;
@@ -50,6 +53,7 @@ export const useCreateQueryClient = () => {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getNewAccessToken({
                 setterMethods: { setToken, resetAuthStore },
+                navigateMethod: { navigate },
                 queryClient,
               });
 

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -36,9 +36,8 @@ export const useCreateQueryClient = () => {
           switch (error.message) {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getNewAccessToken({
-                setterMethods: { setToken, resetAuthStore },
-                navigateMethod: { navigate },
                 queryClient,
+                callbackFunctions: { setToken, resetAuthStore, navigate },
               });
               break;
             }
@@ -52,9 +51,8 @@ export const useCreateQueryClient = () => {
           switch (error.message) {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getNewAccessToken({
-                setterMethods: { setToken, resetAuthStore },
-                navigateMethod: { navigate },
                 queryClient,
+                callbackFunctions: { setToken, resetAuthStore, navigate },
               });
 
               const { options, state } = mutation;


### PR DESCRIPTION
# 관련 이슈 번호
close #274 
# 설명
![hihi](https://github.com/user-attachments/assets/0d2072f7-afc7-445c-924a-a3a08cbcb79d)

![image](https://github.com/user-attachments/assets/2a874376-5f68-4d27-8485-a05651d73abb)

#269 에서 진행 후 `QueryClient` 의 에러 핸들링 부분에서 로그아웃 시 `/login` 페이지로 리다이렉션 되도록 기능 추가 했습니다.

변경된 코드 내역은 주석처리 되었던 부분을 `naviate` 를 인수로 받아 라우팅 시키는 역할을 합니다.


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
