### PR TITLE
[Refactor] 이미지 경로 수정

### DIFF
--- a/src/entities/marking/ui/dashboard.tsx
+++ b/src/entities/marking/ui/dashboard.tsx
@@ -16,8 +16,8 @@ export const MarkingThumbnailGrid = ({
     <div className="grid grid-cols-3 gap-2 w-full">
       {markings.map(({ id, image }) => (
         <img
-          src={`${API_BASE_URL}/markings/image/${image}`}
           key={id}
+          src={`${API_BASE_URL}/markings/image/${id}/${image}`}
           alt={`마킹 번호 ${id}의 썸네일 이미지`}
           className="w-full h-full object-cover rounded-lg aspect-square"
         />

--- a/src/entities/profile/ui/dashboard.tsx
+++ b/src/entities/profile/ui/dashboard.tsx
@@ -19,7 +19,7 @@ export const ProfileImage = ({ profile, nickname }: ProfileImageProps) => {
         profile ? `${API_BASE_URL}/pets/image/${profile}` : "/default-image.png"
       }
       alt={`${nickname} 의 프로필 사진`}
-      className="w-16 h-16 rounded-[1.75rem]"
+      className="w-16 h-16 rounded-[1.75rem] object-cover"
     />
   );
 };

--- a/src/features/map/ui/mapControlButton.tsx
+++ b/src/features/map/ui/mapControlButton.tsx
@@ -100,7 +100,7 @@ export const ShowMyMarkingButton = () => {
         // todo 내 마킹 보기로 상태 변경
       }}
     >
-      <img src="/public/default-image.png" className="w-7 h-7 rounded-full" />
+      <img src="/default-image.png" className="w-7 h-7 rounded-full" />
     </Button>
   );
 };

--- a/src/features/map/ui/mapMarkers.tsx
+++ b/src/features/map/ui/mapMarkers.tsx
@@ -36,13 +36,13 @@ export const MultiplePinMarker = () => {
   const multiMarkerInfo = [
     {
       position: { lat: 37.5664, lng: 126.974 },
-      imageUrl: "/public/default-image.png",
+      imageUrl: "/default-image.png",
       alt: "test",
       markerCount: 2,
     },
     {
       position: { lat: 37.5663, lng: 126.972 },
-      imageUrl: "/public/default-image.png",
+      imageUrl: "/default-image.png",
       alt: "test",
       markerCount: 500,
     },
@@ -73,7 +73,7 @@ export const ClusterMarker = () => {
 
 export const MarkingAddPin = () => {
   // TODO UserInfo API 나오면 유저 프로필 사진 붙이기
-  const profileImage = "/public/default-image.png";
+  const profileImage = "/default-image.png";
   const alt = "test";
 
   return (

--- a/src/features/map/ui/mapMarkers.tsx
+++ b/src/features/map/ui/mapMarkers.tsx
@@ -1,5 +1,6 @@
 import { useGetMarkingList } from "@/features/marking/api";
 import { User, Pin, MultiplePin, Cluster } from "@/entities/map/ui";
+import { API_BASE_URL } from "@/shared/constants";
 import { useMapStore } from "../store";
 
 /*---------- default mode 일 때에만 사용되는 마커입니다. ---------- */
@@ -18,15 +19,15 @@ export const UserMarker = () => {
 export const PinMarker = () => {
   const { data: markersInfo } = useGetMarkingList();
 
-  return markersInfo?.map((markerInfo) => (
+  return markersInfo?.map(({ markingId, lat, lng, images }) => (
     <Pin
-      key={markerInfo.markingId}
+      key={markingId}
       position={{
-        lat: markerInfo.lat,
-        lng: markerInfo.lng,
+        lat: lat,
+        lng: lng,
       }}
-      imageUrl={markerInfo.images[0].imageUrl}
-      alt={markerInfo.images[0].id.toString()}
+      imageUrl={`${API_BASE_URL}/markings/image/${markingId}/${images[0]}`}
+      alt={images[0].id.toString()}
     />
   ));
 };

--- a/src/features/marking/ui/markingItem.tsx
+++ b/src/features/marking/ui/markingItem.tsx
@@ -162,7 +162,7 @@ export const MarkingItem = ({
 
       <div className="flex justify-between items-center gap-1 flex-1">
         <img
-          className="w-8 h-8 rounded-2xl"
+          className="w-8 h-8 rounded-2xl object-cover"
           src={`${API_BASE_URL}/pets/image/${pet.profile}`}
           alt={`${pet.name}-profile`}
         />

--- a/src/features/marking/ui/markingItem.tsx
+++ b/src/features/marking/ui/markingItem.tsx
@@ -186,7 +186,7 @@ export const MarkingItem = ({
         {images.map(({ imageUrl, id }) => (
           <ImgSlider.ImgItem
             key={id}
-            src={`${API_BASE_URL}/${imageUrl}`}
+            src={`${API_BASE_URL}/markings/image/${markingId}/${imageUrl}`}
             alt={`${pet.name}의 마킹 이미지`}
           />
         ))}

--- a/src/features/marking/ui/markingItem.tsx
+++ b/src/features/marking/ui/markingItem.tsx
@@ -163,7 +163,7 @@ export const MarkingItem = ({
       <div className="flex justify-between items-center gap-1 flex-1">
         <img
           className="w-8 h-8 rounded-2xl"
-          src={`${API_BASE_URL}/${pet.profile}`}
+          src={`${API_BASE_URL}/pets/image/${pet.profile}`}
           alt={`${pet.name}-profile`}
         />
         <span className="title-3 text-grey-700">{nickName}</span>


### PR DESCRIPTION
# 관련 이슈 번호

#284

# 설명
잘못된 이미지 경로를 수정했습니다.

### 기본 아이콘 경로 수정

저희 서비스 기본 로고 강아지 url 변경했어요.

- ShowMyMarkingButton: 맵 페이지에서 [내마킹] 버튼
- MultiplePinMarker: multiMarkerInfo의 url
- MarkingAddPin: profileImage

### 핀 이미지 경로 수정: PinMarker

핀에 있는 이미지 경로

```typescript
export const PinMarker = () => {
  const { data: markersInfo } = useGetMarkingList();

  return markersInfo?.map(({ markingId, lat, lng, images }) => (
    <Pin
      key={markingId}
      position={{
        lat: lat,
        lng: lng,
      }}
      imageUrl={`${API_BASE_URL}/markings/image/${markingId}/${images[0].imageUrl}`}
      alt={images[0].id.toString()}
    />
  ));
};

```

### 마킹 아이템 이미지 경로 수정: MarkingItem

마킹 작성자 프로필
```typescript
<img
          className="w-8 h-8 rounded-2xl"
          src={`${API_BASE_URL}/pets/image/${pet.profile}`}
          alt={`${pet.name}-profile`}
/>
```

마킹 이미지들
```typescript
<ImgSlider>
        {images.map(({ imageUrl, id }) => (
          <ImgSlider.ImgItem
            key={id}
            src={`${API_BASE_URL}/markings/image/${markingId}/${imageUrl}`}
            alt={`${pet.name}의 마킹 이미지`}
          />
        ))}
</ImgSlider>
```

### 대시보드 이미지 경로: MarkingThumbnailGrid

대시보드에 있는 사용자 프로필 이미지
```typescript
 <img
          src={`${API_BASE_URL}/markings/image/${id}/${image}`}
          key={id}
          alt={`마킹 번호 ${id}의 썸네일 이미지`}
          className="w-full h-full object-cover rounded-lg aspect-square"
/>
```
