### PR TITLE
[Hotfix] 풀페이지 모달 스타일 수정

### DIFF
--- a/src/entities/auth/ui/SignUpLandingModal.tsx
+++ b/src/entities/auth/ui/SignUpLandingModal.tsx
@@ -24,8 +24,8 @@ export const SignUpLandingModal = ({
   return (
     <Modal modalType="fullPage">
       <Modal.Header onClick={() => handleNavigate(lastNoneAuthRoute)} />
-      <Modal.Content className="pb-32">
-        <section className="flex px-4 flex-col justify-center items-center gap-2 self-stretch headline-3">
+      <Modal.Content>
+        <section className="flex flex-col justify-center items-center gap-2 self-stretch headline-3">
           <h1>
             <span className="text-tangerine-500">{nickname}</span>님
           </h1>
@@ -45,7 +45,10 @@ export const SignUpLandingModal = ({
         >
           등록하기
         </Modal.FilledButton>
-        <Modal.TextButton onClick={() => handleNavigate(lastNoneAuthRoute)}>
+        <Modal.TextButton
+          colorType="tertiary"
+          onClick={() => handleNavigate(lastNoneAuthRoute)}
+        >
           나중에 할게요
         </Modal.TextButton>
       </Modal.Footer>

--- a/src/features/setting/hooks/useChangePetInfoModal.tsx
+++ b/src/features/setting/hooks/useChangePetInfoModal.tsx
@@ -16,7 +16,7 @@ export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
           onClose();
         }}
       />
-      <Modal.Content>
+      <Modal.Content className="pb-32">
         <h1 className="headline-3 overflow-ellipsis text-center text-grey-900">
           우리 댕댕이를 소개해 주세요
         </h1>

--- a/src/features/setting/ui/accountCancellationModal.tsx
+++ b/src/features/setting/ui/accountCancellationModal.tsx
@@ -46,7 +46,7 @@ export const AccountCancellationModal = ({
         </div>
       </Modal.Content>
       {/* 버튼 */}
-      <Modal.Footer axis="col" className="px-4">
+      <Modal.Footer axis="col">
         <Modal.FilledButton onClick={handleOpen} size="large" className="btn-2">
           다음
         </Modal.FilledButton>

--- a/src/shared/ui/modal/Modal.styles.ts
+++ b/src/shared/ui/modal/Modal.styles.ts
@@ -1,6 +1,6 @@
 export const modalStyles = {
   fullPage:
-    "left-0 top-0 px-4 h-full w-full max-w-[37.5rem] mx-auto flex flex-col gap-8 bg-grey-0 overflow-y-auto",
+    "left-0 top-0  h-full w-full max-w-[37.5rem] mx-auto flex flex-col gap-8 bg-grey-0 overflow-y-auto pb-32",
   center:
-    "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 overflow-y-auto max-h-[calc(100vh-1rem)]",
+    "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px- 6 py-6 overflow-y-auto max-h-[calc(100vh-1rem)]",
 } as const;

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -47,7 +47,7 @@ const Header = ({
 
   return (
     <header
-      className={`flex justify-between ${modalType === "fullPage" && "py-2"}`}
+      className={`flex justify-between ${modalType === "fullPage" && "py-2 pl-4 pr-1"}`}
     >
       <h1 className="title-1 text-grey-900">{children}</h1>
       <button
@@ -64,9 +64,17 @@ const Header = ({
 const Content = ({
   children,
   className = "",
-}: Omit<ModalProps, "modalType">) => (
-  <section className={`flex flex-col gap-8 ${className}`}>{children}</section>
-);
+}: Omit<ModalProps, "modalType">) => {
+  const modalType = useContext(ModalTypeContext);
+
+  return (
+    <section
+      className={`flex flex-col gap-8 ${className} ${modalType === "fullPage" && "px-4"}`}
+    >
+      {children}
+    </section>
+  );
+};
 
 interface ModalFooterProps {
   children: React.ReactNode;
@@ -75,8 +83,12 @@ interface ModalFooterProps {
 }
 
 const Footer = ({ children, axis, className = "" }: ModalFooterProps) => {
+  const modalType = useContext(ModalTypeContext);
+
   return (
-    <section className={`flex gap-2 flex-${axis} ${className}`}>
+    <section
+      className={`flex gap-2 flex-${axis} ${modalType === "fullPage" && "px-4"} ${className} `}
+    >
       <ModalFooterAxisContext.Provider value={axis}>
         {children}
       </ModalFooterAxisContext.Provider>


### PR DESCRIPTION
# 관련 이슈 번호
close #349 

# 설명

## 버그 설명
![image](https://github.com/user-attachments/assets/dfcaa902-c12b-4728-86a4-f477bf01e5a0)

풀페이지 모달에서 modalStyles 에서 `pb-32` 를 추가하도록 합니다. 

`Modal.Header` 에서 패딩 값 `py-2 pl-4 pr-1` 를 가지도록 합니다.

`Modal.Content , Footer` 에서 `px-4`  를 가지도록 합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
