### PR TITLE
[Refactor] useMapStore에서 mapInfo 삭제

### DIFF
--- a/src/features/map/store/map.ts
+++ b/src/features/map/store/map.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM } from "../constants";
 
 export interface LatLng {
   lat: number;
@@ -20,7 +19,6 @@ interface UserInfo {
 }
 
 interface MapState {
-  mapInfo: MapInfo;
   userInfo: UserInfo;
   mode: Mode;
   isCenterOnMyLocation: boolean;
@@ -28,7 +26,6 @@ interface MapState {
 }
 
 interface MapActions {
-  setMapInfo: (mapInfo: MapInfo) => void;
   setUserInfo: (userInfo: UserInfo) => void;
   setMode: (mode: Mode) => void;
   setIsCenterOnMyLocation: (isCenterOnMyLocation: boolean) => void;
@@ -36,10 +33,6 @@ interface MapActions {
 }
 
 const mapStoreInitialState: MapState = {
-  mapInfo: {
-    center: MAP_INITIAL_CENTER,
-    zoom: MAP_INITIAL_ZOOM,
-  },
   userInfo: {
     currentLocation: { lat: null, lng: null },
     hasLocationPermission: false,
@@ -51,7 +44,6 @@ const mapStoreInitialState: MapState = {
 
 export const useMapStore = create<MapState & MapActions>((set) => ({
   ...mapStoreInitialState,
-  setMapInfo: (mapInfo) => set({ mapInfo }),
   setUserInfo: (userInfo) => set({ userInfo }),
   setMode: (mode) => set({ mode }),
   setIsCenterOnMyLocation: (isCenterOnMyLocation) =>

--- a/src/widgets/map/ui/googleMaps.tsx
+++ b/src/widgets/map/ui/googleMaps.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { Map } from "@vis.gl/react-google-maps";
-import { MapCameraChangedEvent } from "@vis.gl/react-google-maps";
 import { MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM } from "@/features/map/constants";
 import { useMapStore } from "@/features/map/store/map";
-import { debounce } from "@/shared/lib";
 import { mapOptions } from "../constants";
 
 const GOOGLE_MAPS_MAP_ID = import.meta.env.VITE_GOOGLE_MAPS_ID;
@@ -18,7 +16,6 @@ interface GoogleMapProps {
 export const GoogleMaps = ({ children }: GoogleMapProps) => {
   const isLoadedRef = useRef<boolean>(false);
 
-  const setMapInfo = useMapStore((state) => state.setMapInfo);
   const setIsMapCenteredOnMyLocation = useMapStore(
     (state) => state.setIsCenterOnMyLocation,
   );
@@ -26,21 +23,10 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
     (state) => state.setIsLastSearchedLocation,
   );
 
-  const DELAY_SET_MAP_INFO = 500;
-
-  const debouncedUpdateMapInfo = debounce(
-    (detail: MapCameraChangedEvent["detail"]) => {
-      const { center, zoom } = detail;
-      setMapInfo({ center, zoom });
-    },
-    DELAY_SET_MAP_INFO,
-  );
-
-  const handleMapChange = ({ detail }: MapCameraChangedEvent) => {
+  const handleMapChange = () => {
     if (!isLoadedRef.current) return;
 
     setIsLastSearchedLocation(false);
-    debouncedUpdateMapInfo(detail); // debounce 시켜 MapStore 의 mapInfo 를 변경합니다.
     setIsMapCenteredOnMyLocation(false);
   };
 
@@ -71,7 +57,6 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
       defaultCenter={MAP_INITIAL_CENTER}
       defaultZoom={MAP_INITIAL_ZOOM}
       reuseMaps // Map 컴포넌트가 unmount 되었다가 다시 mount 될 때 기존의 map instance 를 재사용 하여 memory leak을 방지합니다.
-      // debounce 를 이용하여 MapStore 의 mapInfo 를 변경합니다.
       onCameraChanged={handleMapChange}
       onTilesLoaded={() => {
         isLoadedRef.current = true;

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
-import { MAP_INITIAL_ZOOM } from "@/features/map/constants";
 import { useCurrentLocation } from "@/features/map/hooks";
 import { useResearchMarkingList } from "@/features/map/hooks";
 import { useMapStore } from "@/features/map/store";
@@ -16,7 +15,6 @@ export const MapInitializer = () => {
   const setIsCenteredOnMyLocation = useMapStore(
     (state) => state.setIsCenterOnMyLocation,
   );
-  const setMapInfo = useMapStore((state) => state.setMapInfo);
 
   useEffect(() => {
     if (!map) return;
@@ -31,7 +29,6 @@ export const MapInitializer = () => {
         // /map으로 접속했을 때, 현재 위치로 query string를 설정합니다.
         if (!boundsParams) {
           map.setCenter(currentLocationOfUser);
-          setMapInfo({ center: currentLocationOfUser, zoom: MAP_INITIAL_ZOOM });
 
           setTimeout(() => {
             setIsCenteredOnMyLocation(true);
@@ -56,16 +53,6 @@ export const MapInitializer = () => {
       west: southWest.lng,
       north: northEast.lat,
       east: northEast.lng,
-    });
-
-    const center = map.getCenter();
-    const lat = center.lat();
-    const lng = center.lng();
-    const zoom = map.getZoom();
-
-    setMapInfo({
-      center: { lat, lng },
-      zoom: zoom,
     });
 
     researchMarkingList();


### PR DESCRIPTION
# 관련 이슈 번호

close #339

# 설명

useMapStore의 mapInfo를 사용하는 곳이 없더라구요 😢 
mapInfo는 query string이나 map 인스턴스로 충분히 얻을 수 있는 데이터라고 판단하여 삭제합니다.
