### PR TITLE
[Hotfix] 닉네임 변경 모달 버그 수정

### DIFF
--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -49,7 +49,14 @@ export const useCreateQueryClient = () => {
         },
       }),
       mutationCache: new MutationCache({
-        onSuccess: () => {
+        onSuccess: (data, variables, context, mutation) => {
+          // * 중복 닉네임 체크인 경우에만 모달을 닫지 않습니다.
+          if (
+            mutation.options.mutationKey?.includes("checkDuplicateNickname")
+          ) {
+            return;
+          }
+
           if (useOverlayStore.getState().overlays.length > 0) {
             resetOverlays();
           }

--- a/src/features/auth/api/putChangeNickname.ts
+++ b/src/features/auth/api/putChangeNickname.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
 import { AuthStore, useAuthStore } from "@/shared/store/auth";
 import { CHANGE_USER_INFO_END_POINT } from "../constants";
@@ -15,12 +15,18 @@ const putChangeNickname = async ({ nickname }: ChangeNicknameRequest) => {
 };
 
 export const usePutChangeNickname = () => {
+  const queryClient = useQueryClient();
   const setNickname = useAuthStore((state) => state.setNickname);
 
   return useMutation<unknown, Error, ChangeNicknameRequest>({
+    mutationKey: ["changeNickname"],
     mutationFn: putChangeNickname,
     onSuccess: (_, variables) => {
       setNickname(variables.nickname);
+
+      queryClient.invalidateQueries({
+        queryKey: ["myInfo"],
+      });
     },
   });
 };

--- a/src/features/auth/lib/validate.ts
+++ b/src/features/auth/lib/validate.ts
@@ -1,5 +1,6 @@
 export const validateNickname = (nickName: string) => {
-  const regExp = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{1,20}$/;
+  const regExp = /^[a-zA-Z0-9가-힣]{1,20}$/;
+
   return regExp.test(nickName);
 };
 

--- a/src/features/auth/ui/ChangeNicknameModal.tsx
+++ b/src/features/auth/ui/ChangeNicknameModal.tsx
@@ -23,7 +23,7 @@ export const ChangeNicknameModal = ({
 
   const handleOpenSnackbar = useSnackBar();
 
-  const { mutate: postChangeNickname, status: changeNicknameStatus } =
+  const { mutate: putChangeNickname, status: changeNicknameStatus } =
     usePutChangeNickname();
   const { isDuplicateNickname, isPending: isDuplicateCheckPending } =
     usePostCheckDuplicateNicknameState();
@@ -62,7 +62,7 @@ export const ChangeNicknameModal = ({
       return;
     }
 
-    postChangeNickname({ nickname });
+    putChangeNickname({ nickname });
   };
 
   return (

--- a/src/features/auth/ui/ChangeNicknameModal.tsx
+++ b/src/features/auth/ui/ChangeNicknameModal.tsx
@@ -16,14 +16,14 @@ export const ChangeNicknameModal = ({
   onClose,
   nickLastModDt,
 }: {
-  onClose: () => void;
+  onClose: () => Promise<void>;
   nickLastModDt: NonNullable<MyInfo["nickLastModDt"]>;
 }) => {
   const nicknameRef = useRef<HTMLInputElement | null>(null);
 
   const handleOpenSnackbar = useSnackBar();
 
-  const { mutate: putChangeNickname, status: changeNicknameStatus } =
+  const { mutate: putChangeNickname, isPending: isChangeNicknamePending } =
     usePutChangeNickname();
   const { isDuplicateNickname, isPending: isDuplicateCheckPending } =
     usePostCheckDuplicateNicknameState();
@@ -49,8 +49,9 @@ export const ChangeNicknameModal = ({
       return;
     }
 
-    const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-    const canChange = new Date(nickLastModDt) <= oneMonthAgo;
+    const now = new Date();
+    const oneMonthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const canChange = new Date(nickLastModDt) < oneMonthAgo;
 
     if (!canChange) {
       handleOpenSnackbar("한달 이후 닉네임을 변경해 주세요");
@@ -83,9 +84,7 @@ export const ChangeNicknameModal = ({
       <Modal.Footer axis="col">
         <Modal.FilledButton
           type="button"
-          disabled={
-            changeNicknameStatus === "pending" || isDuplicateCheckPending
-          }
+          disabled={isChangeNicknamePending || isDuplicateCheckPending}
           onClick={handleSubmit}
         >
           저장

--- a/src/features/auth/ui/NicknameInput.tsx
+++ b/src/features/auth/ui/NicknameInput.tsx
@@ -17,11 +17,14 @@ export const NicknameInput = forwardRef<HTMLInputElement, NicknameInputProps>(
     const [nickname, setNickname] = useState<string>("");
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const regex = /[^가-힣a-zA-Z0-9ㄱ-ㅎ\s]/g;
+      const filteredNickname = e.target.value.replace(regex, "");
+
       if (!isControlled) {
-        setNickname(e.target.value);
+        setNickname(filteredNickname);
       }
 
-      onChange?.(e.target.value);
+      onChange?.(filteredNickname);
     };
 
     const {

--- a/src/features/auth/ui/NicknameInput.tsx
+++ b/src/features/auth/ui/NicknameInput.tsx
@@ -11,12 +11,18 @@ interface NicknameInputProps {
 
 export const NicknameInput = forwardRef<HTMLInputElement, NicknameInputProps>(
   ({ nickname: controlledNickname, onChange }, ref) => {
+    const MAX_LENGTH = 20;
+
     const isControlled = typeof controlledNickname !== "undefined";
 
     const token = useAuthStore((state) => state.token);
     const [nickname, setNickname] = useState<string>("");
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.value.length > MAX_LENGTH) {
+        e.target.value = e.target.value.slice(0, MAX_LENGTH);
+      }
+
       const regex = /[^가-힣a-zA-Z0-9ㄱ-ㅎ\s]/g;
       const filteredNickname = e.target.value.replace(regex, "");
 
@@ -47,7 +53,7 @@ export const NicknameInput = forwardRef<HTMLInputElement, NicknameInputProps>(
       postDuplicateNickname({ nickname });
     };
 
-    let statusText = "20자 이내의 한글 영어 숫자만 사용 가능합니다.";
+    let statusText = `${MAX_LENGTH}자 이내의 한글 영어 숫자만 사용 가능합니다.`;
 
     if (isDuplicateNickname) {
       statusText = "이미 존재하는 닉네임입니다.";
@@ -71,11 +77,11 @@ export const NicknameInput = forwardRef<HTMLInputElement, NicknameInputProps>(
         value={isControlled ? controlledNickname : nickname}
         onChange={handleChange}
         onBlur={handleBlur}
-        maxLength={20}
+        maxLength={MAX_LENGTH}
         trailingNode={
           <ValueLength
             value={isControlled ? controlledNickname : nickname}
-            maxLength={20}
+            maxLength={MAX_LENGTH}
           />
         }
       />

--- a/src/pages/setting/edit-info/page.tsx
+++ b/src/pages/setting/edit-info/page.tsx
@@ -51,9 +51,12 @@ const NicknameButton = ({
     ),
     {
       beforeClose: () => {
-        const mutationCache = queryClient.getMutationCache().find({
-          mutationKey: ["changeNickname"],
-        });
+        const mutationCache = queryClient
+          .getMutationCache()
+          .findAll({
+            mutationKey: ["changeNickname"],
+          })
+          .reverse()[0];
 
         if (mutationCache?.state.status === "pending") {
           return true;

--- a/src/pages/setting/edit-info/page.tsx
+++ b/src/pages/setting/edit-info/page.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { ChangeNicknameModal } from "@/features/auth/ui/ChangeNicknameModal";
 import { useSettingPermission } from "@/features/setting/hooks";
 import { GenderChangeButton } from "@/features/setting/ui";
@@ -42,10 +43,24 @@ const NicknameButton = ({
   nickLastModDt: NonNullable<MyInfo["nickLastModDt"]>;
 }) => {
   const nickname = useAuthStore((state) => state.nickname);
+  const queryClient = useQueryClient();
 
-  const { handleOpen, onClose } = useModal(() => (
-    <ChangeNicknameModal onClose={onClose} nickLastModDt={nickLastModDt} />
-  ));
+  const { handleOpen, onClose } = useModal(
+    () => (
+      <ChangeNicknameModal onClose={onClose} nickLastModDt={nickLastModDt} />
+    ),
+    {
+      beforeClose: () => {
+        const mutationCache = queryClient.getMutationCache().find({
+          mutationKey: ["changeNickname"],
+        });
+
+        if (mutationCache?.state.status === "pending") {
+          return true;
+        }
+      },
+    },
+  );
 
   return (
     <button className="setting-item" onClick={handleOpen}>


### PR DESCRIPTION
# 관련 이슈 번호

#293 

# 설명

## 1. nickname 인풋 정규표현식 수정

nickname 인풋에서 한글을 입력했을 때 예외 상황이 있어서 수정했습니다.

- 자음만 입력해도 에러가 표시됩니다.
- 모음만 입력할 수 없습니다.
- input에 한글을 입력했을 경우 최대 글자수를 지키지 못하는 문제가 있었습니다.
 
https://github.com/user-attachments/assets/4766e24d-644c-4f83-a025-0bc6363a5dcb

```typescript
const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
      if (e.target.value.length > MAX_LENGTH) {
        e.target.value = e.target.value.slice(0, MAX_LENGTH);
      }

      const regex = /[^가-힣a-zA-Z0-9ㄱ-ㅎ\s]/g;
      const filteredNickname = e.target.value.replace(regex, "");

      if (!isControlled) {
        setNickname(filteredNickname);
      }

      onChange?.(filteredNickname);
};
```
- change 핸들러에 value의 길이가 최대 글자수를 초과했을 경우 String.slice로 글자수를 제한하였습니다.

## 2. 닉네임 중복 검사 응답이 오면 모달이 닫히는 문제

mutationCache에 onSuccess일 경우 모든 모달들을 닫히도록 구현되어있었습니다.
닉네임 변경 요청을 보내기 전에 post 요청인 닉네임 중복 검사가 완료되어 닫히는 문제가 있었습니다.
그래서 mutationCache에서 mutationKey가 닉네임 중복검사 mutationKey일 경우 모달을 닫지 않도록 하였습니다.