### PR TITLE
[Feat] 유저 개인 정보 제출 시 리프레쉬 토큰 함께 전송하도록 기능 수정

### DIFF
--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -227,6 +227,8 @@ const putUserInfoRegister = async ({
     headers: {
       "Content-Type": "application/json",
       Authorization: token,
+      credentials:
+        process.env.NODE_ENV === "development" ? "include" : "same-origin",
     },
     body: JSON.stringify(userInfo),
   });


### PR DESCRIPTION
# 관련 이슈 번호
close #320 
# 설명

2024/10/11 에 시행한 테스트 결과에 맞춰 

유저 개인 정보 제출 시 리프레쉬 토큰을 쿠키에 담아 함께 전송 하도록 합니다.


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
