### PR TITLE
[Feat] petInfoForm이미지 없을 경우 멀티파트 폼에서 이미지 제출 하지 않도록 수정

### DIFF
--- a/src/features/auth/api/postPetInfo.ts
+++ b/src/features/auth/api/postPetInfo.ts
@@ -38,8 +38,6 @@ const postPetInfo = async ({
   if (profile) {
     const profileExtension = profile.type.split("/")[1];
     formData.append("image", profile, `${name}-profile.${profileExtension}`);
-  } else {
-    formData.append("image", "");
   }
 
   formData.append(


### PR DESCRIPTION
# 관련 이슈 번호
close #318
# 설명

2024/10/11 테스트 결과 이미지가 존재하지 않을 경우 formObject 에서 images 키 값을 제거한채로 보내주기로 하였습니다.

이에 해당 기능에 맞춰 변경 합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
