### PR TITLE
[Hotfix] mutationCached 에서 throw error 문 제거

### DIFF
--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -48,7 +48,6 @@ export const useCreateQueryClient = () => {
       }),
       mutationCache: new MutationCache({
         onError: async (error, variables, context, mutation) => {
-          console.error("mutationCache에서 잡는다 얍! ", error);
           switch (error.message) {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getNewAccessToken({

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -48,6 +48,7 @@ export const useCreateQueryClient = () => {
       }),
       mutationCache: new MutationCache({
         onError: async (error, variables, context, mutation) => {
+          console.error("mutationCache에서 잡는다 얍! ", error);
           switch (error.message) {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getNewAccessToken({
@@ -73,7 +74,11 @@ export const useCreateQueryClient = () => {
               break;
             }
             default:
-              throw error;
+              /**
+               * 만약 발생 한 에러가 전역으로 핸들링 할 에러가 아니라면
+               * 해당 mutation 의 onError 를 호출합니다.
+               */
+              mutation?.options.onError?.(error, variables, context);
           }
         },
       }),

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -75,9 +75,12 @@ export const useCreateQueryClient = () => {
             default:
               /**
                * 만약 발생 한 에러가 전역으로 핸들링 할 에러가 아니라면
-               * 해당 mutation 의 onError 를 호출합니다.
+               * 아무런 행위도 하지 않습니다.
+               * 2024/10/15 에서 throw error 문이 제거 되었습니다.
+               * throw error 가 있을 경우 에러가 mutation.onError 에게 에러가 전달 되지 않고
+               * 실행 스택이 중단 되어 mutation.onError 가 호출 되지 않았습니다.
                */
-              mutation?.options.onError?.(error, variables, context);
+              return;
           }
         },
       }),


### PR DESCRIPTION
# 관련 이슈 번호
close #301 
# 설명


# 에러를 찾기 위한 여정

아예 새로운 앱을 만들어서 해보겠습니다.

```jsx

function App() {
  const { mutate } = useMutation({
    mutationFn: async () => {
      throw new Error('에러 발생!');
    },
    onError: (error) => {
      console.log('에러 발생! : useMutation on Error 에서 정의 된', error);
    },
  });

  return (
    <div className='App'>
      <button
        onClick={() => {
          mutate(123, {
            onError: (error) => {
              console.log('에러 발생! : mutate on Error 에서 정의 된', error);
            },
          });
        }}
      >
        뮤테이션!
      </button>
    </div>
  );
}
```
![image](https://github.com/user-attachments/assets/1bd472af-169b-48fc-9960-9fa60267c72d)

잘만 일어 납니다. 

심지어 에러를 다시 던지거나 하지 않아도 캐치가 되네요 ?

우리 앱에서 클라이언트를 만드는데 있어서 문제가 있었던 걸까요 ? 

---

문제의 원인은 바로 `MutationCached` 에 있었습니다. 

`MutationCached` 는 `mutation` 들의 `onError` 를 모두 가로 채는 전역 핸들러 입니다. 이에 `useMutation.onError` 에 정의한 `onError` 들은 모두 `MutataionCached` 에서 가로채져 실행 되고 

실행 되지 않은 에러는 `mutataion.onError` 에게 전달 되어 다시 실행 됩니다. 

> `mutate.onError` 는 `mutation.onError` 와 다르게 실행 됩니다.
> `useMutataion.onError` 는 호출되는 컨텍스트와 상관 없이 매번 실행 되지만 `mutate.onError` 는 호출되는 컨텍스트 내부에서만 실행 됩니다.
> 이에 `MutationCached` 는 `mutate.onError` 를 가로채지 않습니다.

우리의 이전 로직은 `MutationCached` 에서 전역으로 핸들링 할 에러가 아닐 경우 `default` 문에서 에러를 던졌습니다.

![image](https://github.com/user-attachments/assets/b8ca7704-f18b-484a-9c27-3ea9bc736f73)

이 것이 패착이였습니다.

전역 핸들러에서 에러가 던져졌을 때 해당 에러를 핸들링 할 객체가 존재하지 않습니다. 

이에 `mutation.onError -> MutataionCache ---- 에러 발생! --- X --> mutataion.onError` 처럼 `mutataion` 에게 에러를 전파하지 못하고 실행 스택이 종료 되어 버리는 문제가 존재 했습니다. 

> 다만 런타임 에러가 나타나지 않은 `throwOnError` 옵션이 `false` 라 그랬을거라 생각 됩니다.

이에 

```tsx
            default:
              return ;
          }
```

에러를 던지지 않도록 수정 했습니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
