### PR TITLE
[Feat] 맵 바텀 시트 컴포넌트 생성 및 마킹 정렬 필터와 노출 범위 필터 구현

### DIFF
--- a/src/app/FooterNavigationBar.tsx
+++ b/src/app/FooterNavigationBar.tsx
@@ -1,11 +1,4 @@
-import { useRef } from "react";
-import { Sheet, SheetRef } from "react-modal-sheet";
-import { NavLink, useLocation } from "react-router-dom";
-import { useResearchMarkingList } from "@/features/map/hooks";
-import { useMapStore } from "@/features/map/store";
-import { MarkingItem } from "@/features/marking/ui";
-import { useGetMarkingList } from "@/entities/marking/api";
-import { MarkingList } from "@/entities/marking/ui";
+import { NavLink } from "react-router-dom";
 import { useGetProfile } from "@/entities/profile/api";
 import { API_BASE_URL, ROUTER_PATH } from "@/shared/constants";
 import { useAuthStore } from "@/shared/store";
@@ -20,82 +13,8 @@ const footerNavigationBarStyles = {
 export const FooterNavigationBar = () => {
   const { active, inactive, base } = footerNavigationBarStyles;
 
-  const location = useLocation();
-
-  const ref = useRef<HTMLDivElement>(null);
-  const sheetRef = useRef<SheetRef>();
-
-  const snapPoints = [-50, 0.5, 116];
-  const initialSnap = snapPoints.length - 1;
-
-  const snapPointRef = useRef(initialSnap);
-  const snapTo = (i: number) => sheetRef.current?.snapTo(i);
-
-  const { bounds } = useResearchMarkingList();
-  const { data: markingList } = useGetMarkingList({
-    southWestLat: bounds?.southWest.lat,
-    southWestLng: bounds?.southWest.lng,
-    northEastLat: bounds?.northEast.lat,
-    northEastLng: bounds?.northEast.lng,
-    sortType: "RECENT",
-  });
-
-  const mapMode = useMapStore((state) => state.mode);
-
   return (
-    <footer ref={ref} className="relative">
-      <Sheet
-        ref={sheetRef}
-        isOpen={location.pathname === "/map" && mapMode === "view"}
-        onClose={() => {
-          const isSheetTop = snapPointRef.current === 0;
-
-          if (isSheetTop) {
-            snapTo(snapPointRef.current - 1);
-            return;
-          }
-
-          snapTo(initialSnap);
-        }}
-        snapPoints={snapPoints}
-        initialSnap={initialSnap}
-        onSnap={(snapPointIndex) => (snapPointRef.current = snapPointIndex)}
-        style={{ zIndex: 1 }}
-        mountPoint={ref.current || document.querySelector("#root")!}
-      >
-        <Sheet.Container>
-          <Sheet.Header />
-          <Sheet.Content
-            style={{
-              padding: 0,
-              paddingBottom: sheetRef.current?.y,
-            }}
-          >
-            <Sheet.Scroller
-              draggableAt="both"
-              style={{
-                height: "calc(100% - 5rem)",
-              }}
-            >
-              {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
-              <h1 className="title-1 text-grey-900 p-4">주변 마킹</h1>
-
-              <div className="px-4">
-                <MarkingList>
-                  {markingList?.map((marking) => (
-                    <MarkingItem
-                      key={marking.markingId}
-                      {...marking}
-                      onRegionClick={() => {}}
-                    />
-                  ))}
-                </MarkingList>
-              </div>
-            </Sheet.Scroller>
-          </Sheet.Content>
-        </Sheet.Container>
-      </Sheet>
-
+    <footer className="relative">
       <nav className="relative z-10">
         <ul className="flex justify-between items-center gap-2 bg-grey-0 px-2 h-20">
           <li className="grow">

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -58,6 +58,8 @@ export interface Marking {
   images: Image[];
 }
 
+export type SortType = "RECENT" | "DISTANCE" | "POPULARITY";
+
 export interface GetMarkingListRequest {
   southWestLat: number;
   southWestLng: number;
@@ -66,7 +68,7 @@ export interface GetMarkingListRequest {
   lat: number;
   lng: number;
   offset: number; // 페이지 번호
-  sortType: "RECENT" | "DISTANCE" | "POPULARITY"; // 정렬 기준
+  sortType: SortType;
 }
 
 // sort, paged, unpaged은 사용하지 x

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -144,6 +144,7 @@ export const useGetMarkingList = ({
       southWestLng,
       northEastLat,
       northEastLng,
+      sortType,
     ],
 
     queryFn:

--- a/src/entities/marking/ui/MarkingList.tsx
+++ b/src/entities/marking/ui/MarkingList.tsx
@@ -1,9 +1,0 @@
-import { ReactNode } from "react";
-
-interface ContentListProps {
-  children: ReactNode;
-}
-
-export const MarkingList = ({ children }: ContentListProps) => {
-  return <ul className="flex flex-col gap-8">{children}</ul>;
-};

--- a/src/entities/marking/ui/index.ts
+++ b/src/entities/marking/ui/index.ts
@@ -1,2 +1,1 @@
-export * from "./markingList";
 export * from "./dashboard";

--- a/src/entities/marking/ui/markingList.tsx
+++ b/src/entities/marking/ui/markingList.tsx
@@ -1,9 +1,0 @@
-import { ReactNode } from "react";
-
-interface ContentListProps {
-  children: ReactNode;
-}
-
-export const MarkingList = ({ children }: ContentListProps) => {
-  return <ul className="flex flex-col gap-8">{children}</ul>;
-};

--- a/src/features/map/constants/index.ts
+++ b/src/features/map/constants/index.ts
@@ -1,3 +1,5 @@
+import type { SortType } from "@/entities/marking/api";
+
 /**
  * Google map 에 사용 할 옵션들을 지정한 객체입니다.
  * 사용 가능한 객체들은 다음과 같은 곳에서 확인할 수 있습니다.
@@ -49,6 +51,12 @@ export const mapOptions = {
 
   // 모든 제스처를 활성화합니다. 사용자는 한 손가락으로 드래그하고, 두 손가락으로 확대/축소할 수 있습니다.
   gestureHandling: "greedy",
+};
+
+export const sortTypeMap: Record<SortType, string> = {
+  RECENT: "최신순",
+  DISTANCE: "거리순",
+  POPULARITY: "인기순",
 };
 
 export const MAP_INITIAL_CENTER = { lat: 37.5665, lng: 126.978 };

--- a/src/features/map/constants/index.ts
+++ b/src/features/map/constants/index.ts
@@ -59,6 +59,12 @@ export const sortTypeMap: Record<SortType, string> = {
   POPULARITY: "인기순",
 };
 
+export const mapViewModeMap = {
+  ALL_VIEW: "전체보기", // 내 마킹에서만 있는 option
+  CURRENT_LOCATION: "내 위치 중심",
+  MAP_LOCATION: "현재 지도 중심",
+};
+
 export const MAP_INITIAL_CENTER = { lat: 37.5665, lng: 126.978 };
 export const MAP_INITIAL_ZOOM = 16;
 export const MAP_INITIAL_BOUNDS = {

--- a/src/features/map/constants/index.ts
+++ b/src/features/map/constants/index.ts
@@ -55,7 +55,7 @@ export const mapOptions = {
 
 export const sortTypeMap: Record<SortType, string> = {
   RECENT: "최신순",
-  DISTANCE: "거리순",
+  DISTANCE: "가까운순",
   POPULARITY: "인기순",
 };
 

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -19,12 +19,22 @@ export const useResearchMarkingList = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const sortTypeParam = searchParams.get("sortType");
+  const sortType =
+    typeof sortTypeParam === "string" && sortTypeParam in sortTypeMap
+      ? (sortTypeParam as SortType)
+      : "RECENT";
+
   const researchMarkingList = (filter?: Filter) => {
     if (!map) return;
 
+    const mapCenter = map.getCenter();
     const bounds = map.getBounds();
 
     if (!bounds) return;
+
+    const lat = mapCenter.lat();
+    const lng = mapCenter.lng();
 
     const northEast = bounds.getNorthEast();
     const southWest = bounds.getSouthWest();
@@ -39,7 +49,9 @@ export const useResearchMarkingList = () => {
       boundsNELng: northEastLng.toString(),
       boundsSWLat: southWestLat.toString(),
       boundsSWLng: southWestLng.toString(),
-      sortType: filter?.sortType || "RECENT",
+      lat: lat.toString(),
+      lng: lng.toString(),
+      sortType: filter?.sortType || sortType,
     });
 
     setIsLastSearchedLocation(true);
@@ -76,14 +88,18 @@ export const useResearchMarkingList = () => {
       }
     : null;
 
-  const sortTypeParam = searchParams.get("sortType");
-  const sortType =
-    typeof sortTypeParam === "string" && sortTypeParam in sortTypeMap
-      ? (sortTypeParam as SortType)
-      : "RECENT";
+  const lat =
+    typeof searchParams.get("lat") === "string"
+      ? Number(searchParams.get("lat"))
+      : null;
+  const lng =
+    typeof searchParams.get("lng") === "string"
+      ? Number(searchParams.get("lng"))
+      : null;
 
   return {
     bounds,
+    center: { lat, lng },
     sortType,
     researchMarkingList,
   };

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -54,7 +54,9 @@ export const useResearchMarkingList = () => {
       sortType: filter?.sortType || sortType,
     });
 
-    setIsLastSearchedLocation(true);
+    setTimeout(() => {
+      setIsLastSearchedLocation(true);
+    }, 0);
 
     queryClient.removeQueries({
       queryKey: ["markingList"],

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -1,7 +1,13 @@
 import { useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMap } from "@vis.gl/react-google-maps";
+import { SortType } from "@/entities/marking/api";
+import { sortTypeMap } from "../constants";
 import { useMapStore } from "../store";
+
+interface Filter {
+  sortType?: SortType;
+}
 
 export const useResearchMarkingList = () => {
   const queryClient = useQueryClient();
@@ -13,7 +19,7 @@ export const useResearchMarkingList = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const researchMarkingList = () => {
+  const researchMarkingList = (filter?: Filter) => {
     if (!map) return;
 
     const bounds = map.getBounds();
@@ -22,8 +28,6 @@ export const useResearchMarkingList = () => {
 
     const northEast = bounds.getNorthEast();
     const southWest = bounds.getSouthWest();
-
-    if (!northEast || !southWest) return;
 
     const northEastLat = northEast.lat();
     const northEastLng = northEast.lng();
@@ -35,6 +39,7 @@ export const useResearchMarkingList = () => {
       boundsNELng: northEastLng.toString(),
       boundsSWLat: southWestLat.toString(),
       boundsSWLng: southWestLng.toString(),
+      sortType: filter?.sortType || "RECENT",
     });
 
     setIsLastSearchedLocation(true);
@@ -71,8 +76,15 @@ export const useResearchMarkingList = () => {
       }
     : null;
 
+  const sortTypeParam = searchParams.get("sortType");
+  const sortType =
+    typeof sortTypeParam === "string" && sortTypeParam in sortTypeMap
+      ? (sortTypeParam as SortType)
+      : "RECENT";
+
   return {
     bounds,
+    sortType,
     researchMarkingList,
   };
 };

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -20,10 +20,10 @@ export const useResearchMarkingList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const sortTypeParam = searchParams.get("sortType");
-  const sortType =
+  const sortType: SortType =
     typeof sortTypeParam === "string" && sortTypeParam in sortTypeMap
       ? (sortTypeParam as SortType)
-      : "RECENT";
+      : "POPULARITY";
 
   const researchMarkingList = (filter?: Filter) => {
     if (!map) return;

--- a/src/features/map/store/map.ts
+++ b/src/features/map/store/map.ts
@@ -19,6 +19,7 @@ interface UserInfo {
 }
 
 interface MapState {
+  isIdle: boolean;
   userInfo: UserInfo;
   mode: Mode;
   isCenterOnMyLocation: boolean;
@@ -26,6 +27,7 @@ interface MapState {
 }
 
 interface MapActions {
+  setIsIdle: (isIdle: boolean) => void;
   setUserInfo: (userInfo: UserInfo) => void;
   setMode: (mode: Mode) => void;
   setIsCenterOnMyLocation: (isCenterOnMyLocation: boolean) => void;
@@ -33,6 +35,7 @@ interface MapActions {
 }
 
 const mapStoreInitialState: MapState = {
+  isIdle: false,
   userInfo: {
     currentLocation: { lat: null, lng: null },
     hasLocationPermission: false,
@@ -50,4 +53,5 @@ export const useMapStore = create<MapState & MapActions>((set) => ({
     set({ isCenterOnMyLocation }),
   setIsLastSearchedLocation: (isLastSearchedLocation) =>
     set({ isLastSearchedLocation }),
+  setIsIdle: (isIdle) => set({ isIdle }),
 }));

--- a/src/features/marking/ui/index.ts
+++ b/src/features/marking/ui/index.ts
@@ -1,2 +1,3 @@
 export * from "./markingItem";
 export * from "./markingFormModal";
+export * from "./markingFilter";

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -1,5 +1,10 @@
-import { sortTypeMap } from "@/features/map/constants";
-import { useResearchMarkingList } from "@/features/map/hooks";
+import { useMap } from "@vis.gl/react-google-maps";
+import { mapViewModeMap, sortTypeMap } from "@/features/map/constants";
+import {
+  useCurrentLocation,
+  useResearchMarkingList,
+} from "@/features/map/hooks";
+import { useMapStore } from "@/features/map/store";
 import { SortType } from "@/entities/marking/api";
 import { useModal } from "@/shared/lib";
 import { Button } from "@/shared/ui/button";
@@ -65,6 +70,126 @@ export const SortTypeFilter = () => {
   return (
     <MarkingFilterButton onClick={handleOpen}>
       {sortTypeMap[sortType]}
+    </MarkingFilterButton>
+  );
+};
+
+type MapViewMode = keyof typeof mapViewModeMap;
+
+// 내마킹 url
+// map/nickname?sortType => 전체보기 (기본값)
+// map/nickname?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 같은 경우 => 내 위치 중심
+// map/nickname?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 다른 경우 => 현재 지도 중심
+
+// 동네마킹 url
+// map?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 같은 경우 => 내 위치 중심 (기본값)
+// map?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 다른 경우 => 현재 지도 중심
+
+/**
+ * 내 마킹, 동네마킹에서 사용하는 필터
+ * 내 마킹에서 [전체보기], [내 위치 중심], [현재 지도 중심] 옵션 제공
+ * 동네 마킹에서 [내 위치 중심], [현재 지도 중심] 옵션 제공
+ *
+ * 옵션
+ * ALL_VIEW: [전체보기]
+ * CURRENT_LOCATION: [내 위치 중심]
+ * MAP_LOCATION: [현재 지도 중심]
+ *
+ * @param includeAllViewMode: [전체보기] 옵션 포함 여부
+ */
+export const MapViewModeFilter = ({
+  includeAllViewMode,
+}: {
+  includeAllViewMode: boolean;
+}) => {
+  const { currentLocation } = useMapStore((state) => state.userInfo);
+  const setIsCenteredOnMyLocation = useMapStore(
+    (state) => state.setIsCenterOnMyLocation,
+  );
+  const { researchMarkingList, center } = useResearchMarkingList();
+  const { setCurrentLocation } = useCurrentLocation();
+
+  const map = useMap();
+
+  const handleSelect = (mapViewMode: MapViewMode) => {
+    if (mapViewMode === "CURRENT_LOCATION") {
+      setCurrentLocation({
+        onSuccess: ({ coords: { latitude, longitude } }) => {
+          map.setCenter({
+            lat: latitude,
+            lng: longitude,
+          });
+
+          setTimeout(() => {
+            setIsCenteredOnMyLocation(true);
+          }, 0);
+
+          researchMarkingList();
+        },
+      });
+
+      return;
+    }
+
+    if (mapViewMode === "MAP_LOCATION") {
+      if (isCurrentLocation) {
+        // todo 현재 지도 중심과 내 위치 중심이 같을 경우 어떻게 해야할 지 => snack bar 띄우기?
+      }
+      researchMarkingList();
+    }
+
+    // todo mapViewMode가 ALL_VIEW일 경우
+  };
+
+  const defaultMapViewMode: MapViewMode = includeAllViewMode
+    ? "ALL_VIEW"
+    : "CURRENT_LOCATION";
+
+  let mapViewMode: MapViewMode = defaultMapViewMode;
+
+  const isCurrentLocation =
+    !!currentLocation.lat &&
+    !!currentLocation.lng &&
+    center.lat === currentLocation.lat &&
+    center.lng === currentLocation.lng;
+
+  if (!isCurrentLocation) mapViewMode = "MAP_LOCATION";
+
+  const { handleOpen, onClose, isOpen } = useModal(() => (
+    <Modal modalType="center">
+      <Select isOpen={isOpen} onClose={onClose}>
+        <Select.OptionList>
+          <Select.Option
+            value={defaultMapViewMode}
+            onClick={() => handleSelect(defaultMapViewMode)}
+            isSelected={mapViewMode === defaultMapViewMode}
+          >
+            {mapViewModeMap[defaultMapViewMode]}
+          </Select.Option>
+
+          {Object.keys(mapViewModeMap)
+            .filter((key) => includeAllViewMode || key !== "ALL_VIEW")
+            .filter((key) => key !== defaultMapViewMode)
+            .map((key) => {
+              return (
+                <Select.Option
+                  key={key}
+                  value={key}
+                  onClick={() => handleSelect(key as MapViewMode)}
+                  isSelected={mapViewMode === key}
+                >
+                  {mapViewModeMap[key as MapViewMode]}
+                </Select.Option>
+              );
+            })}
+        </Select.OptionList>
+      </Select>
+    </Modal>
+  ));
+
+  return (
+    <MarkingFilterButton onClick={handleOpen}>
+      {mapViewModeMap[mapViewMode]}
     </MarkingFilterButton>
   );
 };

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -126,22 +126,33 @@ type MapViewMode = keyof typeof mapViewModeMap;
 // map?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 다른 경우 => 현재 지도 중심
 
 /**
- * 내 마킹, 동네마킹에서 사용하는 필터
- * 내 마킹에서 [전체보기], [내 위치 중심], [현재 지도 중심] 옵션 제공
- * 동네 마킹에서 [내 위치 중심], [현재 지도 중심] 옵션 제공
+ * 마킹 노출 범위 필터
  *
  * 옵션
  * ALL_VIEW: [전체보기]
  * CURRENT_LOCATION: [내 위치 중심]
  * MAP_LOCATION: [현재 지도 중심]
  *
+ * ! [전체보기] 옵션은 내 마킹에서만 제공합니다.
+ *
+ * 내 마킹: [전체보기] (기본값), [내 위치 중심], [현재 지도 중심]
+ * 동네 마킹: [내 위치 중심] (기본값), [현재 지도 중심]
+ *
  * @param includeAllViewMode: [전체보기] 옵션 포함 여부
  */
 export const MapViewModeFilter = ({
+  defaultMapViewMode,
   includeAllViewMode,
 }: {
+  defaultMapViewMode: MapViewMode;
   includeAllViewMode: boolean;
 }) => {
+  if (defaultMapViewMode === "ALL_VIEW" && !includeAllViewMode) {
+    throw new Error(
+      "defaultMapViewMode가 ALL_VIEW이면 includeAllViewMode는 true여야 합니다.",
+    );
+  }
+
   const { currentLocation } = useMapStore((state) => state.userInfo);
   const setIsCenteredOnMyLocation = useMapStore(
     (state) => state.setIsCenterOnMyLocation,
@@ -180,10 +191,6 @@ export const MapViewModeFilter = ({
 
     // todo mapViewMode가 ALL_VIEW일 경우
   };
-
-  const defaultMapViewMode: MapViewMode = includeAllViewMode
-    ? "ALL_VIEW"
-    : "CURRENT_LOCATION";
 
   let mapViewMode: MapViewMode = defaultMapViewMode;
 

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -44,16 +44,16 @@ const MarkingFilterButton = ({
  * 옵션
  * RECENT: [최신순]
  * POPULAR: [인기순]
- * DISTANCE: [거리순]
+ * DISTANCE: [가까운순]
  *
- * ! 이장소 관련 마킹에서만 [거리순] 옵션 제공하지 않습니다.
+ * ! 이장소 관련 마킹에서만 [가까운순] 옵션 제공하지 않습니다.
  *
- * 내 마킹: [최신순] (기본값), [인기순], [거리순] 제공
- * 동네 마킹: [인기순] (기본값), [최신순], [거리순] 제공
+ * 내 마킹: [최신순] (기본값), [인기순], [가까운순] 제공
+ * 동네 마킹: [인기순] (기본값), [최신순], [가까운순] 제공
  * 이장소 관련 마킹: [인기순] (기본값), [최신순] 제공
  *
- * @param defaultSortType: 기본 정렬 타입
- * @param includeDistanceSortType: [거리순] 옵션 포함 여부
+ * @param options: "RECENT", "POPULAR", "DISTANCE"로 구성된 배열
+ * @param defaultOptionIdx: 기본 옵션 인덱스
  */
 export const SortTypeFilter = ({
   options,
@@ -128,8 +128,8 @@ type MapViewMode = keyof typeof mapViewModeMap;
  * 내 마킹: [전체보기] (기본값), [내 위치 중심], [현재 지도 중심]
  * 동네 마킹: [내 위치 중심] (기본값), [현재 지도 중심]
  *
- * @param defaultMapViewMode: 기본 노출 범위
- * @param includeAllViewMode: [전체보기] 옵션 포함 여부
+ * @param options: "ALL_VIEW", "CURRENT_LOCATION", "MAP_LOCATION"로 구성된 배열
+ * @param defaultOptionIdx: 기본 옵션 인덱스
  */
 export const MapViewModeFilter = ({
   options,

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -142,6 +142,7 @@ type MapViewMode = keyof typeof mapViewModeMap;
  * 내 마킹: [전체보기] (기본값), [내 위치 중심], [현재 지도 중심]
  * 동네 마킹: [내 위치 중심] (기본값), [현재 지도 중심]
  *
+ * @param defaultMapViewMode: 기본 노출 범위
  * @param includeAllViewMode: [전체보기] 옵션 포함 여부
  */
 export const MapViewModeFilter = ({

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -181,7 +181,9 @@ export const MapViewModeFilter = ({
   };
 
   const defaultOption = options[defaultOptionIdx];
-  const otherOptions = options.filter((option) => option !== defaultOption);
+  const nonDefaultOptions = options.filter(
+    (option) => option !== defaultOption,
+  );
 
   const { handleOpen, onClose, isOpen } = useModal(() => (
     <Modal modalType="center">
@@ -195,7 +197,7 @@ export const MapViewModeFilter = ({
             {mapViewModeMap[defaultOption]}
           </Select.Option>
 
-          {otherOptions.map((option) => {
+          {nonDefaultOptions.map((option) => {
             return (
               <Select.Option
                 key={option}

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -61,7 +61,14 @@ export const SortTypeFilter = ({
   defaultSortType: SortType;
   includeDistanceSortType?: boolean;
 }) => {
-  const { sortType, researchMarkingList } = useResearchMarkingList();
+  if (defaultSortType === "DISTANCE" && !includeDistanceSortType) {
+    throw new Error(
+      "defaultSortType가 DISTANCE이면 includeDistanceSortType는 true여야 합니다.",
+    );
+  }
+
+  const { sortType: selectedSortType, researchMarkingList } =
+    useResearchMarkingList();
 
   const handleSelect = (sortType: SortType) => {
     researchMarkingList({
@@ -69,11 +76,9 @@ export const SortTypeFilter = ({
     });
   };
 
-  if (defaultSortType === "DISTANCE" && !includeDistanceSortType) {
-    throw new Error(
-      "defaultSortType가 DISTANCE이면 includeDistanceSortType는 true여야 합니다.",
-    );
-  }
+  const options = Object.entries(sortTypeMap).filter(
+    ([key]) => includeDistanceSortType || key !== "DISTANCE",
+  );
 
   const { handleOpen, onClose, isOpen } = useModal(() => (
     <Modal modalType="center">
@@ -81,14 +86,13 @@ export const SortTypeFilter = ({
         <Select.OptionList>
           <Select.Option
             value={defaultSortType}
-            isSelected={defaultSortType === sortType}
+            isSelected={defaultSortType === selectedSortType}
             onClick={() => handleSelect(defaultSortType)}
           >
             {sortTypeMap[defaultSortType]}
           </Select.Option>
 
-          {Object.entries(sortTypeMap)
-            .filter(([key]) => includeDistanceSortType || key !== "DISTANCE")
+          {options
             .filter(([key]) => key !== defaultSortType)
             .map(([key, value]) => {
               return (
@@ -96,7 +100,7 @@ export const SortTypeFilter = ({
                   key={key}
                   value={key}
                   onClick={() => handleSelect(key as SortType)}
-                  isSelected={sortType === key}
+                  isSelected={key === selectedSortType}
                 >
                   {value}
                 </Select.Option>
@@ -109,7 +113,7 @@ export const SortTypeFilter = ({
 
   return (
     <MarkingFilterButton onClick={handleOpen}>
-      {sortTypeMap[sortType]}
+      {sortTypeMap[selectedSortType]}
     </MarkingFilterButton>
   );
 };

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -55,18 +55,12 @@ const MarkingFilterButton = ({
  * @param includeDistanceSortType: [거리순] 옵션 포함 여부
  */
 export const SortTypeFilter = ({
-  defaultSortType,
-  includeDistanceSortType = true,
+  options,
+  defaultOptionIdx,
 }: {
-  defaultSortType: SortType;
-  includeDistanceSortType?: boolean;
+  options: SortType[];
+  defaultOptionIdx: number;
 }) => {
-  if (defaultSortType === "DISTANCE" && !includeDistanceSortType) {
-    throw new Error(
-      "defaultSortType가 DISTANCE이면 includeDistanceSortType는 true여야 합니다.",
-    );
-  }
-
   const { sortType: selectedSortType, researchMarkingList } =
     useResearchMarkingList();
 
@@ -76,8 +70,10 @@ export const SortTypeFilter = ({
     });
   };
 
-  const options = Object.entries(sortTypeMap).filter(
-    ([key]) => includeDistanceSortType || key !== "DISTANCE",
+  const defaultOption = options[defaultOptionIdx];
+
+  const nonDefaultOptions = options.filter(
+    (option) => option !== defaultOption,
   );
 
   const { handleOpen, onClose, isOpen } = useModal(() => (
@@ -85,27 +81,25 @@ export const SortTypeFilter = ({
       <Select isOpen={isOpen} onClose={onClose}>
         <Select.OptionList>
           <Select.Option
-            value={defaultSortType}
-            isSelected={defaultSortType === selectedSortType}
-            onClick={() => handleSelect(defaultSortType)}
+            value={defaultOption}
+            isSelected={defaultOption === selectedSortType}
+            onClick={() => handleSelect(defaultOption)}
           >
-            {sortTypeMap[defaultSortType]}
+            {sortTypeMap[defaultOption]}
           </Select.Option>
 
-          {options
-            .filter(([key]) => key !== defaultSortType)
-            .map(([key, value]) => {
-              return (
-                <Select.Option
-                  key={key}
-                  value={key}
-                  onClick={() => handleSelect(key as SortType)}
-                  isSelected={key === selectedSortType}
-                >
-                  {value}
-                </Select.Option>
-              );
-            })}
+          {nonDefaultOptions.map((option) => {
+            return (
+              <Select.Option
+                key={option}
+                value={option}
+                onClick={() => handleSelect(option)}
+                isSelected={option === selectedSortType}
+              >
+                {sortTypeMap[option]}
+              </Select.Option>
+            );
+          })}
         </Select.OptionList>
       </Select>
     </Modal>

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -1,17 +1,70 @@
+import { sortTypeMap } from "@/features/map/constants";
+import { useResearchMarkingList } from "@/features/map/hooks";
+import { SortType } from "@/entities/marking/api";
+import { useModal } from "@/shared/lib";
 import { Button } from "@/shared/ui/button";
 import { DropDownIcon } from "@/shared/ui/icon";
+import { Modal } from "@/shared/ui/modal";
+import { Select } from "@/shared/ui/select";
 
-export const MarkingFilter = ({ children }: { children: string }) => {
+const MarkingFilterButton = ({
+  children,
+  onClick,
+}: {
+  children: string;
+  onClick: () => void;
+}) => {
   return (
     <Button
+      type="button"
       variant="text"
       colorType="tertiary"
       size="xSmall"
       fullWidth={false}
-      className="pr-0"
+      onClick={onClick}
+      style={{
+        paddingRight: "0",
+      }}
     >
       {children}
       <DropDownIcon />
     </Button>
+  );
+};
+
+export const SortTypeFilter = () => {
+  const { sortType, researchMarkingList } = useResearchMarkingList();
+
+  const handleSelect = (sortType: SortType) => {
+    researchMarkingList({
+      sortType,
+    });
+  };
+
+  const { handleOpen, onClose, isOpen } = useModal(() => (
+    <Modal modalType="center">
+      <Select isOpen={isOpen} onClose={onClose}>
+        <Select.OptionList>
+          {Object.entries(sortTypeMap).map(([key, value]) => {
+            return (
+              <Select.Option
+                key={key}
+                value={key}
+                onClick={() => handleSelect(key as SortType)}
+                isSelected={sortType === key}
+              >
+                {value}
+              </Select.Option>
+            );
+          })}
+        </Select.OptionList>
+      </Select>
+    </Modal>
+  ));
+
+  return (
+    <MarkingFilterButton onClick={handleOpen}>
+      {sortTypeMap[sortType]}
+    </MarkingFilterButton>
   );
 };

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -1,0 +1,17 @@
+import { Button } from "@/shared/ui/button";
+import { DropDownIcon } from "@/shared/ui/icon";
+
+export const MarkingFilter = ({ children }: { children: string }) => {
+  return (
+    <Button
+      variant="text"
+      colorType="tertiary"
+      size="xSmall"
+      fullWidth={false}
+      className="pr-0"
+    >
+      {children}
+      <DropDownIcon />
+    </Button>
+  );
+};

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -53,14 +53,14 @@ const MarkingFilterButton = ({
  * 이장소 관련 마킹: [인기순] (기본값), [최신순] 제공
  *
  * @param options: "RECENT", "POPULAR", "DISTANCE"로 구성된 배열
- * @param defaultOptionIdx: 기본 옵션 인덱스
+ * @param defaultOptionIdx: 기본 옵션 인덱스 (기본값: 0)
  */
 export const SortTypeFilter = ({
   options,
-  defaultOptionIdx,
+  defaultOptionIdx = 0,
 }: {
   options: SortType[];
-  defaultOptionIdx: number;
+  defaultOptionIdx?: number;
 }) => {
   const { sortType: selectedSortType, researchMarkingList } =
     useResearchMarkingList();
@@ -129,14 +129,14 @@ type MapViewMode = keyof typeof mapViewModeMap;
  * 동네 마킹: [내 위치 중심] (기본값), [현재 지도 중심]
  *
  * @param options: "ALL_VIEW", "CURRENT_LOCATION", "MAP_LOCATION"로 구성된 배열
- * @param defaultOptionIdx: 기본 옵션 인덱스
+ * @param defaultOptionIdx: 기본 옵션 인덱스 (기본값: 0)
  */
 export const MapViewModeFilter = ({
   options,
-  defaultOptionIdx,
+  defaultOptionIdx = 0,
 }: {
   options: MapViewMode[];
-  defaultOptionIdx: number;
+  defaultOptionIdx?: number;
 }) => {
   const setIsCenteredOnMyLocation = useMapStore(
     (state) => state.setIsCenterOnMyLocation,

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -37,7 +37,30 @@ const MarkingFilterButton = ({
   );
 };
 
-export const SortTypeFilter = () => {
+/**
+ * 마킹 데이터들을 정렬하는 필터
+ *
+ * 옵션
+ * RECENT: [최신순]
+ * POPULAR: [인기순]
+ * DISTANCE: [거리순]
+ *
+ * ! 이장소 관련 마킹에서만 [거리순] 옵션 제공하지 않습니다.
+ *
+ * 내 마킹: [최신순] (기본값), [인기순], [거리순] 제공
+ * 동네 마킹: [인기순] (기본값), [최신순], [거리순] 제공
+ * 이장소 관련 마킹: [인기순] (기본값), [최신순] 제공
+ *
+ * @param defaultSortType: 기본 정렬 타입
+ * @param includeDistanceSortType: [거리순] 옵션 포함 여부
+ */
+export const SortTypeFilter = ({
+  defaultSortType,
+  includeDistanceSortType = true,
+}: {
+  defaultSortType: SortType;
+  includeDistanceSortType?: boolean;
+}) => {
   const { sortType, researchMarkingList } = useResearchMarkingList();
 
   const handleSelect = (sortType: SortType) => {
@@ -46,22 +69,39 @@ export const SortTypeFilter = () => {
     });
   };
 
+  if (defaultSortType === "DISTANCE" && !includeDistanceSortType) {
+    throw new Error(
+      "defaultSortType가 DISTANCE이면 includeDistanceSortType는 true여야 합니다.",
+    );
+  }
+
   const { handleOpen, onClose, isOpen } = useModal(() => (
     <Modal modalType="center">
       <Select isOpen={isOpen} onClose={onClose}>
         <Select.OptionList>
-          {Object.entries(sortTypeMap).map(([key, value]) => {
-            return (
-              <Select.Option
-                key={key}
-                value={key}
-                onClick={() => handleSelect(key as SortType)}
-                isSelected={sortType === key}
-              >
-                {value}
-              </Select.Option>
-            );
-          })}
+          <Select.Option
+            value={defaultSortType}
+            isSelected={defaultSortType === sortType}
+            onClick={() => handleSelect(defaultSortType)}
+          >
+            {sortTypeMap[defaultSortType]}
+          </Select.Option>
+
+          {Object.entries(sortTypeMap)
+            .filter(([key]) => includeDistanceSortType || key !== "DISTANCE")
+            .filter(([key]) => key !== defaultSortType)
+            .map(([key, value]) => {
+              return (
+                <Select.Option
+                  key={key}
+                  value={key}
+                  onClick={() => handleSelect(key as SortType)}
+                  isSelected={sortType === key}
+                >
+                  {value}
+                </Select.Option>
+              );
+            })}
         </Select.OptionList>
       </Select>
     </Modal>

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { mapViewModeMap, sortTypeMap } from "@/features/map/constants";
 import {
@@ -114,15 +115,6 @@ export const SortTypeFilter = ({
 
 type MapViewMode = keyof typeof mapViewModeMap;
 
-// 내마킹 url
-// map/nickname?sortType => 전체보기 (기본값)
-// map/nickname?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 같은 경우 => 내 위치 중심
-// map/nickname?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 다른 경우 => 현재 지도 중심
-
-// 동네마킹 url
-// map?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 같은 경우 => 내 위치 중심 (기본값)
-// map?sortType&lat&lng&... => lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 다른 경우 => 현재 지도 중심
-
 /**
  * 마킹 노출 범위 필터
  *
@@ -140,28 +132,27 @@ type MapViewMode = keyof typeof mapViewModeMap;
  * @param includeAllViewMode: [전체보기] 옵션 포함 여부
  */
 export const MapViewModeFilter = ({
-  defaultMapViewMode,
-  includeAllViewMode,
+  options,
+  defaultOptionIdx,
 }: {
-  defaultMapViewMode: MapViewMode;
-  includeAllViewMode: boolean;
+  options: MapViewMode[];
+  defaultOptionIdx: number;
 }) => {
-  if (defaultMapViewMode === "ALL_VIEW" && !includeAllViewMode) {
-    throw new Error(
-      "defaultMapViewMode가 ALL_VIEW이면 includeAllViewMode는 true여야 합니다.",
-    );
-  }
-
-  const { currentLocation } = useMapStore((state) => state.userInfo);
   const setIsCenteredOnMyLocation = useMapStore(
     (state) => state.setIsCenterOnMyLocation,
   );
-  const { researchMarkingList, center } = useResearchMarkingList();
+  const { researchMarkingList } = useResearchMarkingList();
   const { setCurrentLocation } = useCurrentLocation();
 
   const map = useMap();
 
+  const [selectedOption, setSelectedOption] = useState<MapViewMode>(
+    options[defaultOptionIdx],
+  );
+
   const handleSelect = (mapViewMode: MapViewMode) => {
+    setSelectedOption(mapViewMode);
+
     if (mapViewMode === "CURRENT_LOCATION") {
       setCurrentLocation({
         onSuccess: ({ coords: { latitude, longitude } }) => {
@@ -182,55 +173,40 @@ export const MapViewModeFilter = ({
     }
 
     if (mapViewMode === "MAP_LOCATION") {
-      if (isCurrentLocation) {
-        // todo 현재 지도 중심과 내 위치 중심이 같을 경우 어떻게 해야할 지 => snack bar 띄우기?
-      }
       researchMarkingList();
+      return;
     }
 
     // todo mapViewMode가 ALL_VIEW일 경우
   };
 
-  let selectedMapViewMode: MapViewMode = defaultMapViewMode;
-
-  const isCurrentLocation =
-    !!currentLocation.lat &&
-    !!currentLocation.lng &&
-    center.lat === currentLocation.lat &&
-    center.lng === currentLocation.lng;
-
-  if (!isCurrentLocation) selectedMapViewMode = "MAP_LOCATION";
-
-  const options = Object.entries(mapViewModeMap).filter(
-    ([key]) => includeAllViewMode || key !== "ALL_VIEW",
-  );
+  const defaultOption = options[defaultOptionIdx];
+  const otherOptions = options.filter((option) => option !== defaultOption);
 
   const { handleOpen, onClose, isOpen } = useModal(() => (
     <Modal modalType="center">
       <Select isOpen={isOpen} onClose={onClose}>
         <Select.OptionList>
           <Select.Option
-            value={defaultMapViewMode}
-            onClick={() => handleSelect(defaultMapViewMode)}
-            isSelected={selectedMapViewMode === defaultMapViewMode}
+            value={defaultOption}
+            onClick={() => handleSelect(defaultOption)}
+            isSelected={selectedOption === defaultOption}
           >
-            {mapViewModeMap[defaultMapViewMode]}
+            {mapViewModeMap[defaultOption]}
           </Select.Option>
 
-          {options
-            .filter(([key]) => key !== defaultMapViewMode)
-            .map(([key, value]) => {
-              return (
-                <Select.Option
-                  key={key}
-                  value={key}
-                  onClick={() => handleSelect(key as MapViewMode)}
-                  isSelected={selectedMapViewMode === key}
-                >
-                  {value}
-                </Select.Option>
-              );
-            })}
+          {otherOptions.map((option) => {
+            return (
+              <Select.Option
+                key={option}
+                value={option}
+                onClick={() => handleSelect(option)}
+                isSelected={selectedOption === option}
+              >
+                {mapViewModeMap[option]}
+              </Select.Option>
+            );
+          })}
         </Select.OptionList>
       </Select>
     </Modal>
@@ -238,7 +214,7 @@ export const MapViewModeFilter = ({
 
   return (
     <MarkingFilterButton onClick={handleOpen}>
-      {mapViewModeMap[selectedMapViewMode]}
+      {mapViewModeMap[selectedOption]}
     </MarkingFilterButton>
   );
 };

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -196,7 +196,7 @@ export const MapViewModeFilter = ({
     // todo mapViewMode가 ALL_VIEW일 경우
   };
 
-  let mapViewMode: MapViewMode = defaultMapViewMode;
+  let selectedMapViewMode: MapViewMode = defaultMapViewMode;
 
   const isCurrentLocation =
     !!currentLocation.lat &&
@@ -204,7 +204,11 @@ export const MapViewModeFilter = ({
     center.lat === currentLocation.lat &&
     center.lng === currentLocation.lng;
 
-  if (!isCurrentLocation) mapViewMode = "MAP_LOCATION";
+  if (!isCurrentLocation) selectedMapViewMode = "MAP_LOCATION";
+
+  const options = Object.entries(mapViewModeMap).filter(
+    ([key]) => includeAllViewMode || key !== "ALL_VIEW",
+  );
 
   const { handleOpen, onClose, isOpen } = useModal(() => (
     <Modal modalType="center">
@@ -213,23 +217,22 @@ export const MapViewModeFilter = ({
           <Select.Option
             value={defaultMapViewMode}
             onClick={() => handleSelect(defaultMapViewMode)}
-            isSelected={mapViewMode === defaultMapViewMode}
+            isSelected={selectedMapViewMode === defaultMapViewMode}
           >
             {mapViewModeMap[defaultMapViewMode]}
           </Select.Option>
 
-          {Object.keys(mapViewModeMap)
-            .filter((key) => includeAllViewMode || key !== "ALL_VIEW")
-            .filter((key) => key !== defaultMapViewMode)
-            .map((key) => {
+          {options
+            .filter(([key]) => key !== defaultMapViewMode)
+            .map(([key, value]) => {
               return (
                 <Select.Option
                   key={key}
                   value={key}
                   onClick={() => handleSelect(key as MapViewMode)}
-                  isSelected={mapViewMode === key}
+                  isSelected={selectedMapViewMode === key}
                 >
-                  {mapViewModeMap[key as MapViewMode]}
+                  {value}
                 </Select.Option>
               );
             })}
@@ -240,7 +243,7 @@ export const MapViewModeFilter = ({
 
   return (
     <MarkingFilterButton onClick={handleOpen}>
-      {mapViewModeMap[mapViewMode]}
+      {mapViewModeMap[selectedMapViewMode]}
     </MarkingFilterButton>
   );
 };

--- a/src/pages/map/page.tsx
+++ b/src/pages/map/page.tsx
@@ -4,6 +4,7 @@ import {
   MapInitializer,
   MapMarkerWidget,
   GoogleMaps,
+  MapBottomSheet,
 } from "@/widgets/map/ui";
 import { NotificationNavigationBar } from "@/widgets/notification/ui";
 
@@ -15,6 +16,7 @@ export const MapPage = () => {
       <GoogleMaps>
         <MapMarkerWidget />
         <MapControlWidget />
+        <MapBottomSheet />
         <GoogleMapsCopyRight />
       </GoogleMaps>
     </>

--- a/src/widgets/map/ui/googleMaps.tsx
+++ b/src/widgets/map/ui/googleMaps.tsx
@@ -14,7 +14,8 @@ interface GoogleMapProps {
  * 기본적으로 GoogleMaps 는 w-full h-full relative로 설정 되어 있습니다.
  */
 export const GoogleMaps = ({ children }: GoogleMapProps) => {
-  const isLoadedRef = useRef<boolean>(false);
+  const isTilesLoadedRef = useRef<boolean>(false);
+  const setIsIdle = useMapStore((state) => state.setIsIdle);
 
   const setIsMapCenteredOnMyLocation = useMapStore(
     (state) => state.setIsCenterOnMyLocation,
@@ -24,7 +25,7 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
   );
 
   const handleMapChange = () => {
-    if (!isLoadedRef.current) return;
+    if (!isTilesLoadedRef.current) return;
 
     setIsLastSearchedLocation(false);
     setIsMapCenteredOnMyLocation(false);
@@ -53,13 +54,18 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
     <Map
       mapId={GOOGLE_MAPS_MAP_ID}
       options={mapOptions}
+      renderingType="VECTOR"
       // TODO 상태 붙혀서 default Center 이동시키기
       defaultCenter={MAP_INITIAL_CENTER}
       defaultZoom={MAP_INITIAL_ZOOM}
       reuseMaps // Map 컴포넌트가 unmount 되었다가 다시 mount 될 때 기존의 map instance 를 재사용 하여 memory leak을 방지합니다.
       onCameraChanged={handleMapChange}
+      onIdle={() => {
+        // 이동이나 확대/축소 후 지도가 멈추었을 때 호출
+        setIsIdle(true);
+      }}
       onTilesLoaded={() => {
-        isLoadedRef.current = true;
+        isTilesLoadedRef.current = true;
       }}
     >
       {children}

--- a/src/widgets/map/ui/index.ts
+++ b/src/widgets/map/ui/index.ts
@@ -3,3 +3,4 @@ export * from "./googleMaps";
 export * from "./mapControlWidget";
 export * from "./mapMarkerWidget";
 export * from "./mapInitializer";
+export * from "./mapBottomSheet";

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -76,7 +76,7 @@ export const MapBottomSheet = () => {
 
               <div className="flex">
                 <MapViewModeFilter includeAllViewMode={false} />
-                <SortTypeFilter />
+                <SortTypeFilter defaultSortType="POPULARITY" />
               </div>
             </div>
 

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -75,7 +75,10 @@ export const MapBottomSheet = () => {
               </div>
 
               <div className="flex">
-                <MapViewModeFilter includeAllViewMode={false} />
+                <MapViewModeFilter
+                  defaultMapViewMode="CURRENT_LOCATION"
+                  includeAllViewMode={false}
+                />
                 <SortTypeFilter defaultSortType="POPULARITY" />
               </div>
             </div>

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -79,7 +79,10 @@ export const MapBottomSheet = () => {
                   defaultMapViewMode="CURRENT_LOCATION"
                   includeAllViewMode={false}
                 />
-                <SortTypeFilter defaultSortType="POPULARITY" />
+                <SortTypeFilter
+                  options={["POPULARITY", "RECENT", "DISTANCE"]}
+                  defaultOptionIdx={0}
+                />
               </div>
             </div>
 

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -3,7 +3,7 @@ import { Sheet, SheetRef } from "react-modal-sheet";
 import { useLocation } from "react-router-dom";
 import { useResearchMarkingList } from "@/features/map/hooks";
 import { useMapStore } from "@/features/map/store";
-import { SortTypeFilter } from "@/features/marking/ui";
+import { MapViewModeFilter, SortTypeFilter } from "@/features/marking/ui";
 import { useGetMarkingList } from "@/entities/marking/api";
 import { API_BASE_URL } from "@/shared/constants";
 import { MyLocationIcon } from "@/shared/ui/icon";
@@ -75,6 +75,7 @@ export const MapBottomSheet = () => {
               </div>
 
               <div className="flex">
+                <MapViewModeFilter includeAllViewMode={false} />
                 <SortTypeFilter />
               </div>
             </div>

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -3,7 +3,7 @@ import { Sheet, SheetRef } from "react-modal-sheet";
 import { useLocation } from "react-router-dom";
 import { useResearchMarkingList } from "@/features/map/hooks";
 import { useMapStore } from "@/features/map/store";
-import { MarkingFilter } from "@/features/marking/ui";
+import { SortTypeFilter } from "@/features/marking/ui";
 import { useGetMarkingList } from "@/entities/marking/api";
 import { API_BASE_URL } from "@/shared/constants";
 import { MyLocationIcon } from "@/shared/ui/icon";
@@ -20,13 +20,13 @@ export const MapBottomSheet = () => {
   const snapPointRef = useRef(initialSnap);
   const snapTo = (i: number) => sheetRef.current?.snapTo(i);
 
-  const { bounds } = useResearchMarkingList();
+  const { bounds, sortType } = useResearchMarkingList();
   const { data: markingList } = useGetMarkingList({
     southWestLat: bounds?.southWest.lat,
     southWestLng: bounds?.southWest.lng,
     northEastLat: bounds?.northEast.lat,
     northEastLng: bounds?.northEast.lng,
-    sortType: "RECENT",
+    sortType,
   });
 
   const mapMode = useMapStore((state) => state.mode);
@@ -75,8 +75,7 @@ export const MapBottomSheet = () => {
               </div>
 
               <div className="flex">
-                <MarkingFilter>내 위치 중심</MarkingFilter>
-                <MarkingFilter>인기순</MarkingFilter>
+                <SortTypeFilter />
               </div>
             </div>
 

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -77,11 +77,9 @@ export const MapBottomSheet = () => {
               <div className="flex">
                 <MapViewModeFilter
                   options={["CURRENT_LOCATION", "MAP_LOCATION"]}
-                  defaultOptionIdx={0}
                 />
                 <SortTypeFilter
                   options={["POPULARITY", "RECENT", "DISTANCE"]}
-                  defaultOptionIdx={0}
                 />
               </div>
             </div>

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -76,8 +76,8 @@ export const MapBottomSheet = () => {
 
               <div className="flex">
                 <MapViewModeFilter
-                  defaultMapViewMode="CURRENT_LOCATION"
-                  includeAllViewMode={false}
+                  options={["CURRENT_LOCATION", "MAP_LOCATION"]}
+                  defaultOptionIdx={0}
                 />
                 <SortTypeFilter
                   options={["POPULARITY", "RECENT", "DISTANCE"]}

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -1,0 +1,100 @@
+import { useRef } from "react";
+import { Sheet, SheetRef } from "react-modal-sheet";
+import { useLocation } from "react-router-dom";
+import { useResearchMarkingList } from "@/features/map/hooks";
+import { useMapStore } from "@/features/map/store";
+import { MarkingFilter } from "@/features/marking/ui";
+import { useGetMarkingList } from "@/entities/marking/api";
+import { API_BASE_URL } from "@/shared/constants";
+import { MyLocationIcon } from "@/shared/ui/icon";
+import { MarkingList } from "./markingList";
+
+export const MapBottomSheet = () => {
+  const location = useLocation();
+
+  const sheetRef = useRef<SheetRef>();
+
+  const snapPoints = [-50, 0.5, 116];
+  const initialSnap = 1;
+
+  const snapPointRef = useRef(initialSnap);
+  const snapTo = (i: number) => sheetRef.current?.snapTo(i);
+
+  const { bounds } = useResearchMarkingList();
+  const { data: markingList } = useGetMarkingList({
+    southWestLat: bounds?.southWest.lat,
+    southWestLng: bounds?.southWest.lng,
+    northEastLat: bounds?.northEast.lat,
+    northEastLng: bounds?.northEast.lng,
+    sortType: "RECENT",
+  });
+
+  const mapMode = useMapStore((state) => state.mode);
+
+  return (
+    <Sheet
+      ref={sheetRef}
+      isOpen={location.pathname === "/map" && mapMode === "view"}
+      onClose={() => {
+        const isSheetTop = snapPointRef.current === 0;
+
+        if (isSheetTop) {
+          snapTo(snapPointRef.current - 1);
+          return;
+        }
+
+        snapTo(initialSnap);
+      }}
+      snapPoints={snapPoints}
+      initialSnap={initialSnap}
+      onSnap={(snapPointIndex) => (snapPointRef.current = snapPointIndex)}
+      style={{ zIndex: 1 }}
+      mountPoint={document.querySelector("#root")!}
+    >
+      <Sheet.Container>
+        <Sheet.Header />
+        <Sheet.Content
+          style={{
+            padding: 0,
+            paddingBottom: sheetRef.current?.y,
+          }}
+        >
+          <Sheet.Scroller
+            draggableAt="both"
+            style={{
+              height: "calc(100% - 5rem)",
+            }}
+          >
+            {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
+            <h1 className="title-1 text-grey-900 p-4">동네 마킹</h1>
+
+            <div className="flex justify-between px-4 items-center mb-4">
+              <div className="flex gap-1 text-tangerine-500 items-center">
+                <MyLocationIcon width={20} height={20} />
+                <span className="body-2 text-grey-500">영등포 1동 주변</span>
+              </div>
+
+              <div className="flex">
+                <MarkingFilter>내 위치 중심</MarkingFilter>
+                <MarkingFilter>인기순</MarkingFilter>
+              </div>
+            </div>
+
+            <div className="px-4">
+              <MarkingList display="grid">
+                {markingList?.map(({ markingId, previewImage }) => (
+                  <button key={markingId} type="button">
+                    <img
+                      className="aspect-square"
+                      src={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
+                    />
+                  </button>
+                ))}
+              </MarkingList>
+            </div>
+          </Sheet.Scroller>
+        </Sheet.Content>
+      </Sheet.Container>
+    </Sheet>
+  );
+};

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -1,23 +1,35 @@
 import { useEffect } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
+import { sortTypeMap } from "@/features/map/constants";
 import { useCurrentLocation } from "@/features/map/hooks";
 import { useResearchMarkingList } from "@/features/map/hooks";
 import { useMapStore } from "@/features/map/store";
 import { CurrentLocationLoading } from "@/entities/map/ui";
+import { SortType } from "@/entities/marking/api";
 
 export const MapInitializer = () => {
   const map = useMap();
 
   const { loading, setCurrentLocation } = useCurrentLocation();
-  const { researchMarkingList, bounds: boundsParams } =
-    useResearchMarkingList();
+  const {
+    researchMarkingList,
+    bounds: boundsParams,
+    sortType: sortTypeParam,
+  } = useResearchMarkingList();
 
+  const isMapIdle = useMapStore((state) => state.isIdle);
   const setIsCenteredOnMyLocation = useMapStore(
     (state) => state.setIsCenterOnMyLocation,
   );
 
   useEffect(() => {
-    if (!map) return;
+    if (!map || !isMapIdle) return;
+
+    const hasSortTypeParam = !!sortTypeParam && sortTypeParam in sortTypeMap;
+
+    const filterOptions = {
+      sortType: hasSortTypeParam ? (sortTypeParam as SortType) : "RECENT",
+    };
 
     // map 인스턴스가 생기고 나서, 현재 위치를 가져옵니다.
     setCurrentLocation({
@@ -34,12 +46,12 @@ export const MapInitializer = () => {
             setIsCenteredOnMyLocation(true);
           }, 0);
 
-          researchMarkingList();
+          researchMarkingList(filterOptions);
         }
       },
       onError: () => {
         if (!boundsParams) {
-          researchMarkingList();
+          researchMarkingList(filterOptions);
         }
       },
     });
@@ -55,10 +67,10 @@ export const MapInitializer = () => {
       east: northEast.lng,
     });
 
-    researchMarkingList();
-  }, [map]);
+    researchMarkingList(filterOptions);
+  }, [map, sortTypeParam, isMapIdle]);
 
-  if (!map || loading) {
+  if (!map || loading || !isMapIdle) {
     return <CurrentLocationLoading />;
   }
 

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -68,7 +68,7 @@ export const MapInitializer = () => {
     });
 
     researchMarkingList(filterOptions);
-  }, [map, sortTypeParam, isMapIdle]);
+  }, [map, isMapIdle]);
 
   if (!map || loading || !isMapIdle) {
     return <CurrentLocationLoading />;

--- a/src/widgets/map/ui/markingList.tsx
+++ b/src/widgets/map/ui/markingList.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+
+interface ContentListProps {
+  display?: "grid" | "list";
+  children: ReactNode;
+}
+
+export const MarkingList = ({
+  children,
+  display = "list",
+}: ContentListProps) => {
+  const className =
+    display === "grid"
+      ? "grid grid-cols-3 rounded-lg overflow-hidden"
+      : "flex flex-col gap-8";
+
+  return <ul className={className}>{children}</ul>;
+};


### PR DESCRIPTION
# 관련 이슈 번호

#235 

# 설명

이 풀리퀘에서 여러 작업을 했네요 😢 리뷰하기 힘드실 것 같아서 죄송스러운 마음입니다..


## 맵 페이지에 있는 바텀 시트 컴포넌트 생성

기존에 FooterNavigationBar에 있던 바텀 시트를 widgets 레이어로 옮겼습니다.
전에 용현님이 말씀해주셨던 것처럼 분리하니까 확실히 컴포넌트 복잡성이 줄어들었어요 👍 

## MarkingList를 entities에서 widgets로 이동

여러 항목들을 하나로 묶는 목록이기 때문에 독립적으로 작동하는 대규모 기능 또는 UI 컴포넌트, 보통 하나의 완전한 기능인 widgets에 적합하다고 생각하여 옮겼습니다.

## `/map`으로 진입했을 때 query string이 붙여지지 않은 문제

가끔 `/map` 경로로 진입할 때 query string에 boundary 값이 설정되지 않는 경우가 있었습니다.

원인을 찾아보니, 현재 위치를 파악한 이후 map 인스턴스의 bounds 값을 얻는 과정에서 문제가 발생한 것이었습니다.

기존의 query string 설정 순서는 다음과 같습니다.

1. `/map` 경로로 진입
2. MapInitializer의 useEffect에서 map 인스턴스가 있을 경우, 현재 위치 파악
3. 현재 위치를 알아냈다면, researchMarkingList 호출
4. researchMarkingList에서 map 인스턴스의 getBounds로 파라미터 설정 

4번 과정에서 **map 인스턴스가 존재하지만 `map.getBounds()` 값이 undefined**여서 setSearchParams가 호출되지 않았습니다.


```typescript
export const useResearchMarkingList = () => {
  const map = useMap();
  // ...

  const researchMarkingList = () => {
    if (!map) return;

    const mapCenter = map.getCenter();
    const bounds = map.getBounds(); // undefined

    if (!bounds) return; // bounds가 undefined이기 때문에 실행 멈춤

    setSearchParams({
      // ...
    });

  };  
}
```

useMap이 반환하는 map 인스턴스가 있으면 항상 `map.getBounds()` 값이 있는 줄 알았습니다.
알고 보니 Map 컴포넌트의 **change bounds 이벤트가 일어난 이후 bounds 값을 얻을 수 있었습니다.** ([stackoverflow 참고](https://stackoverflow.com/questions/2832636/google-maps-api-v3-getbounds-is-undefined))

따라서, **map 인스턴스의 bounds 값을 얻기 전에 researchMarkingList가 먼저 호출돼서 query string이 설정되지 않았던 것**이었습니다.

1. `/map` 진입
2. 현재 위치 파악하여 researchMarkingList 호출
3. researchMarkingList에서 `map.getBounds()`은 undefined으로 setSearchParams 호출 못 함
4. change bounds 이벤트 발생 => 이 이후로 bounds 값 알 수 있음 

이전에는 idle 이벤트 후에만 bounds 값을 얻을 수 있었지만, change bounds 이벤트 후에도 bounds 값을 얻을 수 있도록 업데이트 됐습니다.

여기서 말하는 idle 이벤트는 **맵 이동 또는 확대/축소가 끝나면 발생**합니다.
맵 이동이 끝나고 나서 딱 한 번만 사용자의 현재 위치를 불러오기 위해, map store에 isIdle 상태를 추가하였습니다.
isIdle의 초기값은 false이고, idle 핸들러가 실행되면 true로 바뀝니다.

- isIdle이 false인 경우, 아직 bounds 값을 얻을 수 없기 때문에 사용자의 위치 파악 x
- isIdle이 true인 경우, bounds 값에 접근할 수 있기 때문에 사용자의 현재 위치 파악

```typescript
// GoogleMaps 컴포넌트
const setIsIdle = useMapStore((state) => state.setIsIdle);

<Map
      // ...
      onIdle={() => {
        // 이동이나 확대/축소 후 지도가 멈추었을 때 호출
        setIsIdle(true);
      }}
>
      {children}
</Map>

// MapInitialize
export const MapInitializer = () => {
  const map = useMap();

  const { loading, setCurrentLocation } = useCurrentLocation();
  const {
    researchMarkingList,
    bounds: boundsParams,
    sortType: sortTypeParam,
  } = useResearchMarkingList();

  const isMapIdle = useMapStore((state) => state.isIdle);

  useEffect(() => {
    if (!map || !isMapIdle) return;

   // ...
  }, [map, isMapIdle]);

  if (!map || loading || !isMapIdle) {
    return <CurrentLocationLoading />;
  }

  return null;
};
```

## useGetMarkingList의 queryKey에 sortType 추가

여기서 sortType이란 마킹 정렬 기준으로 RECENT, POPULAR, DISTANCE 중 하나의 값을 가집니다.
정렬 기준이 바뀌면 자동으로 마킹 리스트들을 새로 불러오도록 하기 위해 queryKey에 sortType을 추가했습니다.

```typescript
export const useGetMarkingList = ({
  southWestLat,
  southWestLng,
  northEastLat,
  northEastLng,
  sortType,
}: {
  southWestLat?: number;
  southWestLng?: number;
  northEastLat?: number;
  northEastLng?: number;
} & Pick<GetMarkingListRequest, "sortType">) => {
  const map = useMap();
  const mapCenter = map?.getCenter();

  const lat = mapCenter?.lat();
  const lng = mapCenter?.lng();

  return useInfiniteQuery({
    queryKey: [
      "markingList",
      southWestLat,
      southWestLng,
      northEastLat,
      northEastLng,
      sortType,
    ],
  // ...
  })
}
```

## url에 파라미터 추가

파라미터에 lat, lng, sortType을 추가했습니다.

lat과 lng을 추가한 이유는 **마킹 노출 범위 필터**에서 현재 선택된 옵션이 무엇인지 판단하기 위해서 입니다. 

<img width="300" src="https://github.com/user-attachments/assets/d447f170-dfa4-4fce-bd80-cbb37f24ba50" />

만약 sortType 파라미터가 없거나 값이 유효하지 않을 경우, 기본값(POPULAR)으로 설정됩니다.
researchMarkingList의 인수로 선택된 sortType을 넘겨주면, 선택된 옵션으로 url이 바뀌면서 자동으로 마킹 리스트들을 불러옵니다.


```typescript
export const useResearchMarkingList = () => {
  const queryClient = useQueryClient();
  const map = useMap();

  const setIsLastSearchedLocation = useMapStore(
    (state) => state.setIsLastSearchedLocation,
  );

  const [searchParams, setSearchParams] = useSearchParams();

  const sortTypeParam = searchParams.get("sortType");
  const sortType =
    typeof sortTypeParam === "string" && sortTypeParam in sortTypeMap
      ? (sortTypeParam as SortType)
      : "RECENT";

  const researchMarkingList = (filter?: Filter) => {
    if (!map) return;

    const mapCenter = map.getCenter();
    const bounds = map.getBounds();

    if (!bounds) return;

    const lat = mapCenter.lat();
    const lng = mapCenter.lng();

    // ...

    setSearchParams({
      boundsNELat: northEastLat.toString(),
      boundsNELng: northEastLng.toString(),
      boundsSWLat: southWestLat.toString(),
      boundsSWLng: southWestLng.toString(),
      lat: lat.toString(),
      lng: lng.toString(),
      sortType: filter?.sortType || sortType,
    });

    setTimeout(() => {
      setIsLastSearchedLocation(true);
    }, 0);

    queryClient.removeQueries({
      queryKey: ["markingList"],
    });
  };

  // ...

  const lat =
    typeof searchParams.get("lat") === "string"
      ? Number(searchParams.get("lat"))
      : null;
  const lng =
    typeof searchParams.get("lng") === "string"
      ? Number(searchParams.get("lng"))
      : null;

  return {
    bounds,
    center: { lat, lng },
    sortType,
    researchMarkingList,
  };
};
```

## 마킹 정렬 필터

>마킹 데이터들을 정렬하는 필터

### 옵션

정렬 필터의 선택지는 총 3가지 입니다.

- RECENT: [최신순]
- POPULAR: [인기순]
- DISTANCE: [거리순]

이 필터를 사용하는 곳은 내 마킹, 동네 마킹, 이장소 관련 마킹입니다.
사용하는 곳에 따라 선택지와 기본값이 다릅니다. 
굵은 글씨로 표시한 옵션은 기본값입니다.

- 내 마킹: **[최신순]**, [인기순], [거리순] 제공
- 동네 마킹: **[인기순]**, [최신순], [거리순] 제공
- 이장소 관련 마킹: **[인기순]**, [최신순] 제공


## 마킹 노출 범위 필터

### 옵션

노출 범위 필터 선택지는 총 3가지 입니다.

- ALL_VIEW: [전체보기]
- CURRENT_LOCATION: [내 위치 중심]
- MAP_LOCATION: [현재 지도 중심]

정렬 필터와 동일하게 사용하는 곳에 따라 선택지와 기본값이 다릅니다.
- 내 마킹: **[전체보기]**, [내 위치 중심], [현재 지도 중심]
- 동네 마킹: **[내 위치 중심]**, [현재 지도 중심]

사용자가 현재 어떤 옵션을 선택했는지 판단하는 기준은 다음과 같습니다.

내마킹 url
- `map/nickname?... ` => 전체보기 (기본값)
- `map/nickname?lat&lng&...`
  - lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 같은 경우 => 내 위치 중심
  - lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 다른 경우 => 현재 지도 중심

동네마킹 url
- `map?lat&lng&...`
  - lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 같은 경우 => 내 위치 중심 (기본값)
  - lat과 lng이 mapStore의 userInfo.currentLocation의 lat과 lng이 다른 경우 => 현재 지도 중심
