### PR TITLE
[Feat] 동네 마킹 바텀시트 무한스크롤 구현

### DIFF
--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -1,4 +1,5 @@
 import { skipToken, useQuery } from "@tanstack/react-query";
+import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { MARKER_END_POINT } from "../constants";
@@ -51,6 +52,8 @@ export const useGetBoundaryMarkerList = ({
   northEastLat?: number;
   northEastLng?: number;
 }) => {
+  const { isIdle: isMapIdle } = useMapStore.getState();
+
   return useQuery({
     queryKey: [
       "boundaryMarkerList",
@@ -59,6 +62,8 @@ export const useGetBoundaryMarkerList = ({
       northEastLat,
       northEastLng,
     ],
+
+    enabled: isMapIdle,
 
     queryFn:
       !!southWestLat && !!southWestLng && !!northEastLat && !!northEastLng

--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -63,10 +63,12 @@ export const useGetBoundaryMarkerList = ({
       northEastLng,
     ],
 
-    enabled: isMapIdle,
-
     queryFn:
-      !!southWestLat && !!southWestLng && !!northEastLat && !!northEastLng
+      isMapIdle &&
+      !!southWestLat &&
+      !!southWestLng &&
+      !!northEastLat &&
+      !!northEastLng
         ? () =>
             getBoundaryMarkerList({
               southWestLat,

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -1,5 +1,6 @@
 import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { useMap } from "@vis.gl/react-google-maps";
+import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { SEARCH_MARKING_END_POINT } from "../constants";
@@ -137,6 +138,8 @@ export const useGetMarkingList = ({
   const lat = mapCenter?.lat();
   const lng = mapCenter?.lng();
 
+  const { isIdle: isMapIdle } = useMapStore.getState();
+
   return useInfiniteQuery({
     queryKey: [
       "markingList",
@@ -146,6 +149,8 @@ export const useGetMarkingList = ({
       northEastLng,
       sortType,
     ],
+
+    enabled: isMapIdle,
 
     queryFn:
       !!southWestLat &&

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -150,9 +150,8 @@ export const useGetMarkingList = ({
       sortType,
     ],
 
-    enabled: isMapIdle,
-
     queryFn:
+      isMapIdle &&
       !!southWestLat &&
       !!southWestLng &&
       !!northEastLat &&

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -28,13 +28,9 @@ export const useResearchMarkingList = () => {
   const researchMarkingList = (filter?: Filter) => {
     if (!map) return;
 
-    const mapCenter = map.getCenter();
     const bounds = map.getBounds();
 
     if (!bounds) return;
-
-    const lat = mapCenter.lat();
-    const lng = mapCenter.lng();
 
     const northEast = bounds.getNorthEast();
     const southWest = bounds.getSouthWest();
@@ -49,8 +45,6 @@ export const useResearchMarkingList = () => {
       boundsNELng: northEastLng.toString(),
       boundsSWLat: southWestLat.toString(),
       boundsSWLng: southWestLng.toString(),
-      lat: lat.toString(),
-      lng: lng.toString(),
       sortType: filter?.sortType || sortType,
     });
 
@@ -90,18 +84,8 @@ export const useResearchMarkingList = () => {
       }
     : null;
 
-  const lat =
-    typeof searchParams.get("lat") === "string"
-      ? Number(searchParams.get("lat"))
-      : null;
-  const lng =
-    typeof searchParams.get("lng") === "string"
-      ? Number(searchParams.get("lng"))
-      : null;
-
   return {
     bounds,
-    center: { lat, lng },
     sortType,
     researchMarkingList,
   };

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -6,6 +6,7 @@ import { useMapStore } from "@/features/map/store";
 import { MapViewModeFilter, SortTypeFilter } from "@/features/marking/ui";
 import { useGetMarkingList } from "@/entities/marking/api";
 import { API_BASE_URL } from "@/shared/constants";
+import { useInfiniteScroll } from "@/shared/lib";
 import { MyLocationIcon } from "@/shared/ui/icon";
 import { MarkingList } from "./markingList";
 
@@ -21,12 +22,23 @@ export const MapBottomSheet = () => {
   const snapTo = (i: number) => sheetRef.current?.snapTo(i);
 
   const { bounds, sortType } = useResearchMarkingList();
-  const { data: markingList } = useGetMarkingList({
+  const {
+    data: markingList,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useGetMarkingList({
     southWestLat: bounds?.southWest.lat,
     southWestLng: bounds?.southWest.lng,
     northEastLat: bounds?.northEast.lat,
     northEastLng: bounds?.northEast.lng,
     sortType,
+  });
+
+  const [setNode] = useInfiniteScroll(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
   });
 
   const mapMode = useMapStore((state) => state.mode);
@@ -87,15 +99,21 @@ export const MapBottomSheet = () => {
             <div className="px-4">
               <MarkingList display="grid">
                 {markingList?.map(({ markingId, previewImage }) => (
-                  <button key={markingId} type="button">
+                  <button
+                    key={markingId}
+                    type="button"
+                    className="aspect-square"
+                  >
                     <img
-                      className="aspect-square"
+                      className="w-full h-full object-cover"
                       src={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
                     />
                   </button>
                 ))}
               </MarkingList>
             </div>
+
+            <div className="h-[.125rem]" ref={setNode} />
           </Sheet.Scroller>
         </Sheet.Content>
       </Sheet.Container>


### PR DESCRIPTION
# 관련 이슈 번호

#235 

# 설명

현재 맵 컴포넌트는 아래와 같이 작동됩니다.

1. defaultCenter와 defaultZoom으로 설정했던 `MAP_INITIAL_CENTER`, `MAP_INITIAL_ZOOM`으로 맵 이동
2. onCameraChanged 실행
3. 맵 움직임이 끝났으므로 onIdle 실행
4. map store의 **isIdle 상태가 false -> true로 변경**
5. `MapInitializer`에서 사용자 현재 위치와 url 파라미터 확인
6. url 파라미터에 맵 바운더리 추가
7. url 변경으로 인해 마킹, 마커 데이터 요청

사용자의 현재 위치를 파악하고 난 이후 마킹과 마커 데이터들을 요청해야 합니다. 

따라서 skipToken을 통해 useInfiniteQuery에 isIdle이 false이면 (= 사용자 현재 위치를 알기 전) 
데이터를 요청하지 않도록 했습니다.

