### PR TITLE
[Feat] 서버에 요청 보내는 apiClient 객체 생성

### DIFF
--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -21,6 +21,19 @@ interface FetcherOptions {
   withToken?: boolean;
 }
 
+/**
+ * body가 FormData 인스턴스일 경우 body를 그대로 서버에 전송하고, 그 외의 경우 JSON.stringify를 감싸서 전송합니다.
+ * 응답이 성공적으로 왔을 경우 content만 반환합니다.
+ * 응답이 실패했을 경우 HttpError를 throw 합니다.
+ *
+ * @param url 서버 api의 엔드 포인트 (API_BASE_URL을 제외한 나머지)
+ * @param method HTTP 메소드
+ * @param headers HTTP 헤더
+ * @param withToken 토큰을 HTTP 헤더에 담아줄지 여부
+ * @param body HTTP 요청 바디
+ * @param credentials HTTP 요청의 credentials
+ * @returns
+ */
 const fetcher = async <T>(
   url: string,
   { method, headers, withToken = false, body, credentials }: FetcherOptions,

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -1,0 +1,77 @@
+import { API_BASE_URL } from "../constants";
+import { useAuthStore } from "../store";
+import { HttpError } from "./error";
+
+type Method = "GET" | "POST" | "DELETE" | "PUT" | "PATCH";
+
+interface Response<T = undefined> {
+  code: number;
+  message: string;
+  content: T extends undefined ? never : T;
+}
+
+interface FetcherOptions {
+  method: Method;
+  headers?: HeadersInit;
+  body?: RequestInit["body"];
+  credentials?: RequestInit["credentials"];
+  withToken?: boolean;
+}
+
+const fetcher = async <T>(
+  url: string,
+  { method, headers, withToken = false, body, credentials }: FetcherOptions,
+) => {
+  try {
+    const httpHeaders = new Headers(headers || {});
+
+    if (withToken) {
+      const { token } = useAuthStore.getState();
+
+      if (token) httpHeaders.set("Authorization", token);
+    }
+
+    const response = await fetch(`${API_BASE_URL + url}`, {
+      method,
+      headers,
+      body:
+        httpHeaders.get("Content-Type") === "application/json"
+          ? JSON.stringify(body)
+          : body,
+      credentials,
+    });
+
+    if (!response.ok) {
+      const { code, message }: Response = await response.json();
+
+      throw new HttpError({ code, message });
+    }
+
+    const { content }: Response<T> = await response.json();
+
+    return content;
+  } catch (error) {
+    if (error instanceof HttpError) {
+      console.error(error.message);
+    }
+  }
+};
+
+export const apiClient = {
+  get: <T>(
+    url: string,
+    {
+      headers,
+      credentials,
+      withToken,
+    }: Omit<FetcherOptions, "method" | "body">,
+  ) => fetcher<T>(url, { method: "GET", headers, credentials, withToken }),
+  post: <T>(url: string, options: Omit<FetcherOptions, "method">) =>
+    fetcher<T>(url, { method: "POST", ...options }),
+  delete: <T>(url: string, options: Omit<FetcherOptions, "method">) =>
+    fetcher<T>(url, { method: "DELETE", ...options }),
+  patch: <T>(url: string, options: Omit<FetcherOptions, "method">) =>
+    fetcher<T>(url, { method: "PATCH", ...options }),
+  put: <T>(url: string, options: Omit<FetcherOptions, "method">) =>
+    fetcher<T>(url, { method: "PUT", ...options }),
+};

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -47,6 +47,10 @@ const fetcher = async <T>(
       if (token) httpHeaders.set("Authorization", token);
     }
 
+    if (body && !(body instanceof FormData)) {
+      httpHeaders.set("Content-Type", "application/json");
+    }
+
     const options: RequestInit = {
       method,
       headers: httpHeaders,

--- a/src/shared/lib/error.ts
+++ b/src/shared/lib/error.ts
@@ -1,0 +1,9 @@
+export class HttpError extends Error {
+  code: number;
+
+  constructor({ code, message }: { code: number; message: string }) {
+    super(message);
+    this.name = "HttpError";
+    this.code = code;
+  }
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -6,6 +6,7 @@ export * from "./debounce";
 export * from "./image";
 export * from "./format";
 export * from "./apiClient";
+export * from "./error";
 
 // TODO refactoring 시 해당 훅 제거 하기
 /**

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -5,6 +5,7 @@ export * from "./overlay";
 export * from "./debounce";
 export * from "./image";
 export * from "./format";
+export * from "./apiClient";
 
 // TODO refactoring 시 해당 훅 제거 하기
 /**


### PR DESCRIPTION
# 관련 이슈 번호

#345 

# 설명

## HttpError 

서버에서 오는 에러 정보를 저장하기 위해 Error 객체를 상속받는 HttpError 클래스를 만들었습니다.
이 클래스는 fetch 요청에서 에러가 발생했을 경우 throw 됩니다.

```typescript
export class HttpError extends Error {
  code: number;

  constructor({ code, message }: { code: number; message: string }) {
    super(message);
    this.name = "HttpError";
    this.code = code;
  }
}
```

## apiClient

저희는 평소에 fetch 요청을 보내는 함수를 만들 때 다음과 같은 불편함을 겪었습니다.

- response 에러와 응답처리 로직이 거의 동일하여 중복되는 코드 많음
- headers에 토큰을 담아줘야 할 때마다 매번 Authorization 정의
- reponse로 항상 오는 code와 message 타입을 항상 정의
- 현재 서버 api url이 하나인데, request url 상수에서 `${API_BASE_URL}/~`와 같이 작성
- body로 객체 데이터를 보낼 때마다 JSON.stringify로 감싸줘야 함


위와 같은 문제점을 해결하기 위해 apiClient를 만들었습니다.

- 제너럴 타입 `<T>` 으로 서버에서 오는 **`content` 타입**을 미리 정의합니다.
- 여기서 말하는 url은 **전체 api 주소를 작성하는게 아니라 path**를 작성해야 합니다. 
  - ex) `${API_BASE_URL}/auth` => "/auth" 
- http headers에 토큰을 담아야 한다면 withToken을 true로 설정해주세요.
- credentials 설정도 가능합니다.
- body가 만약 FormData 타입이라면 그대로 서버에 보내지고, 아니라면 JSON.stringify로 감싸서 보내집니다.

```typescript
import { API_BASE_URL } from "../constants";
import { useAuthStore } from "../store";
import { HttpError } from "./error";

type Method = "GET" | "POST" | "DELETE" | "PUT" | "PATCH";

interface Response {
  code: number;
  message: string;
}

interface SuccessResponse<T> extends Response {
  content: T;
}

interface FetcherOptions {
  method: Method;
  headers?: HeadersInit;
  body?: unknown;
  credentials?: RequestInit["credentials"];
  withToken?: boolean;
}

/**
 * body가 FormData 인스턴스일 경우 body를 그대로 서버에 전송하고, 그 외의 경우 JSON.stringify를 감싸서 전송합니다.
 * 응답이 성공적으로 왔을 경우 content만 반환합니다.
 * 응답이 실패했을 경우 HttpError를 throw 합니다.
 *
 * @param url 서버 api의 엔드 포인트 (API_BASE_URL을 제외한 나머지)
 * @param method HTTP 메소드
 * @param headers HTTP 헤더
 * @param withToken 토큰을 HTTP 헤더에 담아줄지 여부
 * @param body HTTP 요청 바디
 * @param credentials HTTP 요청의 credentials
 * @returns
 */
const fetcher = async <T>(
  url: string,
  { method, headers, withToken = false, body, credentials }: FetcherOptions,
) => {
  try {
    const httpHeaders = new Headers(headers || {});

    if (withToken) {
      const { token } = useAuthStore.getState();

      if (token) httpHeaders.set("Authorization", token);
    }

    const options: RequestInit = {
      method,
      headers: httpHeaders,
      credentials,
    };

    if (body) {
      options.body = body instanceof FormData ? body : JSON.stringify(body);
    }

    const response = await fetch(`${API_BASE_URL + url}`, options);

    if (!response.ok) {
      const { code, message }: Response = await response.json();

      throw new HttpError({ code, message });
    }

    const { content }: SuccessResponse<T> = await response.json();

    return content;
  } catch (error) {
    if (error instanceof HttpError) {
      console.error(error.message);
    }

    throw error;
  }
};

export const apiClient = {
  get: <T>(
    url: string,
    {
      headers,
      credentials,
      withToken,
    }: Omit<FetcherOptions, "method" | "body">,
  ) => fetcher<T>(url, { method: "GET", headers, credentials, withToken }),
  post: <T>(url: string, options: Omit<FetcherOptions, "method">) =>
    fetcher<T>(url, { method: "POST", ...options }),
  delete: <T>(url: string, options: Omit<FetcherOptions, "method">) =>
    fetcher<T>(url, { method: "DELETE", ...options }),
  patch: <T>(url: string, options: Omit<FetcherOptions, "method">) =>
    fetcher<T>(url, { method: "PATCH", ...options }),
  put: <T>(url: string, options: Omit<FetcherOptions, "method">) =>
    fetcher<T>(url, { method: "PUT", ...options }),
};

```

## 사용법

### useQuery

서버로부터 오는 content 데이터 타입을 `apiClient.get`의 제너럴 타입에 정의해주시면 됩니다.

```typescript
interface AddressFromLatLngRequest {
  lat: number;
  lng: number;
}

const getAddressFromLatLng = async ({ lat, lng }: AddressFromLatLngRequest) => {
  return apiClient.get<{
    region: string;
  }>(`/maps/reverse-geocode?lat=${lat}&lng=${lng}`, {
    withToken: true,
  });
};

export const useGetAddressFromLatLng = ({
  lat,
  lng,
}: AddressFromLatLngRequest) => {
  return useQuery({
    queryKey: ["address", lat, lng],
    queryFn: () => getAddressFromLatLng({ lat, lng }),
  });
};
```

### useMutation

만약 서버로부터 code와 message 값만 온다면 useMutation의 제너럴 타입을 지정해주지 않아도 자동으로 타입 추론이 됩니다.

```typescript
const putChangeNickname = async ({ nickname }: { nickname: string }) => {
  return apiClient.put("/users/profile/nickname", {
    withToken: true,
    headers: {
      "Content-Type": "application/json",
    },
    body: { nickname },
  });
};

export const usePutChangeNickname = ({
  onSuccessCallback,
}: {
  onSuccessCallback: () => void;
}) => {
  const setNickname = useAuthStore((state) => state.setNickname);

  return useMutation({
    mutationFn: putChangeNickname,
    onSuccess: (_, variables) => {
      setNickname(variables.nickname);
      onSuccessCallback();
    },
  });
};
```

<img width="661" alt="스크린샷 2024-10-20 오전 12 22 34" src="https://github.com/user-attachments/assets/5500ce7c-01aa-40db-a9c9-c44e8eb30d70">

만약 content가 있을 경우, 제너럴 타입을 통해 content 타입을 설정해주시면 됩니다.

```typescript
export interface LoginResponse {
  authorization: string;
  role: string;
  userId: number | null;
  nickname: string | null;
}

interface EmailLoginFormData {
  email: string;
  password: string;
  persistLogin: boolean;
}

const postLogin = async (formData: EmailLoginFormData) => {
  return apiClient.post<LoginResponse>("/login", {
    headers: {
      "Content-Type": "application/json",
    },
    body: formData,
  });
};

export const usePostLoginForm = () => {
  // ...
  const setToken = useAuthStore((state) => state.setToken);
  const setRole = useAuthStore((state) => state.setRole);
  const setNickname = useAuthStore((state) => state.setNickname);

  const mutate = useMutation<LoginResponse, HttpError, EmailLoginFormData>({
    mutationFn: postLogin,
    onSuccess: (data) => {
      const { authorization, role, nickname } = data;
      setToken(authorization);
      setRole(role);
      setNickname(nickname);

      // ...
    },
    onError: (error) => {
      // TODO 에러 처리 로직 추가하기
      throw new Error(error.message);
    },
  });

  return mutate;
};
```