### PR TITLE
[Hotfix] getNextPageParams 계산식 변경

### DIFF
--- a/src/entities/follow/api/getFollowerList.ts
+++ b/src/entities/follow/api/getFollowerList.ts
@@ -55,7 +55,9 @@ export const useGetFollowerList = ({ nickname }: GetFollowerListRequest) => {
       ? ({ pageParam = 0 }) => getFollowerList({ nickname, pageParam })
       : skipToken,
     getNextPageParam: ({ totalPages, pageAble }) => {
-      return pageAble.pageNumber < totalPages ? pageAble.pageNumber + 1 : null;
+      return pageAble.pageNumber < totalPages - 1
+        ? pageAble.pageNumber + 1
+        : null;
     },
     initialPageParam: 0,
     select: ({ pages }) => pages.flatMap((page) => page.userInfos),

--- a/src/entities/follow/api/getFollowingList.ts
+++ b/src/entities/follow/api/getFollowingList.ts
@@ -54,9 +54,8 @@ export const useGetFollowingList = ({ nickname }: GetFollowingListRequest) => {
     queryFn: token
       ? ({ pageParam = 0 }) => getFollowingList({ nickname, pageParam })
       : skipToken,
-    getNextPageParam: ({ totalPages, pageAble }) => {
-      return pageAble.pageNumber < totalPages ? pageAble.pageNumber + 1 : null;
-    },
+    getNextPageParam: ({ totalPages, pageAble }) =>
+      pageAble.pageNumber < totalPages - 1 ? pageAble.pageNumber + 1 : null,
     initialPageParam: 0,
     select: ({ pages }) => pages.flatMap((page) => page.userInfos),
   });

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -172,7 +172,7 @@ export const useGetMarkingList = ({
         : skipToken,
 
     getNextPageParam: ({ pageAble: { pageNumber }, totalPages }) => {
-      return pageNumber < totalPages ? pageNumber + 1 : null;
+      return pageNumber < totalPages - 1 ? pageNumber + 1 : null;
     },
     initialPageParam: 0,
     select: (data) => data.pages.flatMap((page) => page.markings),

--- a/src/widgets/marking/api/getDashboardMarkingThumbnail.ts
+++ b/src/widgets/marking/api/getDashboardMarkingThumbnail.ts
@@ -51,9 +51,8 @@ export const useGetDashboardMarkingThumbnail = (
             },
           )
       : skipToken,
-    getNextPageParam: ({ totalPages, pageAble }) => {
-      return pageAble.pageNumber < totalPages ? pageAble.pageNumber + 1 : null;
-    },
+    getNextPageParam: ({ totalPages, pageAble }) =>
+      pageAble.pageNumber < totalPages - 1 ? pageAble.pageNumber + 1 : null,
     select: ({ pages }) => pages.flatMap((page) => page.marks),
     initialPageParam: 0,
   });


### PR DESCRIPTION
# 관련 이슈 번호
close #411 
# 설명

2024/10/28 시 발견한 버그 입니다. 


### 버그가 발생한 상황

![image](https://github.com/user-attachments/assets/be59fdd0-09b3-47f6-89d2-e6af95ab6a63)

### 예상 해결 방안

```tsx
    getNextPageParam: ({ totalPages, pageAble }) => {
      return pageAble.pageNumber < totalPages ? pageAble.pageNumber + 1 : null;
    },
```

현재 `getNextPageParams` 는 토탈 페이지보다 적을 경우 요청을 보냅니다.

`pageNumber` 는 0 부터 시작 , totalPages 는 1부터 시작하기에 

1 번째 페이지만 존재 할 경우 존재하지 않는 페이지 (1) 에 대한 요청을 무한히 보내게 됩니다. 

이에 계산식을 변경 합니다. 
# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
