### PR TITLE
[Hotfix] GenderChangeButton 잘못 선언된 타입 변경

### DIFF
--- a/src/features/setting/ui/genderChangeButton.tsx
+++ b/src/features/setting/ui/genderChangeButton.tsx
@@ -3,13 +3,13 @@ import { genderMap, GenderMapKey } from "@/features/auth/constants";
 import type { MyInfo } from "@/entities/auth/api";
 import { ArrowRightIcon } from "@/shared/ui/icon";
 import { Select } from "@/shared/ui/select";
-import { PutChangeAgeRequestData, usePutChangeGender } from "../api";
+import { PutChangeGenderRequestData, usePutChangeGender } from "../api";
 
 export const GenderChangeButton = ({ gender }: Pick<MyInfo, "gender">) => {
   const [isOpen, setIsOpen] = useState(false);
   const { mutate: putChangeGender } = usePutChangeGender();
 
-  const handleSelect = ({ gender: newGender }: PutChangeAgeRequestData) => {
+  const handleSelect = ({ gender: newGender }: PutChangeGenderRequestData) => {
     if (gender === newGender) {
       return;
     }


### PR DESCRIPTION
# 관련 이슈 번호
close #346 
# 설명

## 버그 설명

잘못된 타입이 선언 되어 있습니다.

### 버그가 발생한 상황

![image](https://github.com/user-attachments/assets/57284abf-16af-4577-b55e-33600fb88187)

아마 충돌 해결 과정에서 이런 문제가 발생한 듯 싶습니다. 

```tsx

export const GenderChangeButton = ({ gender }: Pick<MyInfo, "gender">) => {
  const [isOpen, setIsOpen] = useState(false);
  const { mutate: putChangeGender } = usePutChangeGender();

  const handleSelect = ({ gender: newGender }: PutChangeGenderRequestData) => {
    if (gender === newGender) {
      return;
    }
```

올바른 타입으로 변경했습니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
