### PR TITLE
[Hotfix] Modal.Footer 의 axis 에 따라 버튼의 클래스 명을 동적으로 변경하도록 수정

### DIFF
--- a/src/shared/ui/modal/Modal.mocks.tsx
+++ b/src/shared/ui/modal/Modal.mocks.tsx
@@ -12,33 +12,25 @@ export const CenterModal = ({
 }) => {
   return (
     <Modal modalType="center" id={id}>
-      <h1>Center Modal 입니다.</h1>
-      <p>
-        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Ratione ipsa
-        quisquam adipisci delectus nulla assumenda ut a, corporis sed corrupti
-        quas repudiandae illo, similique sunt, quaerat quod nesciunt magnam
-        labore?
-      </p>
-      <p>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quidem aliquam
-        dolores necessitatibus nemo in nulla qui? Molestiae modi eaque fugiat
-        quo quae consectetur sit ullam, ducimus, nemo, necessitatibus odit
-        repellendus.
-      </p>
-      <p>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempore fugiat
-        similique, minima perferendis tenetur explicabo deserunt voluptatem quae
-        temporibus soluta corrupti, nesciunt laborum suscipit sint perspiciatis
-        sit quaerat natus voluptatibus.
-      </p>
-      <div className="flex justify-end px-2 py-2">
-        <button
-          onClick={onClose}
-          className="rounded-xl border px-2 py-2 text-tangerine-500"
+      <Modal.Header onClick={onClose}>CenterModal</Modal.Header>
+      <Modal.Content>
+        <p>CenterModal 입니다.</p>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Nostrum
+          dignissimos tenetur laboriosam commodi.
+        </p>
+      </Modal.Content>
+      <Modal.Footer axis="col">
+        <Modal.FilledButton
+          onClick={() => {
+            console.log("저장!");
+            onClose();
+          }}
         >
-          모달 닫기
-        </button>
-      </div>
+          저장
+        </Modal.FilledButton>
+        <Modal.TextButton onClick={onClose}>취소</Modal.TextButton>
+      </Modal.Footer>
     </Modal>
   );
 };
@@ -50,35 +42,27 @@ export const FullPageModal = ({
 }) => {
   return (
     <Modal modalType="fullPage">
-      <h1 className="text-center">FullPage Modal 입니다.</h1>
-      <p className="mx-4 my-4">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Nostrum
-        dignissimos tenetur laboriosam commodi. Ducimus facilis cum autem
-        consequatur, accusantium animi velit corporis minima nihil quia aliquid
-        sapiente neque cumque dolore?
-      </p>
-      <p className="mx-4 my-4">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Nostrum
-        dignissimos tenetur laboriosam commodi. Ducimus facilis cum autem
-        consequatur, accusantium animi velit corporis minima nihil quia aliquid
-        sapiente neque cumque dolore?
-      </p>
-      <p className="mx-4 my-4">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Nostrum
-        dignissimos tenetur laboriosam commodi. Ducimus facilis cum autem
-        consequatur, accusantium animi velit corporis minima nihil quia aliquid
-        sapiente neque cumque dolore?
-      </p>
-      <div>
-        <div className="flex justify-end px-2 py-2">
-          <button
-            onClick={onClose}
-            className="rounded-xl border px-2 py-2 text-tangerine-500"
-          >
-            모달 닫기
-          </button>
-        </div>
-      </div>
+      <Modal.Header onClick={onClose}>FullPageModal</Modal.Header>
+      <Modal.Content>
+        <p>버튼은 Stacked 형태 입니다.</p>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatibus
+          temporibus recusandae consectetur culpa adipisci minus, corporis ab
+          excepturi tempora magni, sed possimus nesciunt est, sunt non debitis
+          maxime porro neque.
+        </p>
+      </Modal.Content>
+      <Modal.Footer axis="row">
+        <Modal.FilledButton
+          onClick={() => {
+            console.log("저장!");
+            onClose();
+          }}
+        >
+          저장
+        </Modal.FilledButton>
+        <Modal.TextButton onClick={onClose}>취소</Modal.TextButton>
+      </Modal.Footer>
     </Modal>
   );
 };

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactElement } from "react";
 import { Button } from "../button";
 import { ButtonProps } from "../button/Button";
 import { CloseIcon } from "../icon";
