### PR TITLE
[Feat] query , mutation 테스트를 위한 핸들러 내부 가상 DB 생성

### DIFF
--- a/src/mocks/data/myInfo.json
+++ b/src/mocks/data/myInfo.json
@@ -45,6 +45,6 @@
     ],
     "nickLastModDt": "2023-10-01T12:34:56Z",
     "socialType": "NAVER",
-    "isPasswordSet": true
+    "isPasswordSet": false
   }
 }

--- a/src/mocks/data/myInfo.json
+++ b/src/mocks/data/myInfo.json
@@ -1,24 +1,50 @@
 {
-  "email": "example@example.com",
-  "gender": "MALE",
-  "age": 30,
-  "regions": [
-    {
-      "id": 3563,
-      "province": "울산광역시",
-      "cityCounty": "북구",
-      "district": null,
-      "subDistrict": "명촌동"
-    },
-    {
-      "id": 3564,
-      "province": "울산광역시",
-      "cityCounty": "북구",
-      "district": null,
-      "subDistrict": "명촌동"
-    }
-  ],
-  "nickLastModDt": "2023-10-01T12:34:56Z",
-  "socialType": "NAVER",
-  "isPasswordSet": true
+  "EMAIL": {
+    "email": "example@example.com",
+    "gender": "MALE",
+    "age": 30,
+    "regions": [
+      {
+        "id": 3563,
+        "province": "울산광역시",
+        "cityCounty": "북구",
+        "district": null,
+        "subDistrict": "명촌동"
+      },
+      {
+        "id": 3564,
+        "province": "울산광역시",
+        "cityCounty": "북구",
+        "district": null,
+        "subDistrict": "명촌동"
+      }
+    ],
+    "nickLastModDt": "2023-10-01T12:34:56Z",
+    "socialType": "EMAIL",
+    "isPasswordSet": true
+  },
+  "NAVER": {
+    "email": "example@naver.com",
+    "gender": "MALE",
+    "age": 30,
+    "regions": [
+      {
+        "id": 3563,
+        "province": "울산광역시",
+        "cityCounty": "북구",
+        "district": null,
+        "subDistrict": "명촌동"
+      },
+      {
+        "id": 3564,
+        "province": "울산광역시",
+        "cityCounty": "북구",
+        "district": null,
+        "subDistrict": "명촌동"
+      }
+    ],
+    "nickLastModDt": "2023-10-01T12:34:56Z",
+    "socialType": "NAVER",
+    "isPasswordSet": true
+  }
 }

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -5,6 +5,7 @@ import { LOGIN_END_POINT, SIGN_UP_END_POINT } from "@/features/auth/constants";
 import { MarkingListRequest } from "@/features/marking/api";
 import { MARKING_REQUEST_URL } from "@/features/marking/constants";
 import { SETTING_END_POINT } from "@/features/setting/constants";
+import { MyInfo } from "@/entities/auth/api";
 import { MY_INFO_END_POINT } from "@/entities/auth/constants";
 import { API_BASE_URL } from "@/shared/constants";
 import User from "../mocks/data/user.json";
@@ -34,7 +35,16 @@ interface UserDB {
   [key: string]: UserInfo;
 }
 
+interface UserInfoDB {
+  [key: string]: MyInfo;
+}
+
 const userDB: UserDB = {};
+
+const userInfoDB: UserInfoDB = {
+  뽀송송_EMAIL: userInfoData["EMAIL"] as MyInfo,
+  뽀송송_NAVER: userInfoData["NAVER"] as MyInfo,
+};
 
 export const signUpByEmailHandlers = [
   http.post<
@@ -202,10 +212,18 @@ export const userInfoRegistrationHandlers = [
       );
     }
 
+    if (token === "freshAccessToken_naver") {
+      return HttpResponse.json({
+        code: 200,
+        message: "success",
+        content: userInfoDB["뽀송송_NAVER"],
+      });
+    }
+
     return HttpResponse.json({
       code: 200,
       message: "success",
-      content: userInfoData,
+      content: userInfoDB["뽀송송_EMAIL"],
     });
   }),
 ];


### PR DESCRIPTION
# 관련 이슈 번호
close #299 
# 설명
현재 각 핸들러들은 단순히 요청값만 받고 가상의 데이터만 제공하고 있을 뿐 실제 유저 정보에 일어난 mutation 에 대해 적용되고 있지 않습니다.

이에 메모리 상에 존재 할 가상 DB를 객체 형태로 만들어두고 각 핸들러들이 해당 DB 를 바라볼 수 있도록 하여

query 문과 mutation 들이 실제로 잘 적용 될 수 있도록 하기 위해 핸들러에서 가상 DB 와 가상 유저 정보를 생성해두록 합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
