### PR TITLE
[Hotfix] Modal 디자인 시스템 props 내려주는 방식 수정

### DIFF
--- a/src/shared/ui/modal/Modal.styles.ts
+++ b/src/shared/ui/modal/Modal.styles.ts
@@ -1,6 +1,6 @@
 export const modalStyles = {
   fullPage:
-    "left-0 top-0 h-full w-full max-w-[37.5rem] mx-auto flex flex-col gap-8 bg-grey-0 overflow-y-auto",
+    "left-0 top-0 px-4 h-full w-full max-w-[37.5rem] mx-auto flex flex-col gap-8 bg-grey-0 overflow-y-auto",
   center:
     "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 overflow-y-auto max-h-[calc(100vh-1rem)]",
 } as const;

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -50,7 +50,11 @@ const Header = ({
       className={`flex justify-between ${modalType === "fullPage" && "py-2"}`}
     >
       <h1 className="title-1 text-grey-900">{children}</h1>
-      <button onClick={onClick} aria-label={closeButtonAriaLabel}>
+      <button
+        onClick={onClick}
+        aria-label={closeButtonAriaLabel}
+        className={`${modalType === "fullPage" && "px-3 py-3"}`}
+      >
         <CloseIcon />
       </button>
     </header>

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -1,16 +1,19 @@
-import React, { ReactElement } from "react";
+import React from "react";
+import { createContext, useContext } from "react";
 import { Button } from "../button";
 import { ButtonProps } from "../button/Button";
 import { CloseIcon } from "../icon";
 import { modalStyles } from "./Modal.styles";
 
 type ModalType = keyof typeof modalStyles;
-
 interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   modalType: ModalType;
   className?: string;
 }
+
+const ModalTypeContext = createContext<ModalType | null>(null);
+const ModalFooterAxisContext = createContext<"row" | "col" | null>(null);
 
 const ModalWrapper = ({
   modalType,
@@ -22,22 +25,30 @@ const ModalWrapper = ({
 
   return (
     <section className={`${modalBaseClassName} ${className}`} {...props}>
-      {children}
+      <ModalTypeContext.Provider value={modalType}>
+        {children}
+      </ModalTypeContext.Provider>
     </section>
   );
 };
+
+interface ModalHeaderProps {
+  children?: string;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  closeButtonAriaLabel?: string;
+}
 
 const Header = ({
   children,
   onClick,
   closeButtonAriaLabel = "모달창 닫기",
-}: {
-  children?: string;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
-  closeButtonAriaLabel?: string;
-}) => {
+}: ModalHeaderProps) => {
+  const modalType = useContext(ModalTypeContext);
+
   return (
-    <header className="flex justify-between">
+    <header
+      className={`flex justify-between ${modalType === "fullPage" && "py-2"}`}
+    >
       <h1 className="title-1 text-grey-900">{children}</h1>
       <button onClick={onClick} aria-label={closeButtonAriaLabel}>
         <CloseIcon />
@@ -53,27 +64,26 @@ const Content = ({
   <section className={`flex flex-col gap-8 ${className}`}>{children}</section>
 );
 
-const Footer = ({
-  children,
-  axis,
-  className = "",
-}: {
+interface ModalFooterProps {
   children: React.ReactNode;
   axis: "row" | "col";
   className?: string;
-}) => {
+}
+
+const Footer = ({ children, axis, className = "" }: ModalFooterProps) => {
   return (
     <section className={`flex gap-2 flex-${axis} ${className}`}>
-      {React.Children.map(children, (child) =>
-        React.isValidElement(child)
-          ? React.cloneElement(child as ReactElement, {
-              axis,
-            })
-          : child,
-      )}
+      <ModalFooterAxisContext.Provider value={axis}>
+        {children}
+      </ModalFooterAxisContext.Provider>
     </section>
   );
 };
+
+interface ModalButtonProps extends Partial<Omit<ButtonProps, "variant">> {
+  children: React.ReactNode;
+  onClick: ButtonProps["onClick"];
+}
 
 const FilledButton = ({
   onClick,
@@ -81,25 +91,24 @@ const FilledButton = ({
   size = "medium",
   className = "",
   children,
-  axis,
   ...rest
-}: Partial<Omit<ButtonProps, "variant">> & {
-  children: React.ReactNode;
-  onClick: ButtonProps["onClick"];
-  axis?: "row" | "col";
-}) => (
-  <Button
-    variant="filled"
-    colorType={colorType}
-    size={size}
-    onClick={onClick}
-    fullWidth={false}
-    {...rest}
-    className={`${axis === "row" && "flex-1"} ${className}`}
-  >
-    {children}
-  </Button>
-);
+}: ModalButtonProps) => {
+  const axis = useContext(ModalFooterAxisContext);
+
+  return (
+    <Button
+      variant="filled"
+      colorType={colorType}
+      size={size}
+      onClick={onClick}
+      fullWidth={false}
+      {...rest}
+      className={`${axis === "row" && "flex-1"} ${className}`}
+    >
+      {children}
+    </Button>
+  );
+};
 
 const TextButton = ({
   onClick,
@@ -107,25 +116,24 @@ const TextButton = ({
   size = "medium",
   className = "",
   children,
-  axis,
   ...rest
-}: Partial<Omit<ButtonProps, "variant">> & {
-  children: React.ReactNode;
-  onClick: ButtonProps["onClick"];
-  axis?: "row" | "col";
-}) => (
-  <Button
-    variant="text"
-    colorType={colorType}
-    size={size}
-    onClick={onClick}
-    fullWidth={false}
-    className={`${axis === "row" && "flex-1"} ${className}`}
-    {...rest}
-  >
-    {children}
-  </Button>
-);
+}: ModalButtonProps) => {
+  const axis = useContext(ModalFooterAxisContext);
+
+  return (
+    <Button
+      variant="text"
+      colorType={colorType}
+      size={size}
+      onClick={onClick}
+      fullWidth={false}
+      className={`${axis === "row" && "flex-1"} ${className}`}
+      {...rest}
+    >
+      {children}
+    </Button>
+  );
+};
 
 export const Modal = Object.assign(ModalWrapper, {
   Header,


### PR DESCRIPTION
# 관련 이슈 번호
close #323 
# 설명


2024/10/13 에 시행한 테스트에서 발견 된 모달 UI 스타일 변경 입니다. 

![image](https://github.com/user-attachments/assets/225c1c09-7610-49b4-bb99-ba28d970fd94)
구현물

![image](https://github.com/user-attachments/assets/d2cc0e84-5975-4d07-8865-3833e548febf)
피그마

스타일상 `Modal.Header` 는 풀페이지의 경우 `px-4 py- 2` 의 스타일을 가져야 합니다. 

> 센터 모달은 `Modal` 의 스타일을 따라 `px-4` 가 적용 되어 스타일 상 문제가 없습니다. 

`Modal.Header` 는 상위 컴포넌트인 `Modal` 의 `modalType props` 를 바라봐야 합니다. 

우린 이와 비슷한 문제를 `React.CloneElement` 를 이용해 해결했습니다. 

공식 문서를 보고 이렇게 사용 하는 패턴이 괜찮은지 살펴 봅니다 .

공식문서 보자 마자 이런 이미지가 보입니다.
> https://ko.react.dev/reference/react/cloneElement#alternatives

![image](https://github.com/user-attachments/assets/db93d3b4-c966-438f-b805-33bb25ed7f63)

따라서 대안으론 이와 같은 값을 추천 합니다.

![image](https://github.com/user-attachments/assets/543607f7-1b18-48df-8b58-abfdaef23361)

따라서 이번 작업에선 `ModalTypeContext , ModalFooterContext` 를 만들어 하위 컴포넌트에서 소모 할 수 있도록 로직을 변경하고 스타일도 변경 하도록 합니다. 

- 컨텍스트로 props 내려주기
- pullPage 모달 기본 스타일 지정

1. Modal 기본 스타일 지정

우선 `modalStyles` 에서 풀페이지 모달의 경우 `px-4` 값을 기본으로 추가해줬습니다. 

이제 UI 가 깨지는 문제가 존재하지 않습니다.

![image](https://github.com/user-attachments/assets/462c2ae6-9ef0-4424-8a5d-ef1b13970166)
![image](https://github.com/user-attachments/assets/f2e61f75-de85-401a-9db2-7e8f8758a0c9)

2. Modal 의 props 를 컨텍스트로 내려주기
```tsx
const ModalTypeContext = createContext<ModalType | null>(null);
const ModalFooterAxisContext = createContext<"row" | "col" | null>(null);

const ModalWrapper = ({
  modalType,
  ...
}: ModalProps) => {
  const modalBaseClassName = modalStyles[modalType];

  return (
    <section className={`${modalBaseClassName} ${className}`} {...props}>
      <ModalTypeContext.Provider value={modalType}>
        {children}
      </ModalTypeContext.Provider>
    </section>
  );
};

const Header = ({
  children,
  onClick,
  closeButtonAriaLabel = "모달창 닫기",
}: ModalHeaderProps) => {
  const modalType = useContext(ModalTypeContext);

  return (
    <header
      className={`flex justify-between ${modalType === "fullPage" && "py-2"}`}
    >
      <h1 className="title-1 text-grey-900">{children}</h1>
      <button onClick={onClick} aria-label={closeButtonAriaLabel}>
        <CloseIcon />
      </button>
    </header>
  );
};
```

리액트 공식 문서에서 추천하는 방식으로 부모 컴포넌트의 `props` 를 `Context` 를 이용해 자식에게 내려주었습니다. 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
