### PR TITLE
[Hotfix] following , unFollowing 후 사용자 프로필 업데이트 로직 추가

### DIFF
--- a/src/features/follow/api/deleteFollowing.ts
+++ b/src/features/follow/api/deleteFollowing.ts
@@ -1,12 +1,18 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
 import { FOLLOW_END_POINT } from "../constants";
 
 export const useDeleteFollowing = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (nickname: string) => {
       return apiClient.delete(FOLLOW_END_POINT.DELETE_FOLLOWING(nickname), {
         withToken: true,
+      });
+    },
+    onSuccess: (_data, nickname) => {
+      queryClient.invalidateQueries({
+        queryKey: ["profile", nickname],
       });
     },
   });

--- a/src/features/follow/api/postFollowing.ts
+++ b/src/features/follow/api/postFollowing.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Nickname } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
-import { useAuthStore } from "@/shared/store";
 import { FOLLOW_END_POINT } from "../constants";
 
 export const usePostFollowing = () => {
@@ -12,9 +11,9 @@ export const usePostFollowing = () => {
       apiClient.post(FOLLOW_END_POINT.POST_FOLLOWING(nickname), {
         withToken: true,
       }),
-    onSuccess: () => {
+    onSuccess: (_data, nickname) => {
       queryClient.invalidateQueries({
-        queryKey: ["profile", useAuthStore.getState().nickname],
+        queryKey: ["profile", nickname],
       });
     },
   });


### PR DESCRIPTION
# 관련 이슈 번호
close #401 
# 설명

![updatefollowing](https://github.com/user-attachments/assets/63c843d5-6505-43c9-9fdc-cc93d3a57447)

이전엔 팔로잉 , 언팔로잉 요청 후 사용자의 프로필을 업데이트 하는 로직이 존재하지 않았습니다. 

오히려 내 프로필을 업데이트 했습니다.


![updatefollowing](https://github.com/user-attachments/assets/205e6a38-b56a-4fbe-9566-5d795df970aa)

```tsx
import { useMutation, useQueryClient } from "@tanstack/react-query";
import { apiClient } from "@/shared/lib";
import { FOLLOW_END_POINT } from "../constants";

export const useDeleteFollowing = () => {
  const queryClient = useQueryClient();
  return useMutation({
    mutationFn: (nickname: string) => {
      return apiClient.delete(FOLLOW_END_POINT.DELETE_FOLLOWING(nickname), {
        withToken: true,
      });
    },
    onSuccess: (_data, nickname) => {
      queryClient.invalidateQueries({
        queryKey: ["profile", nickname],
      });
    },
  });
};
```

이에 팔로잉, 팔로워 요청 후 사용자의 프로필을 재요청하도록 변경합니다. 

> 추후 `setQueryData` 로 불필요한 `query` 요청 횟수를 줄일 수 있을 거라 생각 합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
