### PR TITLE
[Feat] 팔로워 삭제 기능 구현

### DIFF
--- a/src/features/follow/api/deleteFollower.ts
+++ b/src/features/follow/api/deleteFollower.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import { Nickname } from "@/entities/profile/api";
+import { apiClient } from "@/shared/lib";
+import { FOLLOW_END_POINT } from "../constants";
+
+interface DeleteFollowerRequest {
+  nickname: Nickname;
+}
+
+export const useDeleteFollower = () => {
+  return useMutation({
+    mutationFn: (nickname: DeleteFollowerRequest["nickname"]) =>
+      apiClient.delete(FOLLOW_END_POINT.DELETE_FOLLOWER(nickname), {
+        withToken: true,
+      }),
+  });
+};

--- a/src/features/follow/api/index.ts
+++ b/src/features/follow/api/index.ts
@@ -1,2 +1,3 @@
 export * from "./deleteFollowing";
 export * from "./postFollowing";
+export * from "./deleteFollower";

--- a/src/features/follow/constants/endpoint.ts
+++ b/src/features/follow/constants/endpoint.ts
@@ -6,4 +6,6 @@ export const FOLLOW_END_POINT = {
     `${API_BASE_URL}/users/follows/my-followings/${nickname}`,
   DELETE_FOLLOWING: (nickname: Nickname) =>
     `${API_BASE_URL}/users/follows/my-followings/${nickname}`,
+  DELETE_FOLLOWER: (nickname: Nickname) =>
+    `${API_BASE_URL}/users/follows/my-followers/${nickname}`,
 };

--- a/src/features/follow/ui/deleteFollowerButton.tsx
+++ b/src/features/follow/ui/deleteFollowerButton.tsx
@@ -1,12 +1,15 @@
 import { Button } from "@/shared/ui/button";
 
