### PR TITLE
[Hotfix] 닉네임 중복 검사 시 토큰 함께 보내도록 API 요청 수정

### DIFF
--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import { ROUTER_PATH } from "@/shared/constants";
-import { useAuthStore } from "@/shared/store";
+import { AuthStore, useAuthStore } from "@/shared/store";
 import { SIGN_UP_END_POINT } from "../constants";
 
 export interface VerificationCodeRequestData {
@@ -155,6 +155,7 @@ export const usePostSignUpByEmail = () => {
 
 export interface DuplicateNicknameRequestData {
   nickname: string;
+  token: NonNullable<AuthStore["token"]>;
 }
 
 export interface DuplicateNicknameResponse {
@@ -164,11 +165,13 @@ export interface DuplicateNicknameResponse {
 
 const postDuplicateNickname = async ({
   nickname,
+  token,
 }: DuplicateNicknameRequestData) => {
   const response = await fetch(SIGN_UP_END_POINT.DUPLICATE_NICKNAME, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      Authorization: token,
     },
     body: JSON.stringify({ nickname }),
   });

--- a/src/features/auth/ui/UserInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/UserInfoRegistrationForm.tsx
@@ -51,8 +51,9 @@ const NicknameInput = () => {
 
   const handleBlur = () => {
     if (!isValidNickname || isNicknameEmpty) return;
+    const { token } = useAuthStore.getState();
 
-    postDuplicateNickname({ nickname });
+    postDuplicateNickname({ nickname, token: token! });
   };
 
   let statusText = "20자 이내의 한글 영어 숫자만 사용 가능합니다.";


### PR DESCRIPTION
# 관련 이슈 번호
close #313 
# 설명
2024/10/13 시 발견된 user-info 페이지에서 닉네임 중복 검사 시 토큰을 함께 보내지 않던 로직을 수정 합니다. 

![image](https://github.com/user-attachments/assets/8380795e-262f-431e-be3d-667801b2cb45)

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
