### PR TITLE
[Hotfix] Pet 타입 수정에 대한 타입 컴파일 에러 수정

### DIFF
--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -54,7 +54,7 @@ export interface Marking {
   lng: number;
   address: Address;
   countData: Count;
-  pet: Pick<Pet, "profile" | "petId" | "name">;
+  pet: Pet;
   images: Image[];
 }
 

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -54,7 +54,7 @@ export interface Marking {
   lng: number;
   address: Address;
   countData: Count;
-  pet: Pet;
+  pet: Pick<Pet, "profile" | "petId" | "name">;
   images: Image[];
 }
 

--- a/src/features/auth/api/postAddPetInfo.ts
+++ b/src/features/auth/api/postAddPetInfo.ts
@@ -11,7 +11,7 @@ interface PostPetInfoResponse {
   authorization: string;
 }
 
-type PetInfoFormObject = Omit<PetInfo, "profile">;
+type PetInfoFormObject = Omit<PetInfo, "profile" | "petId">;
 
 interface ProfileImage {
   image: File | null;

--- a/src/features/auth/store/petInformationForm.ts
+++ b/src/features/auth/store/petInformationForm.ts
@@ -10,7 +10,10 @@ export interface FileInfo {
   file: File | null;
 }
 
-export type PetInformationFormExternalState = Omit<PetInfo, "profile"> & {
+export type PetInformationFormExternalState = Omit<
+  PetInfo,
+  "profile" | "petId"
+> & {
   profile: FileInfo;
 };
 

--- a/src/features/auth/ui/petInformationForm.tsx
+++ b/src/features/auth/ui/petInformationForm.tsx
@@ -287,7 +287,7 @@ const PetDescriptionTextArea = () => {
       placeholder="우리 댕댕이를 간단히 소개해주세요"
       statusText=""
       onChange={(e) => setDescription(e.target.value)}
-      defaultValue={description}
+      defaultValue={description || ""}
     />
   );
 };

--- a/src/features/marking/ui/markingItem.tsx
+++ b/src/features/marking/ui/markingItem.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { Marking } from "@/entities/marking/api";
+import type { PetInfo } from "@/entities/profile/api";
 import { API_BASE_URL } from "@/shared/constants";
 import { formatDateToYearMonthDay } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
@@ -23,10 +24,11 @@ import {
 } from "../api";
 import { useDeleteMarking } from "../api";
 
-type MarkingItemProps = {
+interface MarkingItemProps
+  extends Omit<Marking, "isVisible" | "isTempSaved" | "userId" | "pet"> {
   onRegionClick: () => void;
-} & Omit<Marking, "isVisible" | "isTempSaved" | "userId">;
-
+  pet: Pick<PetInfo, "petId" | "profile" | "name">;
+}
 const MarkingManageButton = ({
   markingId,
 }: Pick<MarkingItemProps, "markingId">) => {

--- a/src/features/setting/api/putChangePetInfo.ts
+++ b/src/features/setting/api/putChangePetInfo.ts
@@ -4,7 +4,7 @@ import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { SETTING_END_POINT } from "../constants";
 
-type PetInfoFormObject = Omit<PetInfo, "profile">;
+type PetInfoFormObject = Omit<PetInfo, "profile" | "petId">;
 
 interface ProfileImage {
   image: File | null;

--- a/src/features/setting/hooks/useChangePetInfoModal.tsx
+++ b/src/features/setting/hooks/useChangePetInfoModal.tsx
@@ -1,10 +1,10 @@
 import { PetInformationForm } from "@/features/auth/ui";
-import { UserInfo } from "@/entities/profile/api";
+import { PetInfo } from "@/entities/profile/api";
 import { useModal } from "@/shared/lib";
 import { Modal } from "@/shared/ui/modal";
 import { usePutChangePetInfo } from "../api";
 
-export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
+export const useChangePetInfoModal = (pet: Omit<PetInfo, "petId">) => {
   const { mutate: putChangePetInformation, isPending } = usePutChangePetInfo();
 
   const { handleOpen, onClose } = useModal(() => (
@@ -25,7 +25,7 @@ export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
             ...pet,
             profile: {
               name: "",
-              url: pet.profile,
+              url: pet.profile || "",
               file: null,
             },
           }}
@@ -40,7 +40,8 @@ export const useChangePetInfoModal = (pet: NonNullable<UserInfo["pet"]>) => {
               breed,
               personalities,
               description,
-              isChaProfile: !!profile.file || profile.url !== pet.profile,
+              isChaProfile:
+                !!profile.file || profile.url !== (pet.profile || ""),
               image: profile.file,
             });
           }}


### PR DESCRIPTION
# 관련 이슈 번호
close #394 
# 설명


### 버그가 발생한 상황
#362 작업에서 `getProfile` 의 타입에서 `petId` 가 추가 되었습니다.

```tsx
export interface PetInfo {
  petId: PetId;
  name: PetName;
  breed: Breed;
  description: PetDescription;
  personalities: PetPersonalities;
  profile: ProfileImageUrl;
}
```

이에 `PetInfo` 를 `import` 하여 사용하는 다양한 타입에서 추가 된 `petId` 에 대한 처리가 필요 합니다.

이에 타입 컴파일 에러 작업을 시행 합니다.

---

`PetInfo` 타입을 `import`   하는 곳에서 모두 타입을 적절히 수정해주었습니다.

`petId` 를 제거하거나 , 필요한 타입만 `Pick` 하여 사용하도록 수정했습니다.

추가로 `null` 타입으로 오기도 하는 `string` 인 타입들 (예를 들어 `PetInfo.description`) 에 대해서도 기본 값을 지정해주었습니다. 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
