### PR TITLE
[Feat] 회원 가입 단계에서 유저 정보에서 성별 선택 안함 필드 추가

### DIFF
--- a/src/features/auth/api/signUp.ts
+++ b/src/features/auth/api/signUp.ts
@@ -202,7 +202,7 @@ export const usePostDuplicateNickname = () => {
 interface UserInfoRegistrationRequest {
   token: string;
   nickname: string;
-  gender: "FEMALE" | "MALE";
+  gender: "FEMALE" | "MALE" | "NONE";
   age: 10 | 20 | 30 | 40 | 50 | 60;
   region: number[];
   marketingYn: boolean;

--- a/src/features/auth/constants/form.ts
+++ b/src/features/auth/constants/form.ts
@@ -22,6 +22,10 @@ export const genderOptionList = [
     value: "FEMALE",
     name: "여자",
   },
+  {
+    value: "NONE",
+    name: "선택안함",
+  },
 ] as const;
 
 export const ageRangeOptionList = [

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -126,7 +126,7 @@ export const useLoginFormStore = create<LoginFormStore>((set) => ({
   setStatusText: (statusText: string) => set({ statusText }),
 }));
 
-type Gender = "FEMALE" | "MALE" | null;
+type Gender = "FEMALE" | "MALE" | "NONE" | null;
 type AgeRange = 10 | 20 | 30 | 40 | 50 | 60 | null;
 type CheckedList = boolean[];
 type Region = { address: string; id: number };


### PR DESCRIPTION
# 관련 이슈 번호
close #330
# 설명
![image](https://github.com/user-attachments/assets/91209c48-3900-4040-ad42-b2b829ed102c)

성별란에서 선택 안함 필드가 추가 되었습니다.

이에 백엔드와 이야기 나눈 후 선택 안함은 `NONE` 이란 값으로 보내도록 기능 수정 합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
