### PR TITLE
[Hotfix] 센터 모달 스타일 오타로 인해 스타일 깨지는 문제 수정

### DIFF
--- a/src/shared/ui/modal/Modal.styles.ts
+++ b/src/shared/ui/modal/Modal.styles.ts
@@ -2,5 +2,5 @@ export const modalStyles = {
   fullPage:
     "left-0 top-0  h-full w-full max-w-[37.5rem] mx-auto flex flex-col gap-8 bg-grey-0 overflow-y-auto pb-32",
   center:
-    "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px- 6 py-6 overflow-y-auto max-h-[calc(100vh-1rem)]",
+    "shadow-custom-1 flex gap-8 fixed left-1/2 top-1/2 w-[20.5rem] -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-[1.75rem] bg-grey-0 px-6 py-6 overflow-y-auto max-h-[calc(100vh-1rem)]",
 } as const;


### PR DESCRIPTION
# 관련 이슈 번호
close #366
# 설명
## 버그 설명

![image](https://github.com/user-attachments/assets/0357b0c1-c470-41f6-ac38-74e3e88ade3d)

### 버그가 발생한 상황

![image](https://github.com/user-attachments/assets/1e2e973c-61a9-4d05-aba2-ee1dbd00b9fd)

지금 보니 센터 모달에서 `px-6` 부분에 `px- 6` 이라고 써져있네요 ... 으갸갹 

이 부분 띄어쓰기를 제거하도록 합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