-export const DeleteFollowerButton = () => {
+export const DeleteFollowerButton = (
+  props: React.ButtonHTMLAttributes<HTMLButtonElement>,
+) => {
   return (
     <Button
       size="small"
       variant="outlined"
       colorType="tertiary"
       fullWidth={false}
+      {...props}
     >
       삭제
     </Button>

--- a/src/mocks/data/otherUser.ts
+++ b/src/mocks/data/otherUser.ts
@@ -5,7 +5,7 @@ export const otherUsers = Array.from({ length: 400 }).map((_, i) => ({
   socialType: null,
   tempCnt: 0,
   followersIds: Math.random() < 0.3 ? [1] : [],
-  followingIds: i < 200 ? [1] : [],
+  followingsIds: i < 200 ? [1] : [],
   pet: {
     petId: i + 1,
     name: `name-${i + 1}`,

--- a/src/mocks/data/user.ts
+++ b/src/mocks/data/user.ts
@@ -24,7 +24,7 @@ export const User = {
       nickname: "뽀송송",
       socialType: "EMAIL",
       followersIds: otherUsers
-        .filter(({ followingIds }) => followingIds.includes(1))
+        .filter(({ followingsIds }) => followingsIds.includes(1))
         .map(({ userId }) => userId),
       followingsIds: otherUsers
         .filter(({ followersIds }) => followersIds.includes(1))

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1083,7 +1083,8 @@ const getFollowingListHandler = [
       const followingIds =
         nickname === "뽀송송"
           ? User["ROLE_USER"].content.followingsIds
-          : otherUsers.find((user) => user.nickname === nickname)?.followingIds;
+          : otherUsers.find((user) => user.nickname === nickname)
+              ?.followingsIds;
 
       if (!followingIds) {
         return HttpResponse.json(
@@ -1291,6 +1292,68 @@ const deleteFollowingHandler = [
   ),
 ];
 
+const deleteFollowerHandler = [
+  http.delete(
+    `${API_BASE_URL}/users/follows/my-followers/:nickname`,
+    async ({ request, params }) => {
+      await new Promise((res) => setTimeout(res, 1000));
+      const token = request.headers.get("Authorization");
+
+      if (token === "staleAccessToken") {
+        return HttpResponse.json(
+          {
+            code: 401,
+            message: ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED,
+          },
+          {
+            status: 401,
+          },
+        );
+      }
+      const { nickname } = params;
+
+      if (typeof nickname !== "string") {
+        return HttpResponse.json(
+          {
+            code: 400,
+            message: "잘못된 요청입니다.",
+          },
+          {
+            status: 400,
+          },
+        );
+      }
+
+      const targetUser = otherUsers.find((user) => user.nickname === nickname);
+
+      if (!targetUser) {
+        return HttpResponse.json(
+          {
+            code: 404,
+            message: "해당하는 유저를 찾을 수 없습니다.",
+          },
+          {
+            status: 404,
+          },
+        );
+      }
+      // 내 팔로워 ID 에 해당 유저의 userId 제거
+      User["ROLE_USER"].content.followersIds = User[
+        "ROLE_USER"
+      ].content.followersIds.filter((id) => id !== targetUser.userId);
+      // 팔로워 취소 당하는 유저의 팔로잉 ID 에 내 userId 제거
+      targetUser.followingsIds = targetUser.followingsIds.filter(
+        (id) => id !== 1,
+      );
+
+      return HttpResponse.json({
+        code: 200,
+        message: "success",
+      });
+    },
+  ),
+];
+
 // * 나중에 msw 사용을 대비하여 만들었습니다.
 export const handlers = [
   ...signUpByEmailHandlers,
@@ -1315,4 +1378,5 @@ export const handlers = [
   ...getMarkingListHandler,
   ...postFollowingHandler,
   ...deleteFollowingHandler,
+  ...deleteFollowerHandler,
 ];

--- a/src/widgets/follow/followerUserItem.tsx
+++ b/src/widgets/follow/followerUserItem.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { usePostFollowing } from "@/features/follow/api";
+import { useDeleteFollower, usePostFollowing } from "@/features/follow/api";
 import { FollowingButton, DeleteFollowerButton } from "@/features/follow/ui";
 import type {
   Nickname,
@@ -21,7 +21,11 @@ export const FollowerUserItem = ({
   isFollowing,
 }: FollowerUserItemProps) => {
   const [_isFollowing, _setIsFollowing] = useState(() => isFollowing);
+  const [isDeleted, setIsDeleted] = useState<boolean>(false);
+
   const { mutate: postFollowing } = usePostFollowing();
+  const { mutate: deleteFollower } = useDeleteFollower();
+
   const handleOptimisticFollowing = () => {
     _setIsFollowing(true);
     postFollowing(nickname, {
@@ -30,6 +34,19 @@ export const FollowerUserItem = ({
       },
     });
   };
+
+  const handleOptimisticDeleteFollower = () => {
+    setIsDeleted(true);
+    deleteFollower(nickname, {
+      onError: () => {
+        setIsDeleted(false);
+      },
+    });
+  };
+
+  if (isDeleted) {
+    return null;
+  }
 
   return (
     <li className="px-4 flex  gap-4 overflow-y-auto">
@@ -52,7 +69,7 @@ export const FollowerUserItem = ({
         </div>
         <p className="body-3 text-grey-500">{petName}</p>
       </div>
-      <DeleteFollowerButton />
+      <DeleteFollowerButton onClick={handleOptimisticDeleteFollower} />
     </li>
   );
 };


### PR DESCRIPTION
# 관련 이슈 번호
close #384 
# 설명

뮤테이션을 생성하고 컴포넌트 내부에서 낙관적 업데이트를 위해 `isDeleted` 라는 상태를 생성 했습니다.

```tsx
export const useDeleteFollower = () => {
  return useMutation({
    mutationFn: (nickname: DeleteFollowerRequest["nickname"]) =>
      apiClient.delete(FOLLOW_END_POINT.DELETE_FOLLOWER(nickname), {
        withToken: true,
      }),
  });
};
```

```tsx

export const FollowerUserItem = ({
  nickname,
  petName,
  profile,
  isFollowing,
}: FollowerUserItemProps) => {
  const [_isFollowing, _setIsFollowing] = useState(() => isFollowing);
  const [isDeleted, setIsDeleted] = useState<boolean>(false);

  const { mutate: postFollowing } = usePostFollowing();
  const { mutate: deleteFollower } = useDeleteFollower();

  const handleOptimisticFollowing = () => {
    _setIsFollowing(true);
    postFollowing(nickname, {
      onError: () => {
        _setIsFollowing(false);
      },
    });
  };

  const handleOptimisticDeleteFollower = () => {
    setIsDeleted(true);
    deleteFollower(nickname, {
      onError: () => {
        setIsDeleted(false);
      },
    });
  };

  if (isDeleted) {
    return null;
  }

  return (
    <li className="px-4 flex  gap-4 overflow-y-auto">
      {/* TODO 로딩상태가 함께 있는 ProfileImage 컴포넌트 만들어서 대체하기 */}
      <img
        src={
          profile ? `${API_BASE_URL}/pets/image/${profile}` : MASCOT_IMAGE_URL
        }
        className="w-10 h-10 rounded-[1.75rem]"
      />
      <div className="flex flex-col justify-center flex-1">
        <div className="flex gap-2">
          <p className="title-2 text-grey-700">{nickname}</p>
          {!_isFollowing && (
            <FollowingButton
              buttonType="mini"
              onClick={handleOptimisticFollowing}
            />
          )}
        </div>
        <p className="body-3 text-grey-500">{petName}</p>
      </div>
      <DeleteFollowerButton onClick={handleOptimisticDeleteFollower} />
    </li>
  );
};
```

이 부분도 완벽하지 않은 부분이 많습니다. 

팔로잉 때와 마찬가지로 팔로워 삭제 후 다시 팔로워 페이지에 접속 한 경우 

이전 데이터를 먼저 보여주는 리액트 쿼리 특성 상 해당 팔로워가 지워지지 않은 거 처럼 먼저 보이게 되고 이후 사라지게 됩니다.

이 문제는 로딩 상태를 추가하거나

`setQueryData` 로 아예 캐싱 된 데이터 자체를 조작하면 될 거 같은데 캐싱 된 데이터 자체를 `queryClient.getQueryData` 로 접근하려 해도 매번 `undefined` 가 나오네요 

이 문제는 어떻게 해야할지 모르겠으나 우선 기능 동작 하여 PR 올립니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