@@ -59,7 +59,19 @@ const Footer = ({
 }: {
   children: React.ReactNode;
   axis: "row" | "col";
-}) => <section className={`flex gap-2 flex-${axis}`}>{children}</section>;
+}) => {
+  return (
+    <section className={`flex gap-2 flex-${axis}`}>
+      {React.Children.map(children, (child) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child as ReactElement, {
+              axis,
+            })
+          : child,
+      )}
+    </section>
+  );
+};
 
 const FilledButton = ({
   onClick,
@@ -67,10 +79,12 @@ const FilledButton = ({
   size = "medium",
   className = "",
   children,
+  axis,
   ...rest
 }: Partial<Omit<ButtonProps, "variant">> & {
   children: React.ReactNode;
   onClick: ButtonProps["onClick"];
+  axis?: "row" | "col";
 }) => (
   <Button
     variant="filled"
@@ -79,7 +93,7 @@ const FilledButton = ({
     onClick={onClick}
     fullWidth={false}
     {...rest}
-    className={className}
+    className={`${axis === "row" && "flex-1"} ${className}`}
   >
     {children}
   </Button>
@@ -91,10 +105,12 @@ const TextButton = ({
   size = "medium",
   className = "",
   children,
+  axis,
   ...rest
 }: Partial<Omit<ButtonProps, "variant">> & {
   children: React.ReactNode;
   onClick: ButtonProps["onClick"];
+  axis?: "row" | "col";
 }) => (
   <Button
     variant="text"
@@ -102,7 +118,7 @@ const TextButton = ({
     size={size}
     onClick={onClick}
     fullWidth={false}
-    className={className}
+    className={`${axis === "row" && "flex-1"} ${className}`}
     {...rest}
   >
     {children}

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -68,7 +68,10 @@ const FilledButton = ({
   className = "",
   children,
   ...rest
-}: Partial<Omit<ButtonProps, "variant">> & { children: React.ReactNode }) => (
+}: Partial<Omit<ButtonProps, "variant">> & {
+  children: React.ReactNode;
+  onClick: ButtonProps["onClick"];
+}) => (
   <Button
     variant="filled"
     colorType={colorType}
@@ -89,7 +92,10 @@ const TextButton = ({
   className = "",
   children,
   ...rest
-}: Partial<Omit<ButtonProps, "variant">> & { children: React.ReactNode }) => (
+}: Partial<Omit<ButtonProps, "variant">> & {
+  children: React.ReactNode;
+  onClick: ButtonProps["onClick"];
+}) => (
   <Button
     variant="text"
     colorType={colorType}


### PR DESCRIPTION
# 관련 이슈 번호
close #290
# 설명

## 버그 설명


```tsx
const Footer = ({
  children,
  axis,
}: {
  children: React.ReactNode;
  axis: "row" | "col";
}) => <section className={`flex gap-2 flex-${axis}`}>{children}</section>;

const FilledButton = ({
  onClick,
  colorType = "primary",
  size = "medium",
  className = "",
  children,
  ...rest
}: Partial<Omit<ButtonProps, "variant">> & { children: React.ReactNode }) => (
  <Button
    variant="filled"
    colorType={colorType}
    size={size}
    onClick={onClick}
    fullWidth={false}
    {...rest}
    className={className}
  >
    {children}
  </Button>
);

const TextButton = ({
  onClick,
  colorType = "primary",
  size = "medium",
  className = "",
  children,
  ...rest
}: Partial<Omit<ButtonProps, "variant">> & { children: React.ReactNode }) => (
  <Button
    variant="text"
    colorType={colorType}
    size={size}
    onClick={onClick}
    fullWidth={false}
    className={className}
    {...rest}
  >
    {children}
  </Button>
);
```

현재의 문제는 다음과 같습니다. 

모달 안에 들어가는 버튼들은 단순히 하나의 버튼으로 사용 될 수 없습니다.

`Button` 컴포넌트는 기본적으로 `inline-flex , h-12` 라는 클래스 명을 가지고 있고 상황에 따라 `fullWidth` 값을 `props` 값을 받아 컨테이너 태그 요소의 너비를 100% 받기도 합니다만 현재는 너비를 받지 않고 인라인 요소처럼 작동 합니다. 

![image](https://github.com/user-attachments/assets/207d1f4a-b5de-4dce-85d4-e6a9653a98d2)

현재의 상황은 다음과 같이 `Footer axis = row` 일 땐 아주 멋지게 작동 합니다. 

하지만 문제는 지금과 같은 상황에서 발생 합니다.

![image](https://github.com/user-attachments/assets/8aed4d5d-58a2-40c7-a856-3c0cb1b3be79)

`footer` 의 `axis` 가 `row` 일 땐 버튼의 인라인 요소 특성이 이러한 문제를 야기 합니다. 

`axis` 가 `row` 여서 버튼이 나란히 나열되어야 할 땐  클래스명으로 `flex-1` 을 넣어줘야 버튼들이 모두 서로 같은 크기를 가지고 `Footer` 요소를 채울 수 있습니다. 

따라서 우린 `axis` 값이 `row , col`  인지에 따라 버튼에 다른 클래스 명을 넣어줘야 합니다.

> ### 그냥 `flex-1` 을 넣어두면 되는거 아닌가  ?
> ![image](https://github.com/user-attachments/assets/cf9b274b-41ca-47b4-8ce1-d22f71285dc1)
> 그렇게 되게 되면 axis 가 col 일 때의 버튼들이 문제 입니다.
> 높이를 h-12 로 설정해주었더라도 flex-grow 가 우선적으로 적용되어 부모의 높이만큼 늘어나게 되는데 부모의 높이가 없기 때문에 인라인 요소처럼 글자까지만 나타나게 됩니다.

### 버그가 발생한 상황

### 예상 해결 방안

가장 간단한 방법은 각 버튼들에도 `axis` 를 `props` 로 받아 해당 `props` 에 따라 서로 다른 `className` 을 갖는 것일 것입니다.

그런데 그 방법은 너무나도 귀찮습니다.

그래서 ! `Footer` 에서 본인의 `axis` 를 하위 요소들에게 `context`로 내려주고 해당 `axis` 를 소모하여 클래스명을  설정하도록 하겠습니다. 
---

# 해결 방법 

버튼들의 상위 요소인 `Footer` 컴포넌트에서 `children` 컴포넌트들에게 강제로 `axis` props 값을 설정하여 

복사한 엘리먼트를 만듭니다.

```tsx

const Footer = ({
  children,
  axis,
}: {
  children: React.ReactNode;
  axis: "row" | "col";
}) => {
  return (
    <section className={`flex gap-2 flex-${axis}`}>
      {React.Children.map(children, (child) =>
        React.isValidElement(child)
          ? React.cloneElement(child as ReactElement, {
              axis,
            })
          : child,
      )}
    </section>
  );
};
```

그렇게 되면 `axis`  를 `props` 로 받는 컴포넌트들은 해당 값이 적용된 채로 `React.Element` 형태로 렌더링 됩니다.

```tsx

const FilledButton = ({
  onClick,
  colorType = "primary",
  size = "medium",
  className = "",
  children,
  axis,
  ...rest
}: Partial<Omit<ButtonProps, "variant">> & {
  children: React.ReactNode;
  onClick: ButtonProps["onClick"];
  axis?: "row" | "col";
}) => (
  <Button
    variant="filled"
    colorType={colorType}
    size={size}
    onClick={onClick}
    fullWidth={false}
    {...rest}
    className={`${axis === "row" && "flex-1"} ${className}`}
  >
    {children}
  </Button>
);
```



### 첨부 파일 (Optional)

## 버그 발생 코드 (Optional)

### 레퍼런스 이슈 (Optional)


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
