### PR TITLE
[Feat] 내 정보 수정 페이지 ui

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -4,6 +4,7 @@ import { EmailLoginPage } from "@/pages/login/email";
 import { MapPage } from "@/pages/map";
 import { MyPage } from "@/pages/my-page";
 import { SettingPage } from "@/pages/my-page/setting";
+import { EditInfoPage } from "@/pages/my-page/setting/edit-info/page";
 import { AccountManagementPage } from "@/pages/my-page/setting/manage-account";
 import { SignUpPage } from "@/pages/sign-up";
 import PetInfoPage from "@/pages/sign-up/pet-info/page";
@@ -42,6 +43,10 @@ export const router = createBrowserRouter([
               {
                 path: ROUTER_PATH.MANAGE_ACCOUNT,
                 element: <AccountManagementPage />,
+              },
+              {
+                path: ROUTER_PATH.EDIT_MY_INFO,
+                element: <EditInfoPage />,
               },
             ],
           },

--- a/src/mocks/data/myInfo.json
+++ b/src/mocks/data/myInfo.json
@@ -4,12 +4,18 @@
   "age": 30,
   "regions": [
     {
-      "id": 1,
-      "name": "Region1"
+      "id": 3563,
+      "province": "울산광역시",
+      "cityCounty": "북구",
+      "district": null,
+      "subDistrict": "명촌동"
     },
     {
-      "id": 2,
-      "name": "Region2"
+      "id": 3564,
+      "province": "울산광역시",
+      "cityCounty": "북구",
+      "district": null,
+      "subDistrict": "명촌동"
     }
   ],
   "nickLastModDt": "2023-10-01T12:34:56Z",

--- a/src/pages/my-page/setting/edit-info/index.ts
+++ b/src/pages/my-page/setting/edit-info/index.ts
@@ -1,0 +1,1 @@
+export * from "./page";

