### PR TITLE
[Hotfix] API_BASE_URL 붙어있지 않은 엔드포인트 경로 수정

### DIFF
--- a/src/entities/auth/constants/index.ts
+++ b/src/entities/auth/constants/index.ts
@@ -1,6 +1,6 @@
 import { API_BASE_URL } from "@/shared/constants";
 
-export const MY_INFO_END_POINT = "/users/profile";
+export const MY_INFO_END_POINT = `${API_BASE_URL}/users/profile`;
 
 export const SOCIAL_TYPE = {
   EMAIL: "이메일",

--- a/src/features/marking/constants/endPoint.ts
+++ b/src/features/marking/constants/endPoint.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from "@/shared/constants";
 export const MARKING_END_POINT = {
   ADD: `${API_BASE_URL}/markings`,
   SAVE_TEMP: `${API_BASE_URL}/markings/temp`,
-  DELETE: "/markings",
+  DELETE: `${API_BASE_URL}/markings`,
   LIKE: (markingId: number) => `${API_BASE_URL}/markings/like/${markingId}`,
   SAVE: (markingId: number) => `${API_BASE_URL}/markings/saves/${markingId}`,
 };


### PR DESCRIPTION
# 관련 이슈 번호
close #412
# 설명
2024/10/29 에 발견된 버그 입니다.

버그가 발생한 상황
종종 constants 폴더에 존재하는 엔드포인트에 API_BASE_URL 이 붙어있지 않는 경우가 존재합니다.

이에 문제를 해결 합니다.
# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
