### PR TITLE
[Feat] hyperlink Link 컴포넌트에서 a 태그로 변경

### DIFF
--- a/src/features/auth/ui/hyperlinks.tsx
+++ b/src/features/auth/ui/hyperlinks.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, useEffect } from "react";
+import { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { NaverIcon, GoogleIcon } from "@/entities/auth/assets";
@@ -20,26 +20,24 @@ const hyperLinkColorMap = {
 const LoginHyperLinkClass =
   "flex h-12 items-center justify-center gap-[10px] self-stretch rounded-2xl pl-4 pr-6";
 
-const NaverLoginHyperLink = (props: HTMLAttributes<HTMLAnchorElement>) => (
-  <Link
+const NaverLoginHyperLink = () => (
+  <a
     className={`${LoginHyperLinkClass} ${hyperLinkColorMap.naver} `}
-    to={LOGIN_END_POINT.NAVER}
-    {...props}
+    href={LOGIN_END_POINT.NAVER}
   >
     <NaverIcon />
     <p className="button-2 text-center text-grey-0">Naver로 계속하기</p>
-  </Link>
+  </a>
 );
 
-const GoogleLoginHyperLink = (props: HTMLAttributes<HTMLAnchorElement>) => (
-  <Link
+const GoogleLoginHyperLink = () => (
+  <a
     className={`${LoginHyperLinkClass} ${hyperLinkColorMap.google}`}
-    {...props}
-    to={LOGIN_END_POINT.GOOGLE}
+    href={LOGIN_END_POINT.GOOGLE}
   >
     <GoogleIcon />
     <p className="button-2 text-center text-grey-900">Google로 계속하기</p>
-  </Link>
+  </a>
 );
 
 /* ----------------------------------컴포넌트 외부로 export 되어 사용되는 컴포넌트------------------------------- */


### PR DESCRIPTION
# 관련 이슈 번호
close #309 
# 설명

2024/10/11 에 시행했던 간이 테스트에서 발생한 문제인 

소셜 로그인 진입 컴포넌트를 `Link` 컴포넌트에서 `a` 태그로 변경 합니다. 


![image](https://github.com/user-attachments/assets/c8017ebb-b2f5-4221-bca6-68541805101f)

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
