### PR TITLE
[Feat] 자동 로그인 기능 구현 

### DIFF
--- a/src/app/MainLayout.tsx
+++ b/src/app/MainLayout.tsx
@@ -1,6 +1,29 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { ROUTER_PATH } from "@/shared/constants";
+import { apiClient } from "@/shared/lib";
+import { useAuthStore } from "@/shared/store";
 import { FooterNavigationBar } from "./FooterNavigationBar";
+import { APP_END_POINT } from "./ReactQueryProvider/constants";
 
 export const MainLayout = ({ children }: { children: React.ReactNode }) => {
+  const setToken = useAuthStore((state) => state.setToken);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    apiClient
+      .get<{ authorization: string }>(APP_END_POINT.REFRESH_ACCESS_TOKEN, {
+        credentials:
+          process.env.NODE_ENV === "development" ? "include" : "same-origin",
+      })
+      .then(({ authorization }) => {
+        setToken(authorization);
+        if (authorization === "ROLE_NONE") {
+          navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
+        }
+      });
+  }, [navigate, setToken]);
+
   return (
     <div className="mx-auto my-0 flex h-screen max-w-[37.5rem] flex-col">
       <main className="flex grow flex-col overflow-y-scroll">{children}</main>

--- a/src/app/MainLayout.tsx
+++ b/src/app/MainLayout.tsx
@@ -6,17 +6,16 @@ import { FooterNavigationBar } from "./FooterNavigationBar";
 import { getAccessTokenByRefreshToken } from "./api";
 
 export const MainLayout = ({ children }: { children: React.ReactNode }) => {
-  const setToken = useAuthStore((state) => state.setToken);
   const navigate = useNavigate();
 
   useEffect(() => {
-    getAccessTokenByRefreshToken().then(({ authorization }) => {
-      setToken(authorization);
+    getAccessTokenByRefreshToken().then(({ authorization, role, nickname }) => {
+      useAuthStore.setState({ token: authorization, role, nickname });
       if (authorization === "ROLE_NONE") {
         navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
       }
     });
-  }, [navigate, setToken]);
+  }, [navigate]);
 
   return (
     <div className="mx-auto my-0 flex h-screen max-w-[37.5rem] flex-col">

--- a/src/app/MainLayout.tsx
+++ b/src/app/MainLayout.tsx
@@ -1,27 +1,21 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { ROUTER_PATH } from "@/shared/constants";
-import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { FooterNavigationBar } from "./FooterNavigationBar";
-import { APP_END_POINT } from "./ReactQueryProvider/constants";
+import { getAccessTokenByRefreshToken } from "./api";
 
 export const MainLayout = ({ children }: { children: React.ReactNode }) => {
   const setToken = useAuthStore((state) => state.setToken);
   const navigate = useNavigate();
 
   useEffect(() => {
-    apiClient
-      .get<{ authorization: string }>(APP_END_POINT.REFRESH_ACCESS_TOKEN, {
-        credentials:
-          process.env.NODE_ENV === "development" ? "include" : "same-origin",
-      })
-      .then(({ authorization }) => {
-        setToken(authorization);
-        if (authorization === "ROLE_NONE") {
-          navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
-        }
-      });
+    getAccessTokenByRefreshToken().then(({ authorization }) => {
+      setToken(authorization);
+      if (authorization === "ROLE_NONE") {
+        navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
+      }
+    });
   }, [navigate, setToken]);
 
   return (

--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -1,7 +1,7 @@
 import { NavigateFunction } from "react-router-dom";
 import type { QueryClient } from "@tanstack/react-query";
 import { ROUTER_PATH } from "@/shared/constants";
-import { AuthStore } from "@/shared/store";
+import { AuthStore, useAuthStore } from "@/shared/store";
 import { getAccessTokenByRefreshToken } from "../api";
 import { ERROR_MESSAGE } from "./constants";
 
@@ -11,17 +11,22 @@ export const getValidAuthorization = async ({
 }: {
   queryClient: QueryClient;
   callbackFunctions: {
-    setToken: AuthStore["setToken"];
     resetAuthStore: AuthStore["reset"];
     navigate: NavigateFunction;
   };
 }) => {
-  const { setToken, resetAuthStore, navigate } = callbackFunctions;
+  const { resetAuthStore, navigate } = callbackFunctions;
 
   // 해당 try-catch 문은 access token 을 refresh token 을 이용해 재발급 받는 로직입니다.
   try {
-    const { authorization } = await getAccessTokenByRefreshToken();
-    setToken(authorization);
+    const { authorization, role, nickname } =
+      await getAccessTokenByRefreshToken();
+
+    useAuthStore.setState({
+      token: authorization,
+      role,
+      nickname,
+    });
   } catch (error) {
     if (
       error instanceof Error &&

--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -5,7 +5,7 @@ import { AuthStore } from "@/shared/store";
 import { getAccessTokenByRefreshToken } from "../api";
 import { ERROR_MESSAGE } from "./constants";
 
-export const getNewAccessToken = async ({
+export const getValidAuthorization = async ({
   queryClient,
   callbackFunctions,
 }: {

--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -2,7 +2,8 @@ import { NavigateFunction } from "react-router-dom";
 import type { QueryClient } from "@tanstack/react-query";
 import { ROUTER_PATH } from "@/shared/constants";
 import { AuthStore } from "@/shared/store";
-import { APP_END_POINT, ERROR_MESSAGE } from "./constants";
+import { getAccessTokenByRefreshToken } from "../api";
+import { ERROR_MESSAGE } from "./constants";
 
 export const getNewAccessToken = async ({
   queryClient,
@@ -19,20 +20,8 @@ export const getNewAccessToken = async ({
 
   // 해당 try-catch 문은 access token 을 refresh token 을 이용해 재발급 받는 로직입니다.
   try {
-    const response = await fetch(APP_END_POINT.REFRESH_ACCESS_TOKEN, {
-      credentials:
-        process.env.NODE_ENV === "development" ? "include" : "same-origin",
-    });
-
-    const data = await response.json();
-
-    if (!response.ok) {
-      throw new Error(data.message);
-    }
-
-    // 새로운 access token 을 AuthStore 에 저장합니다.
-    // 토큰을 쿼리 키로 갖는 쿼리들은 자연스럽게 새로운 토큰을 사용하게 됩니다.
-    setToken(data.content.authorization);
+    const { authorization } = await getAccessTokenByRefreshToken();
+    setToken(authorization);
   } catch (error) {
     if (
       error instanceof Error &&

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -7,7 +7,6 @@ import { ERROR_MESSAGE } from "./constants";
 import { getValidAuthorization } from "./errorHandlers";
 
 export const useCreateQueryClient = () => {
-  const setToken = useAuthStore((state) => state.setToken);
   const resetAuthStore = useAuthStore((state) => state.reset);
   const navigate = useNavigate();
   const resetOverlays = useOverlayStore((state) => state.resetOverlays);
@@ -39,7 +38,7 @@ export const useCreateQueryClient = () => {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getValidAuthorization({
                 queryClient,
-                callbackFunctions: { setToken, resetAuthStore, navigate },
+                callbackFunctions: { resetAuthStore, navigate },
               });
               queryClient.invalidateQueries({
                 queryKey: query.queryKey,
@@ -69,7 +68,7 @@ export const useCreateQueryClient = () => {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
               await getValidAuthorization({
                 queryClient,
-                callbackFunctions: { setToken, resetAuthStore, navigate },
+                callbackFunctions: { resetAuthStore, navigate },
               });
               const { options, state } = mutation;
               /**

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -4,7 +4,7 @@ import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
 import { useAuthStore } from "@/shared/store";
 import { useOverlayStore } from "@/shared/store/overlay";
 import { ERROR_MESSAGE } from "./constants";
-import { getNewAccessToken } from "./errorHandlers";
+import { getValidAuthorization } from "./errorHandlers";
 
 export const useCreateQueryClient = () => {
   const setToken = useAuthStore((state) => state.setToken);
@@ -37,7 +37,7 @@ export const useCreateQueryClient = () => {
         onError: async (error, query) => {
           switch (error.message) {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
-              await getNewAccessToken({
+              await getValidAuthorization({
                 queryClient,
                 callbackFunctions: { setToken, resetAuthStore, navigate },
               });
@@ -67,7 +67,7 @@ export const useCreateQueryClient = () => {
         onError: async (error, variables, context, mutation) => {
           switch (error.message) {
             case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
-              await getNewAccessToken({
+              await getValidAuthorization({
                 queryClient,
                 callbackFunctions: { setToken, resetAuthStore, navigate },
               });

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,12 +1,15 @@
 import { apiClient } from "@/shared/lib";
 import { APP_END_POINT } from "./ReactQueryProvider/constants";
 
-interface GetNewAccessTokenResponse {
+interface getAccessTokenByRefreshTokenResponse {
   authorization: string;
 }
 
 export const getAccessTokenByRefreshToken = () =>
-  apiClient.get<GetNewAccessTokenResponse>(APP_END_POINT.REFRESH_ACCESS_TOKEN, {
-    credentials:
-      process.env.NODE_ENV === "development" ? "include" : "same-origin",
-  });
+  apiClient.get<getAccessTokenByRefreshTokenResponse>(
+    APP_END_POINT.REFRESH_ACCESS_TOKEN,
+    {
+      credentials:
+        process.env.NODE_ENV === "development" ? "include" : "same-origin",
+    },
+  );

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,8 +1,11 @@
+import { Nickname } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { APP_END_POINT } from "./ReactQueryProvider/constants";
 
 interface getAccessTokenByRefreshTokenResponse {
   authorization: string;
+  role: string;
+  nickname: Nickname;
 }
 
 export const getAccessTokenByRefreshToken = () =>

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,0 +1,12 @@
+import { apiClient } from "@/shared/lib";
+import { APP_END_POINT } from "./ReactQueryProvider/constants";
+
+interface GetNewAccessTokenResponse {
+  authorization: string;
+}
+
+export const getAccessTokenByRefreshToken = () =>
+  apiClient.get<GetNewAccessTokenResponse>(APP_END_POINT.REFRESH_ACCESS_TOKEN, {
+    credentials:
+      process.env.NODE_ENV === "development" ? "include" : "same-origin",
+  });

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2,14 +2,14 @@ import { Nickname } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { APP_END_POINT } from "./ReactQueryProvider/constants";
 
-interface getAccessTokenByRefreshTokenResponse {
+interface GetAccessTokenByRefreshTokenResponse {
   authorization: string;
   role: string;
   nickname: Nickname;
 }
 
 export const getAccessTokenByRefreshToken = () =>
-  apiClient.get<getAccessTokenByRefreshTokenResponse>(
+  apiClient.get<GetAccessTokenByRefreshTokenResponse>(
     APP_END_POINT.REFRESH_ACCESS_TOKEN,
     {
       credentials:

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -577,7 +577,7 @@ export const petInfoFormHandlers = [
   }),
 ];
 
-const getNewAccessTokenHandler = [
+const getValidAuthorizationHandler = [
   http.get(APP_END_POINT.REFRESH_ACCESS_TOKEN, ({ cookies }) => {
     const refreshToken = cookies["Authorization-refresh"];
 
@@ -1364,7 +1364,7 @@ export const handlers = [
   ...addressHandlers,
   ...petInfoFormHandlers,
   ...postLogoutHandlers,
-  ...getNewAccessTokenHandler,
+  ...getValidAuthorizationHandler,
   ...putChangeRegionHandler,
   ...deleteAccountHandlers,
   ...putChangeGenderHandler,


### PR DESCRIPTION
# 관련 이슈 번호
close #390 
# 설명

`/` 경로에서 사용 할 자동 로그인 기능을 구현했습니다. 

```tsx
export const MainLayout = ({ children }: { children: React.ReactNode }) => {
  const setToken = useAuthStore((state) => state.setToken);
  const navigate = useNavigate();

  useEffect(() => {
    getAccessTokenByRefreshToken().then(({ authorization }) => {
      setToken(authorization);
      if (authorization === "ROLE_NONE") {
        navigate(ROUTER_PATH.SIGN_UP_USER_INFO);
      }
    });
  }, [navigate, setToken]);
```

기존 `getNewAccessToken` 은 리프레쉬 토큰이 유효하지 않으면 매번 `login` 페이지로 네비게이팅 시켰는데 

자동 로그인 시도 때는 그러지 않는 편이 좋을 거 같아서 

리프레쉬 토큰으로 액세스 토큰을 받아오는 `getAccessTokenByRefreshToken` 메소드를 따로 분리해서 만들었습니다. 

> 에러 핸들러에서는 `getAccess...By..` 메소드를 활용해서 받아오고 `catch` 문으로 로그인 페이지로 보내버립니다. 

핸들러를 이용해서 테스트 해보려했더니 `localhost` 도메인을 대상으로 한 쿠키 설정은 세션 쿠키로만 설정되어서

새로고침하면 날아가는 거 같습니다. 

> https://velog.io/@swj9077/Cookie%EC%9D%98-domain-%EC%86%8D%EC%84%B1%EA%B3%BC-localhost-%EC%82%AC%EC%9A%A9-%EC%8B%9C-%EC%A3%BC%EC%9D%98%EC%82%AC%ED%95%AD

도메인 네임이 유효하지 않아서 그런 거 같습니다. 

한 번 고쳐보려고 게시글에 있는 메모장도 만져보고 뭐 그래봤는데 그렇게 하려면 핸들러의 도메인도 다 바꾸고 이것 저것 건드려야 합니다. 

되겠죠 뭐 




# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
