### PR TITLE
[Hotfix] 남의 프로필 페이지에서 경로 상 닉네임을 렌더링 하도록 변경

### DIFF
--- a/src/pages/[nickname]/otherProfilePage.tsx
+++ b/src/pages/[nickname]/otherProfilePage.tsx
@@ -55,7 +55,9 @@ export const OtherProfilePage = () => {
           <EmptyMyProfileOverView />
         )}
         <div className="flex flex-col items-start gap-2 w-full ">
-          <h3 className="text-grey-900 text-center title-2">내 마킹</h3>
+          <h3 className="text-grey-900 text-center title-2">
+            {nicknameParams}
+          </h3>
           <MarkingThumbnailGrid nickname={nicknameParams} />
         </div>
       </section>

--- a/src/pages/[nickname]/otherProfilePage.tsx
+++ b/src/pages/[nickname]/otherProfilePage.tsx
@@ -56,7 +56,7 @@ export const OtherProfilePage = () => {
         )}
         <div className="flex flex-col items-start gap-2 w-full ">
           <h3 className="text-grey-900 text-center title-2">
-            {nicknameParams}
+            {nicknameParams}님의 마킹
           </h3>
           <MarkingThumbnailGrid nickname={nicknameParams} />
         </div>


### PR DESCRIPTION
# 관련 이슈 번호
close #410
## 버그 설명
2024/10/28 시행한 테스트에서 발견된 버그 입니다. 


### 버그가 발생한 상황

![image](https://github.com/user-attachments/assets/8b075a4f-629f-4d75-91a6-ada1614ea9bf)

### 예상 해결 방안

`OtherProfilePage` 에서 렌더링 되는 글을 변경 합니다. 

### 첨부 파일 (Optional)

## 버그 발생 코드 (Optional)

### 레퍼런스 이슈 (Optional)
