### PR TITLE
[Hotfix] Modal.Button에서 충돌 일으키는 클래스 제거

### DIFF
--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -76,7 +76,7 @@ const FilledButton = ({
     onClick={onClick}
     fullWidth={false}
     {...rest}
-    className={`flex flex-1 ${className}`}
+    className={className}
   >
     {children}
   </Button>
@@ -96,7 +96,7 @@ const TextButton = ({
     size={size}
     onClick={onClick}
     fullWidth={false}
-    className={`flex flex-1 ${className}`}
+    className={className}
     {...rest}
   >
     {children}


### PR DESCRIPTION
# 관련 이슈 번호
close #288 
# 설명

## 버그 설명

![image](https://github.com/user-attachments/assets/1753fb0f-7242-4890-9e10-e4ee2b680b33)

#285  에서 설정해둔 모달 버튼들의 추가 클래스 명인 `flex flex-grow` 부분이 문제를 일으키고 있습니다 

```tsx
 <Button
    variant="text"
    colorType={colorType}
    size={size}
    onClick={onClick}
    fullWidth={false}
    className={`flex flex-1 ${className}`}
    {...rest}
  >
```

버튼 내부에 이미 `inline-flex` 속성이 존재하는데 `flex, flex-1` 을 따로 설정해줘서 충돌이 일어나는듯 싶습니다.

이에 모달 시스템에서 정적으로 추가 된 클래스인 `flex , flex-1` 을 제거하도록 합니다. 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
