### PR TITLE
[Hotfix] useMutation 에게 callback 으로 전달 된 onClose 가 현재 열려 있는 모달을 바라보지 못하는 문제 수정

### DIFF
--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
 import { useAuthStore } from "@/shared/store";
+import { useOverlayStore } from "@/shared/store/overlay";
 import { ERROR_MESSAGE } from "./constants";
 import { getNewAccessToken } from "./errorHandlers";
 
@@ -9,6 +10,7 @@ export const useCreateQueryClient = () => {
   const setToken = useAuthStore((state) => state.setToken);
   const resetAuthStore = useAuthStore((state) => state.reset);
   const navigate = useNavigate();
+  const resetOverlays = useOverlayStore((state) => state.resetOverlays);
 
   const queryClient = useRef(
     new QueryClient({
@@ -47,6 +49,11 @@ export const useCreateQueryClient = () => {
         },
       }),
       mutationCache: new MutationCache({
+        onSuccess: () => {
+          if (useOverlayStore.getState().overlays.length > 0) {
+            resetOverlays();
+          }
+        },
         onError: async (error, variables, context, mutation) => {
           switch (error.message) {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
@@ -54,9 +61,7 @@ export const useCreateQueryClient = () => {
                 queryClient,
                 callbackFunctions: { setToken, resetAuthStore, navigate },
               });
-
               const { options, state } = mutation;
-
               /**
                * 이전에 시도 했던 mutationFn 을 업데이트 된 액세스 토큰을 이용해 다시 시도합니다.
                * options.mutationFn 으로 재시도 하는 mutation의 경우엔 onSuccess, onError를 자동으로 호출하지 않습니다.
@@ -66,6 +71,11 @@ export const useCreateQueryClient = () => {
                 const { token } = useAuthStore.getState();
                 const updatedVariables = { ...(variables as object), token };
                 await options.mutationFn?.(updatedVariables);
+                // mutation이 성공하면 mutationCached에 존재하는 로직과 동일하게 모든 오버레이 닫기
+                if (useOverlayStore.getState().overlays.length > 0) {
+                  resetOverlays();
+                }
+                // 기존 mutation 의 onSuccess 호출
                 options.onSuccess?.(state.data, updatedVariables, context);
               } catch (error) {
                 options.onError?.(error, variables, context);

--- a/src/features/auth/api/putChangeNickname.ts
+++ b/src/features/auth/api/putChangeNickname.ts
@@ -34,18 +34,13 @@ const putChangeNickname = async ({
   return data;
 };
 
-export const usePutChangeNickname = ({
-  onSuccessCallback,
-}: {
-  onSuccessCallback: () => void;
-}) => {
+export const usePutChangeNickname = () => {
   const setNickname = useAuthStore((state) => state.setNickname);
 
   return useMutation<ChangeNicknameResponse, Error, ChangeNicknameRequest>({
     mutationFn: putChangeNickname,
     onSuccess: (_, variables) => {
       setNickname(variables.nickname);
-      onSuccessCallback();
     },
   });
 };

--- a/src/features/auth/ui/ChangeNicknameModal.tsx
+++ b/src/features/auth/ui/ChangeNicknameModal.tsx
@@ -45,9 +45,7 @@ export const ChangeNicknameModal = ({
   ));
 
   const { mutate: postChangeNickname, status: changeNicknameStatus } =
-    usePutChangeNickname({
-      onSuccessCallback: onClose,
-    });
+    usePutChangeNickname();
   const { isDuplicateNickname, isPending: isDuplicateCheckPending } =
     usePostDuplicateNicknameState();
 

--- a/src/features/marking/api/postMarkingForm.tsx
+++ b/src/features/marking/api/postMarkingForm.tsx
@@ -1,6 +1,8 @@
 import { useMutation } from "@tanstack/react-query";
 import { LatLng } from "@/features/auth/api/region";
 import { useMapStore } from "@/features/map/store";
+import { MapSnackbar } from "@/entities/map/ui";
+import { useSnackBar } from "@/shared/lib";
 import { AuthStore } from "@/shared/store";
 import {
   MARKING_ADD_ERROR_MESSAGE,
@@ -67,22 +69,25 @@ const postMarkingFormData = async ({
   return data;
 };
 
-export const usePostMarkingForm = ({
-  onSuccess,
-}: {
-  onSuccess: () => void;
-}) => {
+export const usePostMarkingForm = () => {
   const resetMarkingFormStore = useMarkingFormStore(
     (state) => state.resetMarkingFormStore,
   );
   const setMode = useMapStore((state) => state.setMode);
 
+  const { handleOpen, onClose } = useSnackBar(() => (
+    <MapSnackbar onClose={onClose}>내 마킹이 추가되었습니다</MapSnackbar>
+  ));
+
   return useMutation({
     mutationFn: postMarkingFormData,
     onSuccess: () => {
-      onSuccess();
       resetMarkingFormStore();
       setMode("view");
+      handleOpen();
+    },
+    onError: (error) => {
+      throw new Error(error.message);
     },
   });
 };

--- a/src/features/marking/api/postTempMarkingForm.tsx
+++ b/src/features/marking/api/postTempMarkingForm.tsx
@@ -1,6 +1,8 @@
 // Marking Form 임시 저장 API
 import { useMutation } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
+import { MapSnackbar } from "@/entities/map/ui";
+import { useSnackBar } from "@/shared/lib";
 import {
   MARKING_ADD_ERROR_MESSAGE,
   MARKING_REQUEST_URL,
@@ -62,22 +64,24 @@ const postMarkingFormDataTemporary = async ({
   return data;
 };
 
-export const usePostTempMarkingForm = ({
-  onSuccess,
-}: {
-  onSuccess: () => void;
-}) => {
+export const usePostTempMarkingForm = () => {
   const resetMarkingFormStore = useMarkingFormStore(
     (state) => state.resetMarkingFormStore,
   );
   const setMode = useMapStore((state) => state.setMode);
+  const { handleOpen, onClose } = useSnackBar(() => (
+    <MapSnackbar onClose={onClose}>
+      <p>임시저장 되었습니다</p>
+      <p>내 마킹에서 저장을 완료해 주세요</p>
+    </MapSnackbar>
+  ));
 
   return useMutation({
     mutationFn: postMarkingFormDataTemporary,
     onSuccess: () => {
-      onSuccess();
       resetMarkingFormStore();
       setMode("view");
+      handleOpen();
     },
     onError: (error) => {
       throw new Error(error.message);

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { SelectOpener } from "@/entities/auth/ui";
-import { MapSnackbar } from "@/entities/map/ui";
-import { useModal, useSnackBar } from "@/shared/lib/overlay";
+import { useModal } from "@/shared/lib/overlay";
 import { useAuthStore } from "@/shared/store";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
@@ -12,7 +11,6 @@ import { Modal } from "@/shared/ui/modal";
 import { Select } from "@/shared/ui/select";
 import { TextArea } from "@/shared/ui/textarea";
 import { useGetAddressFromLatLng } from "../../map/api";
-import { useMapStore } from "../../map/store/map";
 import { usePostMarkingForm, usePostTempMarkingForm } from "../api";
 import {
   MARKING_ADD_ERROR_MESSAGE,
@@ -43,8 +41,8 @@ export const MarkingFormModal = ({
         <MarkingTextArea />
         {/* 제출 버튼들 */}
         <div className="flex flex-col gap-2">
-          <SaveButton onCloseMarkingModal={onCloseMarkingModal} />
-          <TemporarySaveButton onCloseMarkingModal={onCloseMarkingModal} />
+          <SaveButton />
+          <TemporarySaveButton />
         </div>
       </section>
     </Modal>
@@ -279,28 +277,12 @@ const MarkingTextArea = () => {
   );
 };
 
-const SaveButton = ({ onCloseMarkingModal }: MarkingFormModalProps) => {
+const SaveButton = () => {
   const map = useMap();
 
-  const setMode = useMapStore((state) => state.setMode);
-  const resetMarkingFormStore = useMarkingFormStore(
-    (state) => state.resetMarkingFormStore,
-  );
   const isCompressing = useMarkingFormStore((state) => state.isCompressing);
-  const { handleOpen: onOpenSnackbar, onClose: onCloseSnackbar } = useSnackBar(
-    () => (
-      <MapSnackbar onClose={onCloseSnackbar}>
-        내 마킹이 추가되었습니다
-      </MapSnackbar>
-    ),
-  );
 
-  const { mutate: postMarkingData } = usePostMarkingForm({
-    onSuccess: () => {
-      onCloseMarkingModal();
-      onOpenSnackbar();
-    },
-  });
+  const { mutate: postMarkingData } = usePostMarkingForm();
 
   const handleSave = async () => {
     const { token } = useAuthStore.getState();
@@ -331,28 +313,15 @@ const SaveButton = ({ onCloseMarkingModal }: MarkingFormModalProps) => {
     const lat = center.lat();
     const lng = center.lng();
 
-    postMarkingData(
-      {
-        token,
-        lat,
-        lng,
-        region,
-        isVisible,
-        images: images.map((image) => image.file),
-        content,
-      },
-      {
-        onSuccess: () => {
-          onCloseMarkingModal();
-          resetMarkingFormStore();
-          setMode("view");
-          onOpenSnackbar();
-        },
-        onError: (error) => {
-          throw new Error(error.message);
-        },
-      },
-    );
+    postMarkingData({
+      token,
+      lat,
+      lng,
+      region,
+      isVisible,
+      images: images.map((image) => image.file),
+      content,
+    });
   };
 
   return (
@@ -367,27 +336,11 @@ const SaveButton = ({ onCloseMarkingModal }: MarkingFormModalProps) => {
     </Button>
   );
 };
-const TemporarySaveButton = ({
-  onCloseMarkingModal,
-}: MarkingFormModalProps) => {
+const TemporarySaveButton = () => {
   const map = useMap();
   const isCompressing = useMarkingFormStore((state) => state.isCompressing);
 
-  const { handleOpen: onOpenSnackbar, onClose: onCloseSnackbar } = useSnackBar(
-    () => (
-      <MapSnackbar onClose={onCloseSnackbar}>
-        <p>임시저장 되었습니다</p>
-        <p>내 마킹에서 저장을 완료해 주세요</p>
-      </MapSnackbar>
-    ),
-  );
-
-  const { mutate: postTempMarkingData } = usePostTempMarkingForm({
-    onSuccess: () => {
-      onCloseMarkingModal();
-      onOpenSnackbar();
-    },
-  });
+  const { mutate: postTempMarkingData } = usePostTempMarkingForm();
 
   const handleSave = () => {
     const { token } = useAuthStore.getState();

--- a/src/features/setting/api/putChangePassword.tsx
+++ b/src/features/setting/api/putChangePassword.tsx
@@ -36,11 +36,7 @@ const putChangePassword = async (
   return data;
 };
 
-export const usePutChangePassword = ({
-  onSuccessCallback,
-}: {
-  onSuccessCallback: () => void;
-}) => {
+export const usePutChangePassword = () => {
   const resetPasswordChangeForm = usePasswordChangeFormStore(
     (state) => state.reset,
   );
@@ -55,13 +51,6 @@ export const usePutChangePassword = ({
     onSuccess: () => {
       resetPasswordChangeForm();
       handleOpenSnackbar();
-      /**
-       * onSuccessCallback 실행 후 시행 되는 beforeClose 는 mutationCache 를 통해 해당 뮤테이션의 상태를 확인하고
-       * pending 상태이면 pending 상태를 기다리고, success 상태이면 닫히도록 하는 로직이 있습니다.
-       * 하지만 mutationCache 는 onSuccess 시점에는 success 상태가 아니기 때문에 beforeClose 가 실행되지 않습니다.
-       * 따라서 setTimeout 을 통해 onSuccessCallback 이후에 실행되도록 합니다.
-       */
-      setTimeout(onSuccessCallback, 0);
     },
     onError: (error) => {
       // TODO 에러  바운더리 로직 나오면 변경 하기

--- a/src/features/setting/api/putChangePetInformation.ts
+++ b/src/features/setting/api/putChangePetInformation.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { PostPetInfoRequestData } from "@/features/auth/api";
-import { useModal } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { useOverlayStore } from "@/shared/store/overlay";
 import { SETTING_END_POINT } from "../constants";
 
 // TODO 타입 리팩토링 하며 변경 하기
@@ -42,12 +40,11 @@ const putChangePetInformation = async ({
 };
 
 export const usePutChangePetInformation = ({
-  modalId,
+  onSuccessCallback,
 }: {
-  modalId: ReturnType<typeof useModal>["id"];
+  onSuccessCallback: () => Promise<void>;
 }) => {
   const queryClient = useQueryClient();
-  const removeOverlay = useOverlayStore((state) => state.removeOverlay);
 
   return useMutation({
     mutationFn: putChangePetInformation,
@@ -56,7 +53,7 @@ export const usePutChangePetInformation = ({
       queryClient.invalidateQueries({
         queryKey: ["profile", useAuthStore.getState().nickname],
       });
-      removeOverlay(modalId);
+      onSuccessCallback();
     },
     onError: (error) => {
       // TODO 에러 바운더리 나오면 수정 하기

--- a/src/features/setting/api/putChangePetInformation.ts
+++ b/src/features/setting/api/putChangePetInformation.ts
@@ -39,11 +39,7 @@ const putChangePetInformation = async ({
   return data;
 };
 
-export const usePutChangePetInformation = ({
-  onSuccessCallback,
-}: {
-  onSuccessCallback: () => Promise<void>;
-}) => {
+export const usePutChangePetInformation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -53,7 +49,6 @@ export const usePutChangePetInformation = ({
       queryClient.invalidateQueries({
         queryKey: ["profile", useAuthStore.getState().nickname],
       });
-      onSuccessCallback();
     },
     onError: (error) => {
       // TODO 에러 바운더리 나오면 수정 하기

--- a/src/features/setting/api/putChangePetInformation.ts
+++ b/src/features/setting/api/putChangePetInformation.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { PostPetInfoRequestData } from "@/features/auth/api";
+import { useModal } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
+import { useOverlayStore } from "@/shared/store/overlay";
 import { SETTING_END_POINT } from "../constants";
 
 // TODO 타입 리팩토링 하며 변경 하기
@@ -39,8 +41,14 @@ const putChangePetInformation = async ({
   return data;
 };
 
-export const usePutChangePetInformation = () => {
+export const usePutChangePetInformation = ({
+  modalId,
+}: {
+  modalId: ReturnType<typeof useModal>["id"];
+}) => {
   const queryClient = useQueryClient();
+  const removeOverlay = useOverlayStore((state) => state.removeOverlay);
+
   return useMutation({
     mutationFn: putChangePetInformation,
     mutationKey: ["putChangePetInformation"],
@@ -48,6 +56,7 @@ export const usePutChangePetInformation = () => {
       queryClient.invalidateQueries({
         queryKey: ["profile", useAuthStore.getState().nickname],
       });
+      removeOverlay(modalId);
     },
     onError: (error) => {
       // TODO 에러 바운더리 나오면 수정 하기

--- a/src/features/setting/api/putSetPassword.tsx
+++ b/src/features/setting/api/putSetPassword.tsx
@@ -34,11 +34,7 @@ const putSetPassword = async (setPasswordData: PutSetPasswordRequest) => {
   return data;
 };
 
-export const usePutSetPassword = ({
-  onSuccessCallback,
-}: {
-  onSuccessCallback: () => void;
-}) => {
+export const usePutSetPassword = () => {
   const resetPasswordSetForm = usePasswordSetFormStore((state) => state.reset);
   const { handleOpen: handleOpenSnackbar, onClose: onCloseSnackbar } =
     useSnackBar(() => (
@@ -55,13 +51,6 @@ export const usePutSetPassword = ({
       queryClient.invalidateQueries({ queryKey: ["myInfo"] });
       resetPasswordSetForm();
       handleOpenSnackbar();
-      /**
-       * onSuccessCallback 실행 후 시행 되는 beforeClose 는 mutationCache 를 통해 해당 뮤테이션의 상태를 확인하고
-       * pending 상태이면 pending 상태를 기다리고, success 상태이면 닫히도록 하는 로직이 있습니다.
-       * 하지만 mutationCache 는 onSuccess 시점에는 success 상태가 아니기 때문에 beforeClose 가 실행되지 않습니다.
-       * 따라서 setTimeout 을 통해 onSuccessCallback 이후에 실행되도록 합니다.
-       */
-      setTimeout(onSuccessCallback, 0);
     },
     onError: (error) => {
       // TODO 에러바운더리 로직 나오면 변경 하기

--- a/src/features/setting/hooks/useChangePetInfoModal.tsx
+++ b/src/features/setting/hooks/useChangePetInfoModal.tsx
@@ -5,7 +5,7 @@ import { Modal } from "@/shared/ui/modal";
 import { usePutChangePetInformation } from "../api";
 
 export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
-  const { handleOpen, onClose, id } = useModal(() => (
+  const { handleOpen, onClose } = useModal(() => (
     <Modal modalType="fullPage">
       <Modal.Header
         onClick={() => {
@@ -49,7 +49,7 @@ export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
 
   const { mutate: putChangePetInformation, isPending } =
     usePutChangePetInformation({
-      modalId: id,
+      onSuccessCallback: onClose,
     });
 
   return handleOpen;

--- a/src/features/setting/hooks/useChangePetInfoModal.tsx
+++ b/src/features/setting/hooks/useChangePetInfoModal.tsx
@@ -48,9 +48,7 @@ export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
   ));
 
   const { mutate: putChangePetInformation, isPending } =
-    usePutChangePetInformation({
-      onSuccessCallback: onClose,
-    });
+    usePutChangePetInformation();
 
   return handleOpen;
 };

--- a/src/features/setting/hooks/useChangePetInfoModal.tsx
+++ b/src/features/setting/hooks/useChangePetInfoModal.tsx
@@ -5,10 +5,7 @@ import { Modal } from "@/shared/ui/modal";
 import { usePutChangePetInformation } from "../api";
 
 export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
-  const { mutate: putChangePetInformation, isPending } =
-    usePutChangePetInformation();
-
-  const { handleOpen, onClose } = useModal(() => (
+  const { handleOpen, onClose, id } = useModal(() => (
     <Modal modalType="fullPage">
       <Modal.Header
         onClick={() => {
@@ -36,24 +33,24 @@ export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
              * initialState 로 건내준 pet 정보와 변경 된 정보가 변경되지 않았다면
              * isChaProfile 을 false 로 설정합니다.
              */
-            putChangePetInformation(
-              {
-                name,
-                breed,
-                personalities,
-                description,
-                isChaProfile: !!profile.file || profile.url !== pet.profile,
-                image: profile.file,
-              },
-              {
-                onSuccess: onClose,
-              },
-            );
+            putChangePetInformation({
+              name,
+              breed,
+              personalities,
+              description,
+              isChaProfile: !!profile.file || profile.url !== pet.profile,
+              image: profile.file,
+            });
           }}
         />
       </Modal.Content>
     </Modal>
   ));
+
+  const { mutate: putChangePetInformation, isPending } =
+    usePutChangePetInformation({
+      modalId: id,
+    });
 
   return handleOpen;
 };

--- a/src/features/setting/hooks/useChangeRegionModal.tsx
+++ b/src/features/setting/hooks/useChangeRegionModal.tsx
@@ -12,14 +12,9 @@ export const useChangeRegionModal = (regions: MyInfo["regions"]) => {
       <RegionModal
         onClose={onClose}
         onSave={(regionList) => {
-          putChangeRegion(
-            {
-              newIds: regionList.map((region) => region.id),
-            },
-            {
-              onSuccess: onClose,
-            },
-          );
+          putChangeRegion({
+            newIds: regionList.map((region) => region.id),
+          });
         }}
         initialState={{
           regionList: regions,

--- a/src/features/setting/ui/passwordChangeModal.tsx
+++ b/src/features/setting/ui/passwordChangeModal.tsx
@@ -111,9 +111,7 @@ export const PasswordChangeModal = ({
     (state) => state.reset,
   );
 
-  const { mutate: putChangePassword, isPending } = usePutChangePassword({
-    onSuccessCallback: onClose,
-  });
+  const { mutate: putChangePassword, isPending } = usePutChangePassword();
 
   const handleSave = () => {
     const {

--- a/src/features/setting/ui/passwordSetModal.tsx
+++ b/src/features/setting/ui/passwordSetModal.tsx
@@ -77,9 +77,7 @@ export const PasswordSetModal = ({
 }) => {
   const resetPasswordSetForm = usePasswordSetFormStore((state) => state.reset);
 
-  const { mutate: putSetPassword, isPending } = usePutSetPassword({
-    onSuccessCallback: onClose,
-  });
+  const { mutate: putSetPassword, isPending } = usePutSetPassword();
 
   const handleSave = () => {
     const {

--- a/src/shared/lib/overlay.ts
+++ b/src/shared/lib/overlay.ts
@@ -8,6 +8,7 @@ type UseOverlay = (
   handleOpen: () => Promise<void>;
   onClose: () => Promise<void>;
   isOpen: boolean;
+  id: number;
 };
 
 const generateId = () => window.crypto.getRandomValues(new Uint32Array(1))[0];
@@ -18,7 +19,7 @@ export const useOverlay: UseOverlay = (
 ) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const { disableInteraction = true, beforeClose, afterClose } = options;
-  const id = generateId();
+  const [id] = useState(() => generateId()); // 불변하는 상태값 생성
 
   const addOverlay = useOverlayStore((state) => state.addOverlay);
   const removeOverlay = useOverlayStore((state) => state.removeOverlay);
@@ -43,7 +44,7 @@ export const useOverlay: UseOverlay = (
     setIsOpen(true);
   };
 
-  return { handleOpen, onClose, isOpen };
+  return { handleOpen, onClose, isOpen, id };
 };
 
 export const useSnackBar: UseOverlay = (createOverlayComponent, options) => {

--- a/src/shared/lib/overlay.ts
+++ b/src/shared/lib/overlay.ts
@@ -8,7 +8,6 @@ type UseOverlay = (
   handleOpen: () => Promise<void>;
   onClose: () => Promise<void>;
   isOpen: boolean;
-  id: number;
 };
 
 const generateId = () => window.crypto.getRandomValues(new Uint32Array(1))[0];
@@ -44,7 +43,7 @@ export const useOverlay: UseOverlay = (
     setIsOpen(true);
   };
 
-  return { handleOpen, onClose, isOpen, id };
+  return { handleOpen, onClose, isOpen };
 };
 
 export const useSnackBar: UseOverlay = (createOverlayComponent, options) => {


### PR DESCRIPTION
# 관련 이슈 번호
close #348 
# 설명


`staleAccessToken` 을 들고 mutation 을 보냈다고 가정 합니다.

이 때 `mutation` 은 모달에서 일어났고 뮤테이션이 성공하면 `onSuccess` 로 모달이 닫히게 됩니다.

`staleAcceeToken` 으로 인해 `mutation` 의 흐름은 이렇게 됩니다.

`1차 mutation -> 403 에러 -> queryClient.MutationCache.onError 에서 캐치 -> freshAccessToken 받아옴 -> 기존 mutation 재실행 -> onSuccess 실행`  

매우 다행이게도 `onSuccess` 까지 잘 시행 됩니다.

![image](https://github.com/user-attachments/assets/a1b2e13f-9aa7-40bf-9f9f-7ec119800de0)

> `profile` 을 새롭게  `GET` 요청 해오는 것이 `onSuccess` 가 실행 되었다는 증거입니다. 

하지만 문제는 모달이 닫히지 않습니다. 

도대체 왜?

![modal dosent close](https://github.com/user-attachments/assets/8904b089-a4f2-4b7d-b901-e8a337bf749e)

# useMutation 에게 onSuccessCallback 은 필수적으로 건내 줘야 합니다. 

실험해보니 `mutate.onSuccess` 에게 건내준 콜백은 `queryClinet.MutataionCached.onSuccess` 에서 호출 되지 않습니다. 

토큰에 대한 에러 처리를 하는 로직은 `useMutation` 의 콜백을 받아 작동 하기 때문입니다.

```tsx
      mutationCache: new MutationCache({
        onError: async (error, variables, context, mutation) => {
          switch (error.message) {
            case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
              await getNewAccessToken({
                queryClient,
                callbackFunctions: { setToken, resetAuthStore, navigate },
              });
              const { options, state } = mutation;
              try {
                ...
                // 실패했던 mutataion 의 onSuccess 를 다시 실행 합니다
                options.onSuccess?.(state.data, updatedVariables, context);
              } catch (error) {
                options.onError?.(error, variables, context);
              }
              break;
            }
```


```tsx
  const { mutate: putChangePetInformation, isPending } =
    usePutChangePetInformation({
      onSuccessCallback: onClose,
    });
```

다음과 같이 코드를 변경하고 `onSuccessCallback` 에게 건내줘봅시다 .

![image](https://github.com/user-attachments/assets/fb953f1e-98aa-4b7b-ad50-8ce6dcf2fb74)

순서대로 모달이 열렸을 때의 오버레이 스토어 -> onSuccesSCallback 에 의해 beforeClose , onClose 실행 -> 오버레이 스토어 

이상합니다. `onSuccessCallback` 에서 닫고자 하는 모달의 `id` 가 열려있는 모달의 `id` 를 바라보지 못합니다.

이상한 `onClose` 를 바라보고 있다는 것이 문제입니다. 

이런 문제는 왜 일어날까요 ?

# useOverlay 가 리렌더링 때 마다 새로운 `id` 를 생성해내게 되는 것이 문제 

```tsx
export const useOverlay: UseOverlay = (
  createOverlayComponent,
  options = {},
) => {
  const [isOpen, setIsOpen] = useState<boolean>(false);
  const { disableInteraction = true, beforeClose, afterClose } = options;
  const id = generateId();
```

`useOverlay` 는 새롭게 호출 될 때 마다 `id` 값을 새롭게 생성 합니다.

![image](https://github.com/user-attachments/assets/236c3a8e-16da-4953-a13a-9343529da82b)

`useMutataion` 과 `useModal` 을 함께 쓰게 되면 모달의 `id` 는 다음과 같이 생성 됩니다. 

1. 모달 열기를 트리거 하는 컴포넌트가 마운트 될 때 (모달과 오버레이 포탈이 바라보는 onClose 는 이 때의 id 값을 닫도록 정의 되어 있음)

![image](https://github.com/user-attachments/assets/0dbec383-d9ab-4dc8-b3dc-0e89607671b5)

모달이 열릴 때 오버레이 포탈에 존재하는 `id` 값입니다.

2. 모달이 열려 `useOverlay` 내부에 존재하는 `isOpen` 의 값이 바뀌었을 때 
![image](https://github.com/user-attachments/assets/75b0d0cd-a191-4bce-998c-a8449ae54940)> isOpen 상태가 변경 되어 useOverlay 가 재호출되고 새로운 id 가 생성 되었습니다.
> useOverlay 가 재호출되면서 useChangePetInfoModal 이 재호출 됩니다. 
> 2번째 재호출은 왜일어나는지 모르겠습니다. useMutation 이 정의되면서 재호출인가 .. ? 이건 모르겠습니다 ..
3. `useMutation` 의 실행이 일어나 `isPending` 의 상태가 바뀌었을 때 
![image](https://github.com/user-attachments/assets/672e53ce-670e-4ed4-a606-ed225eed72c3)
5. `useMutation` 의 실행이 끝나 `isPending` 의 상태가 종료 되었을 때 
![image](https://github.com/user-attachments/assets/f691f468-8c72-4d26-9404-7539d09b658e)

전체 사진
![image](https://github.com/user-attachments/assets/79235639-da95-45fe-a557-2fee8a50838d)

보게되면 오버레이 배열에 존재하는 `id` 는 `useModal` 이 처음 호출 될 때의 `id` 를 담은 배열이 들어가고 

마지막에 `onSuccessCallback` 에 의해 닫고자 하는 모달의 `id` 는 가장 마지막에 정의된 `id` 임을 알 수 있습니다. 

아마도 `useChangePetInfo` 부분이 리렌더링됨에 따라 `useMutataion` 의 `onSuccessCallback` 이 새로운 `id` 를 바라보는 onClsoe` 라 그러겠죠 ? 

# 이렇게 해결했습니다

![image](https://github.com/user-attachments/assets/8ff4711a-445e-4361-9e3f-2edb2152617e)

`id` 를 불변하는 상태값으로 생성해줍니다. 

이후 `onSuccessCallback` 에게 `onClose` 를 건내주면 됩니다. 

짝짝 

# 테스트 해보기 위해선

`useGetProfile` 의 쿼리 키에서 `token` 을 지워주세요 

그리고 `freshAccessToken` 을 들고 마이페이지에 접속 합니다.

마이페이지가 렌더링 되면 `stale AT & freshRT` 로 변경해주세요 

이후 펫 정보 수정에서 포스트 요청을 해주시면 됩니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