--- a/src/pages/my-page/setting/edit-info/page.tsx
+++ b/src/pages/my-page/setting/edit-info/page.tsx
@@ -1,0 +1,94 @@
+import { MyInfo, useGetMyInfo } from "@/entities/auth/api";
+import { useAuthStore } from "@/shared/store";
+import { ActionChip } from "@/shared/ui/chip";
+import { ArrowRightIcon } from "@/shared/ui/icon";
+import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+
+export const EditInfoPage = () => {
+  const token = useAuthStore((state) => state.token);
+  const { data: myInfo } = useGetMyInfo({ token });
+
+  if (!myInfo) {
+    return null;
+  }
+
+  const { age, gender, regions } = myInfo;
+
+  return (
+    <>
+      <BackwardNavigationBar
+        label={<h1 className="title-1 text-grey-700">내 정보 수정</h1>}
+      />
+
+      <section className="flex flex-col gap-4 px-4 py-4">
+        <Nickname />
+        <Age age={age} />
+        <Gender gender={gender} />
+        <RegionSetting regions={regions} />
+      </section>
+    </>
+  );
+};
+
+const Nickname = () => {
+  const nickname = useAuthStore((state) => state.nickname);
+
+  return (
+    <div className="setting-item">
+      <span>닉네임 변경</span>
+
+      <div className="flex items-center text-grey-500">
+        <span className="body-2">{nickname}</span>
+        <ArrowRightIcon />
+      </div>
+    </div>
+  );
+};
+
+const Gender = ({ gender }: Pick<MyInfo, "gender">) => {
+  return (
+    <div className="setting-item">
+      <span>성별 변경</span>
+
+      <div className="flex items-center text-grey-500">
+        <span className="body-2">{gender === "MALE" ? "남자" : "여자"}</span>
+        <ArrowRightIcon />
+      </div>
+    </div>
+  );
+};
+
+const Age = ({ age }: Pick<MyInfo, "age">) => {
+  return (
+    <div className="setting-item">
+      <span>나이대 변경</span>
+
+      <div className="flex items-center text-grey-500">
+        <span className="body-2">{age}</span>
+        <ArrowRightIcon />
+      </div>
+    </div>
+  );
+};
+
+const RegionSetting = ({ regions }: Pick<MyInfo, "regions">) => {
+  return (
+    <div>
+      <div className="setting-item">
+        <span>동네설정</span>
+
+        <div className="text-grey-500">
+          <ArrowRightIcon />
+        </div>
+      </div>
+
+      <ul className="flex items-start gap-2 self-stretch overflow-auto pb-4">
+        {regions.map(({ id, subDistrict }) => (
+          <ActionChip key={id} variant="outlined" isSelected={true}>
+            {subDistrict}
+          </ActionChip>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/pages/my-page/setting/edit-info/page.tsx
+++ b/src/pages/my-page/setting/edit-info/page.tsx
@@ -21,59 +21,59 @@ export const EditInfoPage = () => {
       />
 
       <section className="flex flex-col gap-4 px-4 py-4">
-        <Nickname />
-        <Age age={age} />
-        <Gender gender={gender} />
-        <RegionSetting regions={regions} />
+        <NicknameButton />
+        <GenderButton gender={gender} />
+        <AgeButton age={age} />
+        <RegionSettingButton regions={regions} />
       </section>
     </>
   );
 };
 
-const Nickname = () => {
+const NicknameButton = () => {
   const nickname = useAuthStore((state) => state.nickname);
 
   return (
-    <div className="setting-item">
+    <button className="setting-item">
       <span>닉네임 변경</span>
 
       <div className="flex items-center text-grey-500">
         <span className="body-2">{nickname}</span>
         <ArrowRightIcon />
       </div>
-    </div>
+    </button>
   );
 };
 
-const Gender = ({ gender }: Pick<MyInfo, "gender">) => {
+const GenderButton = ({ gender }: Pick<MyInfo, "gender">) => {
   return (
-    <div className="setting-item">
+    <button className="setting-item">
       <span>성별 변경</span>
 
       <div className="flex items-center text-grey-500">
         <span className="body-2">{gender === "MALE" ? "남자" : "여자"}</span>
         <ArrowRightIcon />
       </div>
-    </div>
+    </button>
   );
 };
 
-const Age = ({ age }: Pick<MyInfo, "age">) => {
+const AgeButton = ({ age }: Pick<MyInfo, "age">) => {
   return (
-    <div className="setting-item">
+    <button className="setting-item">
       <span>나이대 변경</span>
 
       <div className="flex items-center text-grey-500">
         <span className="body-2">{age}</span>
         <ArrowRightIcon />
       </div>
-    </div>
+    </button>
   );
 };
 
-const RegionSetting = ({ regions }: Pick<MyInfo, "regions">) => {
+const RegionSettingButton = ({ regions }: Pick<MyInfo, "regions">) => {
   return (
-    <div>
+    <button>
       <div className="setting-item">
         <span>동네설정</span>
 
@@ -89,6 +89,6 @@ const RegionSetting = ({ regions }: Pick<MyInfo, "regions">) => {
           </ActionChip>
         ))}
       </ul>
-    </div>
+    </button>
   );
 };

--- a/src/pages/my-page/setting/page.tsx
+++ b/src/pages/my-page/setting/page.tsx
@@ -47,7 +47,7 @@ const AccountManagement = () => (
 );
 
 const EditMyInfo = () => (
-  <Link to="." className="setting-item">
+  <Link to={ROUTER_PATH.EDIT_MY_INFO} className="setting-item">
     <p>내 정보 수정</p>
     <span className="text-grey-500">
       <ArrowRightIcon />

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -105,6 +105,7 @@ export const ROUTER_PATH = {
   MY_PAGE: `/my-page`,
   SETTING: `/my-page/setting`,
   MANAGE_ACCOUNT: `/my-page/setting/manage-account`,
+  EDIT_MY_INFO: `/my-page/setting/edit-info`,
 
   LOGIN: `/login`,
   LOGIN_BY_EMAIL: `/login/email`,


### PR DESCRIPTION
# 관련 이슈 번호

#292 

# 설명

내 정보 페이지 ui를 만들었습니다.

<img width="638" alt="스크린샷 2024-10-13 오전 12 46 33" src="https://github.com/user-attachments/assets/f02f5acd-91fa-4f34-be7f-6c0f47d9cda0">

보니까 ActionChip과 SelectChip을 리팩토링해야 할 것 같습니다.
SelectChip은 ActionChip으로도 만들 수 있더라구요. 그리고 둘의 기능이 똑같습니다!

지금 동네리스트 표현할 때 ActionChip을 이용해서 hover하거나 focus, 클릭도 가능합니다.

사실 ActionChip에서 핸들러를 받지 않았을 때 인터렉션 일어나지 못하는 식으로 수정하면, 충분히 동네 리스트에서 ActionChip을 쓸 수 있다고 생각합니다.
이 부분에 대해 어떻게 생각하시는지 코멘트 남겨주세요!


