### PR TITLE
[Hotfix] 동네 수정 엔드포인트 변경 

### DIFF
--- a/src/features/setting/constants/endpoint.ts
+++ b/src/features/setting/constants/endpoint.ts
@@ -2,7 +2,7 @@ import { API_BASE_URL } from "@/shared/constants";
 
 export const SETTING_END_POINT = {
   LOGOUT: `${API_BASE_URL}/logout`,
-  CHANGE_REGION: `${API_BASE_URL}/users/profile/address`,
+  CHANGE_REGION: `${API_BASE_URL}/users/profile/addresses`,
   DELETE_ACCOUNT: `${API_BASE_URL}/users/me`,
   CHANGE_GENDER: `${API_BASE_URL}/users/profile/gender`,
   CHANGE_PASSWORD: `${API_BASE_URL}/users/profile/password`,


### PR DESCRIPTION
# 관련 이슈 번호
close #380
# 설명
동네 수정 요청의 엔드포인트는 `/users/profile/addresses` 인데 현재 `/users/profile/address` 로 되어 있어 수정 합니다.
# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
