### PR TITLE
[Feat] Modal.Footer 에서 클래스명 받도록 확장

### DIFF
--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -56,12 +56,14 @@ const Content = ({
 const Footer = ({
   children,
   axis,
+  className = "",
 }: {
   children: React.ReactNode;
   axis: "row" | "col";
+  className?: string;
 }) => {
   return (
-    <section className={`flex gap-2 flex-${axis}`}>
+    <section className={`flex gap-2 flex-${axis} ${className}`}>
       {React.Children.map(children, (child) =>
         React.isValidElement(child)
           ? React.cloneElement(child as ReactElement, {


### PR DESCRIPTION
# 관련 이슈 번호
close #304 

# 설명

```tsx
const Footer = ({
  children,
  axis,
}: {
  children: React.ReactNode;
  axis: "row" | "col";
}) => {
  return (
    <section className={`flex gap-2 flex-${axis}`}>
      {React.Children.map(children, (child) =>
        React.isValidElement(child)
          ? React.cloneElement(child as ReactElement, {
              axis,
            })
          : child,
      )}
    </section>
  );
};
```

`Modal.Footer` 에서 동적으로 클래스명을 받아 확장 가능하도록 기능을 수정 합니다. 



# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
