### PR TITLE
[Feat] 이 장소 마킹 바텀 시트 기능 구현 (클러스터링 제외)

### DIFF
--- a/src/app/FooterNavigationBar.tsx
+++ b/src/app/FooterNavigationBar.tsx
@@ -29,15 +29,7 @@ export const FooterNavigationBar = () => {
             </NavLink>
           </li>
           <li className="grow">
-            <NavLink
-              to={ROUTER_PATH.MAP}
-              className={({ isActive }) =>
-                `${isActive ? active : inactive} ${base}`
-              }
-            >
-              <MapIcon />
-              지도
-            </NavLink>
+            <MapPageNavLink />
           </li>
           <li className="grow">
             <MyPageNavLink />
@@ -82,6 +74,32 @@ const MyPageNavLink = () => {
         className="w-6 h-6 rounded-2xl flex-shrink-0"
       />
       My
+    </NavLink>
+  );
+};
+
+const MapPageNavLink = () => {
+  const { active, inactive, base } = footerNavigationBarStyles;
+
+  const getMapPagePath = () => {
+    const { pathname } = window.location;
+
+    const mapPagePaths: string[] = [ROUTER_PATH.MAP, ROUTER_PATH.PLACE];
+
+    if (mapPagePaths.includes(pathname)) {
+      return window.location;
+    }
+
+    return ROUTER_PATH.MAP;
+  };
+
+  return (
+    <NavLink
+      to={getMapPagePath()}
+      className={({ isActive }) => `${isActive ? active : inactive} ${base}`}
+    >
+      <MapIcon />
+      지도
     </NavLink>
   );
 };

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -11,7 +11,7 @@ import { AccountManagementPage } from "@/pages/setting/manage-account";
 import { SignUpPage } from "@/pages/sign-up";
 import PetInfoPage from "@/pages/sign-up/pet-info/page";
 import { UserInfoRegistrationPage } from "@/pages/sign-up/user-info";
-import { LocalMarkingList } from "@/widgets/map/ui";
+import { LocalMarkingList, PlaceMarkingList } from "@/widgets/map/ui";
 import { ROUTER_PATH } from "@/shared/constants";
 import { MainPage } from "../pages";
 import { AppProviderLayout } from "./AppProviderLayout";
@@ -32,6 +32,10 @@ export const router = createBrowserRouter([
           {
             index: true,
             element: <LocalMarkingList />,
+          },
+          {
+            path: ROUTER_PATH.PLACE,
+            element: <PlaceMarkingList />,
           },
         ],
       },

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -11,6 +11,7 @@ import { AccountManagementPage } from "@/pages/setting/manage-account";
 import { SignUpPage } from "@/pages/sign-up";
 import PetInfoPage from "@/pages/sign-up/pet-info/page";
 import { UserInfoRegistrationPage } from "@/pages/sign-up/user-info";
+import { LocalMarkingList } from "@/widgets/map/ui";
 import { ROUTER_PATH } from "@/shared/constants";
 import { MainPage } from "../pages";
 import { AppProviderLayout } from "./AppProviderLayout";
@@ -27,6 +28,12 @@ export const router = createBrowserRouter([
       {
         path: ROUTER_PATH.MAP,
         element: <MapPage />, // 지도
+        children: [
+          {
+            index: true,
+            element: <LocalMarkingList />,
+          },
+        ],
       },
       {
         path: ROUTER_PATH.PROFILE,

--- a/src/entities/map/ui/customMarker.tsx
+++ b/src/entities/map/ui/customMarker.tsx
@@ -7,6 +7,7 @@ interface MarkerProps {
     lat: number;
     lng: number;
   };
+  onClick?: () => void;
 }
 
 interface GooglePinProps extends MarkerProps, PinProps {}
@@ -25,9 +26,9 @@ export const User = ({ position }: MarkerProps) => {
   );
 };
 
-export const Pin = ({ position, imageUrl, alt }: GooglePinProps) => {
+export const Pin = ({ position, imageUrl, alt, onClick }: GooglePinProps) => {
   return (
-    <AdvancedMarker position={position}>
+    <AdvancedMarker position={position} onClick={onClick}>
       <_Pin.Default imageUrl={imageUrl} alt={alt} />
     </AdvancedMarker>
   );

--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -47,10 +47,10 @@ export const useGetBoundaryMarkerList = ({
   northEastLat,
   northEastLng,
 }: {
-  southWestLat?: number;
-  southWestLng?: number;
-  northEastLat?: number;
-  northEastLng?: number;
+  southWestLat: number | null;
+  southWestLng: number | null;
+  northEastLat: number | null;
+  northEastLng: number | null;
 }) => {
   const { isIdle: isMapIdle } = useMapStore.getState();
 

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -127,10 +127,10 @@ export const useGetMarkingList = ({
   northEastLng,
   sortType,
 }: {
-  southWestLat?: number;
-  southWestLng?: number;
-  northEastLat?: number;
-  northEastLng?: number;
+  southWestLat: number | null;
+  southWestLng: number | null;
+  northEastLat: number | null;
+  northEastLng: number | null;
 } & Pick<GetMarkingListRequest, "sortType">) => {
   const map = useMap();
   const mapCenter = map?.getCenter();
@@ -172,7 +172,7 @@ export const useGetMarkingList = ({
         : skipToken,
 
     getNextPageParam: ({ pageAble: { pageNumber }, totalPages }) => {
-      return pageNumber < totalPages ? pageNumber + 1 : null;
+      return pageNumber < totalPages - 1 ? pageNumber + 1 : null;
     },
     initialPageParam: 0,
     select: (data) => data.pages.flatMap((page) => page.markings),

--- a/src/features/map/constants/index.ts
+++ b/src/features/map/constants/index.ts
@@ -1,58 +1,5 @@
 import type { SortType } from "@/entities/marking/api";
 
-/**
- * Google map 에 사용 할 옵션들을 지정한 객체입니다.
- * 사용 가능한 객체들은 다음과 같은 곳에서 확인할 수 있습니다.
- * mapOptions : @https://developers.google.com/maps/documentation/javascript/reference/map?hl=ko&_gl=1*y1qget*_up*MQ..*_ga*MTU1NzczMDk3NS4xNzI1MzU1Mzc5*_ga_NRWSTWS78N*MTcyNTM1NTM3OS4xLjAuMTcyNTM1NTM3OS4wLjAuMA..#MapOptions
- * styles : @https://developers.google.com/maps/documentation/javascript/reference/map?hl=ko&_gl=1*k2t292*_up*MQ..*_ga*MTU1NzczMDk3NS4xNzI1MzU1Mzc5*_ga_NRWSTWS78N*MTcyNTM1NTM3OS4xLjAuMTcyNTM1NTM3OS4wLjAuMA..#MapTypeStyle
- */
-export const mapOptions = {
-  // 확대 , 축소 , 전체 화면 등과 같은 기본 구글 맵스 UI 제거
-  disableDefaultUI: true,
-
-  // 거리뷰 컨트롤 제거
-  streetViewControl: false,
-
-  // 지도 타입 컨트롤 제거
-  mapTypeControl: false,
-
-  // 지도 축척 컨트롤 제거
-  scaleControl: false,
-
-  // 키보드 단축키 제거
-  keyboardShortcuts: false,
-
-  // 전체 화면 컨트롤 제거
-  fullscreenControl: false,
-
-  // 최대 볼 수 있는 bound 를 대한민국으로 제한
-  restriction: {
-    latLngBounds: {
-      north: 38.634,
-      south: 33.0,
-      east: 131.0,
-      west: 124.0,
-    },
-    strictBounds: true,
-  },
-
-  /**
-   * TODO 상의 후 픽스하기
-   */
-  maxZoom: 18, // 최대 줌 레벨
-  minZoom: 10, // 최소 줌 레벨
-  // TODO 상의 후 픽스하기
-
-  // 지도 회전 기능 제거 , 지도를 회전하면 우리의 마커들이 모두 같이  회전 되나 ?
-  headingInteractionEnabled: false,
-
-  // 카메라 기울기 제어
-  tiltInteractionEnabled: false, // 사용자가 카메라 기울기를 조정 할 수 없도록 설정, 기울기를 조정하면 마커들이 어떻게 기울어질까 ?
-
-  // 모든 제스처를 활성화합니다. 사용자는 한 손가락으로 드래그하고, 두 손가락으로 확대/축소할 수 있습니다.
-  gestureHandling: "greedy",
-};
-
 export const sortTypeMap: Record<SortType, string> = {
   RECENT: "최신순",
   DISTANCE: "가까운순",

--- a/src/features/map/constants/index.ts
+++ b/src/features/map/constants/index.ts
@@ -59,7 +59,7 @@ export const sortTypeMap: Record<SortType, string> = {
   POPULARITY: "인기순",
 };
 
-export const mapViewModeMap = {
+export const RangeFilterMap = {
   ALL_VIEW: "전체보기", // 내 마킹에서만 있는 option
   CURRENT_LOCATION: "내 위치 중심",
   MAP_LOCATION: "현재 지도 중심",

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -109,25 +109,10 @@ export const useResearchMarkingList = () => {
   const navigate = useNavigate();
 
   const navigatePlace = (filter: Filter) => {
-    navigate(ROUTER_PATH.PLACE);
+    const boundsParams = `boundsNELat=${filter.bounds?.northEastLat || northEastLat}&boundsNELng=${filter.bounds?.northEastLng || northEastLng}&boundsSWLat=${filter.bounds?.southWestLat || southWestLat}&boundsSWLng=${filter.bounds?.southWestLng || southWestLng}`;
+    const sortTypeParam = `sortType=${filter.sortType || sortType}`;
 
-    if (filter.bounds) {
-      setSearchParams({
-        boundsNELat: filter.bounds.northEastLat.toString(),
-        boundsNELng: filter.bounds.northEastLng.toString(),
-        boundsSWLat: filter.bounds.southWestLat.toString(),
-        boundsSWLng: filter.bounds.southWestLng.toString(),
-        sortType: filter.sortType || sortType,
-      });
-    } else {
-      setSearchParams({
-        boundsNELat: northEastLat!.toString(),
-        boundsNELng: northEastLng!.toString(),
-        boundsSWLat: southWestLat!.toString(),
-        boundsSWLng: southWestLng!.toString(),
-        sortType: filter.sortType || sortType,
-      });
-    }
+    navigate(`${ROUTER_PATH.PLACE}?${boundsParams}&${sortTypeParam}`);
 
     setTimeout(() => {
       setIsLastSearchedLocation(true);

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -7,10 +7,10 @@ import { sortTypeMap } from "../constants";
 import { useMapStore } from "../store";
 
 interface Bounds {
-  northEastLat: number;
-  northEastLng: number;
-  southWestLat: number;
-  southWestLng: number;
+  northEastLat: number | null;
+  northEastLng: number | null;
+  southWestLat: number | null;
+  southWestLng: number | null;
 }
 
 interface Filter {
@@ -56,14 +56,12 @@ export const useResearchMarkingList = () => {
   const hasBoundsParams =
     northEastLat && northEastLng && southWestLat && southWestLng;
 
-  const bounds: Bounds | null = hasBoundsParams
-    ? {
-        northEastLat,
-        northEastLng,
-        southWestLat,
-        southWestLng,
-      }
-    : null;
+  const bounds: Bounds = {
+    northEastLat: hasBoundsParams ? northEastLat : null,
+    northEastLng: hasBoundsParams ? northEastLat : null,
+    southWestLat: hasBoundsParams ? northEastLat : null,
+    southWestLng: hasBoundsParams ? northEastLat : null,
+  };
 
   // 정렬 기준 파라미터
   const sortTypeParam = searchParams.get("sortType");

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -6,9 +6,37 @@ import { ROUTER_PATH } from "@/shared/constants";
 import { sortTypeMap } from "../constants";
 import { useMapStore } from "../store";
 
+interface Bounds {
+  northEastLat: number;
+  northEastLng: number;
+  southWestLat: number;
+  southWestLng: number;
+}
+
 interface Filter {
   sortType?: SortType;
+  bounds?: Bounds;
 }
+
+const getNumberParam = (
+  key: string,
+  searchParams: URLSearchParams,
+): number | null => {
+  const value = searchParams.get(key);
+
+  if (value === null) {
+    return null;
+  }
+
+  const paramToNumber = Number(value);
+  const isNumber = !Number.isNaN(paramToNumber);
+
+  if (isNumber) {
+    return paramToNumber;
+  }
+
+  return null;
+};
 
 export const useResearchMarkingList = () => {
   const queryClient = useQueryClient();
@@ -20,21 +48,41 @@ export const useResearchMarkingList = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
+  // 경계 좌표 파라미터
+  const northEastLat = getNumberParam("boundsNELat", searchParams);
+  const northEastLng = getNumberParam("boundsNELng", searchParams);
+  const southWestLat = getNumberParam("boundsSWLat", searchParams);
+  const southWestLng = getNumberParam("boundsSWLng", searchParams);
+  const hasBoundsParams =
+    northEastLat && northEastLng && southWestLat && southWestLng;
+
+  const bounds: Bounds | null = hasBoundsParams
+    ? {
+        northEastLat,
+        northEastLng,
+        southWestLat,
+        southWestLng,
+      }
+    : null;
+
+  // 정렬 기준 파라미터
   const sortTypeParam = searchParams.get("sortType");
-  const sortType: SortType =
-    typeof sortTypeParam === "string" && sortTypeParam in sortTypeMap
-      ? (sortTypeParam as SortType)
-      : "POPULARITY";
+  const hasSortTypeParam =
+    typeof sortTypeParam === "string" && sortTypeParam in sortTypeMap;
+
+  const sortType: SortType = hasSortTypeParam
+    ? (sortTypeParam as SortType)
+    : "POPULARITY";
 
   const researchMarkingList = (filter?: Filter) => {
     if (!map) return;
 
-    const bounds = map.getBounds();
+    const mapBounds = map.getBounds();
 
-    if (!bounds) return;
+    if (!mapBounds) return;
 
-    const northEast = bounds.getNorthEast();
-    const southWest = bounds.getSouthWest();
+    const northEast = mapBounds.getNorthEast();
+    const southWest = mapBounds.getSouthWest();
 
     const northEastLat = northEast.lat();
     const northEastLng = northEast.lng();
@@ -58,60 +106,40 @@ export const useResearchMarkingList = () => {
     });
   };
 
-  const northEastLat =
-    typeof searchParams.get("boundsNELat") === "string"
-      ? Number(searchParams.get("boundsNELat"))
-      : null;
-  const northEastLng =
-    typeof searchParams.get("boundsNELng") === "string"
-      ? Number(searchParams.get("boundsNELng"))
-      : null;
-  const southWestLat =
-    typeof searchParams.get("boundsSWLat") === "string"
-      ? Number(searchParams.get("boundsSWLat"))
-      : null;
-  const southWestLng =
-    typeof searchParams.get("boundsSWLng") === "string"
-      ? Number(searchParams.get("boundsSWLng"))
-      : null;
-
   const navigate = useNavigate();
 
-  const hasBoundsParams =
-    northEastLat && northEastLng && southWestLat && southWestLng;
-
-  const navigatePlace = ({ lat, lng }: { lat: number; lng: number }) => {
-    map.setCenter({ lat, lng });
-    map.setZoom(19);
-
-    const bounds = map.getBounds();
-
-    if (!bounds) return;
-
-    const northEast = bounds.getNorthEast();
-    const southWest = bounds.getSouthWest();
-
-    const northEastLat = northEast.lat();
-    const northEastLng = northEast.lng();
-    const southWestLat = southWest.lat();
-    const southWestLng = southWest.lng();
-
+  const navigatePlace = (filter: Filter) => {
     navigate(ROUTER_PATH.PLACE);
-    setSearchParams({
-      boundsNELat: northEastLat.toString(),
-      boundsNELng: northEastLng.toString(),
-      boundsSWLat: southWestLat.toString(),
-      boundsSWLng: southWestLng.toString(),
-      sortType: "RECENT",
+
+    if (filter.bounds) {
+      setSearchParams({
+        boundsNELat: filter.bounds.northEastLat.toString(),
+        boundsNELng: filter.bounds.northEastLng.toString(),
+        boundsSWLat: filter.bounds.southWestLat.toString(),
+        boundsSWLng: filter.bounds.southWestLng.toString(),
+        sortType: filter.sortType || sortType,
+      });
+    } else {
+      setSearchParams({
+        boundsNELat: northEastLat!.toString(),
+        boundsNELng: northEastLng!.toString(),
+        boundsSWLat: southWestLat!.toString(),
+        boundsSWLng: southWestLng!.toString(),
+        sortType: filter.sortType || sortType,
+      });
+    }
+
+    setTimeout(() => {
+      setIsLastSearchedLocation(true);
+    }, 0);
+
+    queryClient.removeQueries({
+      queryKey: ["markingList"],
+    });
+    queryClient.removeQueries({
+      queryKey: ["boundaryMarkerList"],
     });
   };
-
-  const bounds = hasBoundsParams
-    ? {
-        northEast: { lat: northEastLat, lng: northEastLng },
-        southWest: { lat: southWestLat, lng: southWestLng },
-      }
-    : null;
 
   return {
     bounds,

--- a/src/features/map/hooks/useResearchMarkingList.ts
+++ b/src/features/map/hooks/useResearchMarkingList.ts
@@ -1,7 +1,8 @@
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMap } from "@vis.gl/react-google-maps";
 import { SortType } from "@/entities/marking/api";
+import { ROUTER_PATH } from "@/shared/constants";
 import { sortTypeMap } from "../constants";
 import { useMapStore } from "../store";
 
@@ -74,8 +75,36 @@ export const useResearchMarkingList = () => {
       ? Number(searchParams.get("boundsSWLng"))
       : null;
 
+  const navigate = useNavigate();
+
   const hasBoundsParams =
     northEastLat && northEastLng && southWestLat && southWestLng;
+
+  const navigatePlace = ({ lat, lng }: { lat: number; lng: number }) => {
+    map.setCenter({ lat, lng });
+    map.setZoom(19);
+
+    const bounds = map.getBounds();
+
+    if (!bounds) return;
+
+    const northEast = bounds.getNorthEast();
+    const southWest = bounds.getSouthWest();
+
+    const northEastLat = northEast.lat();
+    const northEastLng = northEast.lng();
+    const southWestLat = southWest.lat();
+    const southWestLng = southWest.lng();
+
+    navigate(ROUTER_PATH.PLACE);
+    setSearchParams({
+      boundsNELat: northEastLat.toString(),
+      boundsNELng: northEastLng.toString(),
+      boundsSWLat: southWestLat.toString(),
+      boundsSWLng: southWestLng.toString(),
+      sortType: "RECENT",
+    });
+  };
 
   const bounds = hasBoundsParams
     ? {
@@ -88,5 +117,6 @@ export const useResearchMarkingList = () => {
     bounds,
     sortType,
     researchMarkingList,
+    navigatePlace,
   };
 };

--- a/src/features/map/ui/mapMarkers.tsx
+++ b/src/features/map/ui/mapMarkers.tsx
@@ -21,20 +21,28 @@ export const PinMarker = () => {
   const { bounds, navigatePlace } = useResearchMarkingList();
 
   const { data: markerList } = useGetBoundaryMarkerList({
-    southWestLat: bounds?.southWest.lat,
-    southWestLng: bounds?.southWest.lng,
-    northEastLat: bounds?.northEast.lat,
-    northEastLng: bounds?.northEast.lng,
+    southWestLat: bounds?.southWestLat,
+    southWestLng: bounds?.southWestLng,
+    northEastLat: bounds?.northEastLat,
+    northEastLng: bounds?.northEastLng,
   });
 
-  return markerList?.map(({ markingId, lat, lng, previewImage }, idx) => (
+  return markerList?.map(({ markingId, lat, lng, previewImage }) => (
     <Pin
       key={markingId}
       position={{ lat, lng }}
       imageUrl={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
-      alt={`${markingId}의 ${idx}번째 이미지`}
+      alt={`${markingId}의 이미지`}
       onClick={() => {
-        navigatePlace({ lat, lng });
+        // todo 클러스터링 데이터에 있는 bounds로 인수 전달
+        navigatePlace({
+          bounds: {
+            southWestLat: lat - 0.00001,
+            southWestLng: lng - 0.00001,
+            northEastLat: lat + 0.00001,
+            northEastLng: lng + 0.00001,
+          },
+        });
       }}
     />
   ));

--- a/src/features/map/ui/mapMarkers.tsx
+++ b/src/features/map/ui/mapMarkers.tsx
@@ -20,12 +20,7 @@ export const UserMarker = () => {
 export const PinMarker = () => {
   const { bounds, navigatePlace } = useResearchMarkingList();
 
-  const { data: markerList } = useGetBoundaryMarkerList({
-    southWestLat: bounds?.southWestLat,
-    southWestLng: bounds?.southWestLng,
-    northEastLat: bounds?.northEastLat,
-    northEastLng: bounds?.northEastLng,
-  });
+  const { data: markerList } = useGetBoundaryMarkerList(bounds);
 
   return markerList?.map(({ markingId, lat, lng, previewImage }) => (
     <Pin

--- a/src/features/map/ui/mapMarkers.tsx
+++ b/src/features/map/ui/mapMarkers.tsx
@@ -2,9 +2,6 @@ import { User, MultiplePin, Cluster, Pin } from "@/entities/map/ui";
 import { useGetBoundaryMarkerList } from "@/entities/marking/api";
 import { API_BASE_URL } from "@/shared/constants";
 import { useResearchMarkingList } from "../hooks";
-// import { useGetMarkingList } from "@/entities/marking/api";
-// import { API_BASE_URL } from "@/shared/constants";
-// import { useResearchMarkingList } from "../hooks";
 import { useMapStore } from "../store";
 
 /*---------- default mode 일 때에만 사용되는 마커입니다. ---------- */
@@ -21,7 +18,7 @@ export const UserMarker = () => {
 };
 
 export const PinMarker = () => {
-  const { bounds } = useResearchMarkingList();
+  const { bounds, navigatePlace } = useResearchMarkingList();
 
   const { data: markerList } = useGetBoundaryMarkerList({
     southWestLat: bounds?.southWest.lat,
@@ -39,6 +36,9 @@ export const PinMarker = () => {
       }}
       imageUrl={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
       alt={`${markingId}의 ${idx}번째 이미지`}
+      onClick={() => {
+        navigatePlace({ lat, lng });
+      }}
     />
   ));
 };

--- a/src/features/map/ui/mapMarkers.tsx
+++ b/src/features/map/ui/mapMarkers.tsx
@@ -30,10 +30,7 @@ export const PinMarker = () => {
   return markerList?.map(({ markingId, lat, lng, previewImage }, idx) => (
     <Pin
       key={markingId}
-      position={{
-        lat: lat,
-        lng: lng,
-      }}
+      position={{ lat, lng }}
       imageUrl={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
       alt={`${markingId}의 ${idx}번째 이미지`}
       onClick={() => {

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
-import { mapViewModeMap, sortTypeMap } from "@/features/map/constants";
+import { RangeFilterMap, sortTypeMap } from "@/features/map/constants";
 import {
   useCurrentLocation,
   useResearchMarkingList,
@@ -113,7 +113,7 @@ export const SortTypeFilter = ({
   );
 };
 
-type MapViewMode = keyof typeof mapViewModeMap;
+type RangeFilter = keyof typeof RangeFilterMap;
 
 /**
  * 마킹 노출 범위 필터
@@ -131,11 +131,11 @@ type MapViewMode = keyof typeof mapViewModeMap;
  * @param options: "ALL_VIEW", "CURRENT_LOCATION", "MAP_LOCATION"로 구성된 배열
  * @param defaultOptionIdx: 기본 옵션 인덱스 (기본값: 0)
  */
-export const MapViewModeFilter = ({
+export const RangeFilter = ({
   options,
   defaultOptionIdx = 0,
 }: {
-  options: MapViewMode[];
+  options: RangeFilter[];
   defaultOptionIdx?: number;
 }) => {
   const setIsCenteredOnMyLocation = useMapStore(
@@ -146,14 +146,14 @@ export const MapViewModeFilter = ({
 
   const map = useMap();
 
-  const [selectedOption, setSelectedOption] = useState<MapViewMode>(
+  const [selectedOption, setSelectedOption] = useState<RangeFilter>(
     options[defaultOptionIdx],
   );
 
-  const handleSelect = (mapViewMode: MapViewMode) => {
-    setSelectedOption(mapViewMode);
+  const handleSelect = (rangeFilter: RangeFilter) => {
+    setSelectedOption(rangeFilter);
 
-    if (mapViewMode === "CURRENT_LOCATION") {
+    if (rangeFilter === "CURRENT_LOCATION") {
       setCurrentLocation({
         onSuccess: ({ coords: { latitude, longitude } }) => {
           map.setCenter({
@@ -172,7 +172,7 @@ export const MapViewModeFilter = ({
       return;
     }
 
-    if (mapViewMode === "MAP_LOCATION") {
+    if (rangeFilter === "MAP_LOCATION") {
       researchMarkingList();
       return;
     }
@@ -194,7 +194,7 @@ export const MapViewModeFilter = ({
             onClick={() => handleSelect(defaultOption)}
             isSelected={selectedOption === defaultOption}
           >
-            {mapViewModeMap[defaultOption]}
+            {RangeFilterMap[defaultOption]}
           </Select.Option>
 
           {nonDefaultOptions.map((option) => {
@@ -205,7 +205,7 @@ export const MapViewModeFilter = ({
                 onClick={() => handleSelect(option)}
                 isSelected={selectedOption === option}
               >
-                {mapViewModeMap[option]}
+                {RangeFilterMap[option]}
               </Select.Option>
             );
           })}
@@ -216,7 +216,7 @@ export const MapViewModeFilter = ({
 
   return (
     <MarkingFilterButton onClick={handleOpen}>
-      {mapViewModeMap[selectedOption]}
+      {RangeFilterMap[selectedOption]}
     </MarkingFilterButton>
   );
 };

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -62,10 +62,20 @@ export const SortTypeFilter = ({
   options: SortType[];
   defaultOptionIdx?: number;
 }) => {
-  const { sortType: selectedSortType, researchMarkingList } =
-    useResearchMarkingList();
+  const {
+    sortType: selectedSortType,
+    researchMarkingList,
+    navigatePlace,
+  } = useResearchMarkingList();
 
   const handleSelect = (sortType: SortType) => {
+    const path = window.location.pathname;
+
+    if (path === "/map/place") {
+      navigatePlace({ sortType });
+      return;
+    }
+
     researchMarkingList({
       sortType,
     });

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -100,7 +100,9 @@ export const colors = {
 
 export const ROUTER_PATH = {
   MAIN: "/",
+
   MAP: `/map`,
+  PLACE: "/map/place",
 
   PROFILE: `/:nickname`,
   FOLLOWINGS: `followings`,

--- a/src/widgets/map/constants/index.ts
+++ b/src/widgets/map/constants/index.ts
@@ -37,7 +37,7 @@ export const mapOptions = {
   /**
    * TODO 상의 후 픽스하기
    */
-  maxZoom: 18, // 최대 줌 레벨
+  maxZoom: 19, // 최대 줌 레벨
   minZoom: 10, // 최소 줌 레벨
   // TODO 상의 후 픽스하기
 

--- a/src/widgets/map/ui/index.ts
+++ b/src/widgets/map/ui/index.ts
@@ -5,3 +5,4 @@ export * from "./mapMarkerWidget";
 export * from "./mapInitializer";
 export * from "./mapBottomSheet";
 export * from "./localMarkingList";
+export * from "./placeMarkingList";

--- a/src/widgets/map/ui/index.ts
+++ b/src/widgets/map/ui/index.ts
@@ -4,3 +4,4 @@ export * from "./mapControlWidget";
 export * from "./mapMarkerWidget";
 export * from "./mapInitializer";
 export * from "./mapBottomSheet";
+export * from "./localMarkingList";

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -7,7 +7,7 @@ import { MyLocationIcon } from "@/shared/ui/icon";
 import { MarkingList } from "./markingList";
 
 export const LocalMarkingList = () => {
-  const { bounds, sortType } = useResearchMarkingList();
+  const { bounds, sortType, navigatePlace } = useResearchMarkingList();
   const {
     data: markingList,
     fetchNextPage,
@@ -43,8 +43,15 @@ export const LocalMarkingList = () => {
         </div>
       </div>
       <MarkingList display="grid">
-        {markingList?.map(({ markingId, previewImage }) => (
-          <button key={markingId} type="button" className="aspect-square">
+        {markingList?.map(({ markingId, previewImage, lat, lng }) => (
+          <button
+            key={markingId}
+            type="button"
+            className="aspect-square"
+            onClick={() => {
+              navigatePlace({ lat, lng });
+            }}
+          >
             <img
               className="w-full h-full object-cover"
               src={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -1,0 +1,58 @@
+import { useResearchMarkingList } from "@/features/map/hooks";
+import { MapViewModeFilter, SortTypeFilter } from "@/features/marking/ui";
+import { useGetMarkingList } from "@/entities/marking/api";
+import { API_BASE_URL } from "@/shared/constants";
+import { useInfiniteScroll } from "@/shared/lib";
+import { MyLocationIcon } from "@/shared/ui/icon";
+import { MarkingList } from "./markingList";
+
+export const LocalMarkingList = () => {
+  const { bounds, sortType } = useResearchMarkingList();
+  const {
+    data: markingList,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useGetMarkingList({
+    southWestLat: bounds?.southWest.lat,
+    southWestLng: bounds?.southWest.lng,
+    northEastLat: bounds?.northEast.lat,
+    northEastLng: bounds?.northEast.lng,
+    sortType,
+  });
+
+  const [setNode] = useInfiniteScroll(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  });
+
+  return (
+    <>
+      {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
+      <h1 className="title-1 text-grey-900 py-4">동네 마킹</h1>
+      <div className="flex justify-between items-center mb-4">
+        <div className="flex gap-1 text-tangerine-500 items-center">
+          <MyLocationIcon width={20} height={20} />
+          <span className="body-2 text-grey-500">영등포 1동 주변</span>
+        </div>
+
+        <div className="flex">
+          <MapViewModeFilter options={["CURRENT_LOCATION", "MAP_LOCATION"]} />
+          <SortTypeFilter options={["POPULARITY", "RECENT", "DISTANCE"]} />
+        </div>
+      </div>
+      <MarkingList display="grid">
+        {markingList?.map(({ markingId, previewImage }) => (
+          <button key={markingId} type="button" className="aspect-square">
+            <img
+              className="w-full h-full object-cover"
+              src={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
+            />
+          </button>
+        ))}
+      </MarkingList>
+      <div className="h-[.125rem]" ref={setNode} />
+    </>
+  );
+};

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -28,7 +28,7 @@ export const LocalMarkingList = () => {
   });
 
   return (
-    <>
+    <div className="px-4">
       {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
       <h1 className="title-1 text-grey-900 py-4">동네 마킹</h1>
       <div className="flex justify-between items-center mb-4">
@@ -60,6 +60,6 @@ export const LocalMarkingList = () => {
         ))}
       </MarkingList>
       <div className="h-[.125rem]" ref={setNode} />
-    </>
+    </div>
   );
 };

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -1,5 +1,5 @@
 import { useResearchMarkingList } from "@/features/map/hooks";
-import { MapViewModeFilter, SortTypeFilter } from "@/features/marking/ui";
+import { RangeFilter, SortTypeFilter } from "@/features/marking/ui";
 import { useGetMarkingList } from "@/entities/marking/api";
 import { API_BASE_URL } from "@/shared/constants";
 import { useInfiniteScroll } from "@/shared/lib";
@@ -38,7 +38,7 @@ export const LocalMarkingList = () => {
         </div>
 
         <div className="flex">
-          <MapViewModeFilter options={["CURRENT_LOCATION", "MAP_LOCATION"]} />
+          <RangeFilter options={["CURRENT_LOCATION", "MAP_LOCATION"]} />
           <SortTypeFilter options={["POPULARITY", "RECENT", "DISTANCE"]} />
         </div>
       </div>

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -14,10 +14,10 @@ export const LocalMarkingList = () => {
     hasNextPage,
     isFetchingNextPage,
   } = useGetMarkingList({
-    southWestLat: bounds?.southWest.lat,
-    southWestLng: bounds?.southWest.lng,
-    northEastLat: bounds?.northEast.lat,
-    northEastLng: bounds?.northEast.lng,
+    southWestLat: bounds?.southWestLat,
+    southWestLng: bounds?.southWestLng,
+    northEastLat: bounds?.northEastLat,
+    northEastLng: bounds?.northEastLng,
     sortType,
   });
 
@@ -49,7 +49,15 @@ export const LocalMarkingList = () => {
             type="button"
             className="aspect-square"
             onClick={() => {
-              navigatePlace({ lat, lng });
+              // todo 클러스터링 데이터에 있는 bounds로 인수 전달
+              navigatePlace({
+                bounds: {
+                  southWestLat: lat - 0.00001,
+                  southWestLng: lng - 0.00001,
+                  northEastLat: lat + 0.00001,
+                  northEastLng: lng + 0.00001,
+                },
+              });
             }}
           >
             <img

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -14,10 +14,7 @@ export const LocalMarkingList = () => {
     hasNextPage,
     isFetchingNextPage,
   } = useGetMarkingList({
-    southWestLat: bounds?.southWestLat,
-    southWestLng: bounds?.southWestLng,
-    northEastLat: bounds?.northEastLat,
-    northEastLng: bounds?.northEastLng,
+    ...bounds,
     sortType,
   });
 

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -53,7 +53,6 @@ export const MapBottomSheet = () => {
         >
           <Sheet.Scroller
             draggableAt="both"
-            className="px-4"
             style={{
               height: "calc(100% - 5rem)",
             }}

--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -1,18 +1,9 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Sheet, SheetRef } from "react-modal-sheet";
-import { useLocation } from "react-router-dom";
-import { useResearchMarkingList } from "@/features/map/hooks";
+import { Outlet } from "react-router-dom";
 import { useMapStore } from "@/features/map/store";
-import { MapViewModeFilter, SortTypeFilter } from "@/features/marking/ui";
-import { useGetMarkingList } from "@/entities/marking/api";
-import { API_BASE_URL } from "@/shared/constants";
-import { useInfiniteScroll } from "@/shared/lib";
-import { MyLocationIcon } from "@/shared/ui/icon";
-import { MarkingList } from "./markingList";
 
 export const MapBottomSheet = () => {
-  const location = useLocation();
-
   const sheetRef = useRef<SheetRef>();
 
   const snapPoints = [-50, 0.5, 116];
@@ -21,32 +12,21 @@ export const MapBottomSheet = () => {
   const snapPointRef = useRef(initialSnap);
   const snapTo = (i: number) => sheetRef.current?.snapTo(i);
 
-  const { bounds, sortType } = useResearchMarkingList();
-  const {
-    data: markingList,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useGetMarkingList({
-    southWestLat: bounds?.southWest.lat,
-    southWestLng: bounds?.southWest.lng,
-    northEastLat: bounds?.northEast.lat,
-    northEastLng: bounds?.northEast.lng,
-    sortType,
-  });
-
-  const [setNode] = useInfiniteScroll(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  });
-
   const mapMode = useMapStore((state) => state.mode);
+
+  const [contentPaddingBottom, setContentPaddingBottom] =
+    useState<SheetRef["y"]>();
+
+  useEffect(() => {
+    if (sheetRef.current) {
+      setContentPaddingBottom(sheetRef.current.y);
+    }
+  }, []);
 
   return (
     <Sheet
       ref={sheetRef}
-      isOpen={location.pathname === "/map" && mapMode === "view"}
+      isOpen={mapMode === "view"}
       onClose={() => {
         const isSheetTop = snapPointRef.current === 0;
 
@@ -68,52 +48,17 @@ export const MapBottomSheet = () => {
         <Sheet.Content
           style={{
             padding: 0,
-            paddingBottom: sheetRef.current?.y,
+            paddingBottom: contentPaddingBottom,
           }}
         >
           <Sheet.Scroller
             draggableAt="both"
+            className="px-4"
             style={{
               height: "calc(100% - 5rem)",
             }}
           >
-            {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
-            <h1 className="title-1 text-grey-900 p-4">동네 마킹</h1>
-
-            <div className="flex justify-between px-4 items-center mb-4">
-              <div className="flex gap-1 text-tangerine-500 items-center">
-                <MyLocationIcon width={20} height={20} />
-                <span className="body-2 text-grey-500">영등포 1동 주변</span>
-              </div>
-
-              <div className="flex">
-                <MapViewModeFilter
-                  options={["CURRENT_LOCATION", "MAP_LOCATION"]}
-                />
-                <SortTypeFilter
-                  options={["POPULARITY", "RECENT", "DISTANCE"]}
-                />
-              </div>
-            </div>
-
-            <div className="px-4">
-              <MarkingList display="grid">
-                {markingList?.map(({ markingId, previewImage }) => (
-                  <button
-                    key={markingId}
-                    type="button"
-                    className="aspect-square"
-                  >
-                    <img
-                      className="w-full h-full object-cover"
-                      src={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
-                    />
-                  </button>
-                ))}
-              </MarkingList>
-            </div>
-
-            <div className="h-[.125rem]" ref={setNode} />
+            <Outlet />
           </Sheet.Scroller>
         </Sheet.Content>
       </Sheet.Container>

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -58,13 +58,14 @@ export const MapInitializer = () => {
 
     if (!boundsParams) return;
 
-    const { southWest, northEast } = boundsParams;
+    const { northEastLat, northEastLng, southWestLat, southWestLng } =
+      boundsParams;
 
     map.fitBounds({
-      south: southWest.lat,
-      west: southWest.lng,
-      north: northEast.lat,
-      east: northEast.lng,
+      south: southWestLat,
+      west: southWestLng,
+      north: northEastLat,
+      east: northEastLng,
     });
 
     researchMarkingList(filterOptions);

--- a/src/widgets/map/ui/markingList.tsx
+++ b/src/widgets/map/ui/markingList.tsx
@@ -2,17 +2,19 @@ import { ReactNode } from "react";
 
 interface ContentListProps {
   display?: "grid" | "list";
+  className?: string;
   children: ReactNode;
 }
 
 export const MarkingList = ({
   children,
+  className = "",
   display = "list",
 }: ContentListProps) => {
-  const className =
+  const markingListStyles =
     display === "grid"
       ? "grid grid-cols-3 rounded-lg overflow-hidden"
       : "flex flex-col gap-8";
 
-  return <ul className={className}>{children}</ul>;
+  return <ul className={`${markingListStyles} ${className}`}>{children}</ul>;
 };

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -43,11 +43,11 @@ export const PlaceMarkingList = () => {
         label={<h1 className="text-grey-900 title-1">이 장소 관련 마킹</h1>}
       />
 
-      <div className="flex justify-end w-full mb-4">
+      <div className="flex justify-end w-full mb-4 px-4">
         <SortTypeFilter options={["POPULARITY", "RECENT"]} />
       </div>
 
-      <MarkingList display="list">
+      <MarkingList display="list" className="px-4">
         {markingList?.map((marking) => (
           <MarkingItem
             key={marking.markingId}

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from "react-router-dom";
+import { useMap } from "@vis.gl/react-google-maps";
+import { useResearchMarkingList } from "@/features/map/hooks";
+import { MarkingItem, SortTypeFilter } from "@/features/marking/ui";
+import { useGetMarkingList } from "@/entities/marking/api";
+import { ROUTER_PATH } from "@/shared/constants";
+import { useInfiniteScroll } from "@/shared/lib";
+import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { MarkingList } from "./markingList";
+
+export const PlaceMarkingList = () => {
+  const { bounds, sortType, researchMarkingList } = useResearchMarkingList();
+  const {
+    data: markingList,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useGetMarkingList({
+    southWestLat: bounds?.southWest.lat,
+    southWestLng: bounds?.southWest.lng,
+    northEastLat: bounds?.northEast.lat,
+    northEastLng: bounds?.northEast.lng,
+    sortType,
+  });
+
+  const [setNode] = useInfiniteScroll(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  });
+
+  const map = useMap();
+
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <BackwardNavigationBar
+        onClick={() => {
+          navigate(ROUTER_PATH.MAP);
+          researchMarkingList();
+        }}
+        label={<h1 className="text-grey-900 title-1">이 장소 관련 마킹</h1>}
+      />
+
+      <div className="flex justify-end w-full mb-4">
+        <SortTypeFilter options={["POPULARITY", "RECENT"]} />
+      </div>
+
+      <MarkingList display="list">
+        {markingList?.map((marking) => (
+          <MarkingItem
+            key={marking.markingId}
+            onRegionClick={() => {
+              map.setCenter({
+                lat: marking.lat,
+                lng: marking.lng,
+              });
+              map.setZoom(19);
+            }}
+            {...marking}
+          />
+        ))}
+      </MarkingList>
+      <div className="h-[.125rem]" ref={setNode} />
+    </>
+  );
+};

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -16,10 +16,10 @@ export const PlaceMarkingList = () => {
     hasNextPage,
     isFetchingNextPage,
   } = useGetMarkingList({
-    southWestLat: bounds?.southWest.lat,
-    southWestLng: bounds?.southWest.lng,
-    northEastLat: bounds?.northEast.lat,
-    northEastLng: bounds?.northEast.lng,
+    southWestLat: bounds?.southWestLat,
+    southWestLng: bounds?.southWestLng,
+    northEastLat: bounds?.northEastLat,
+    northEastLng: bounds?.northEastLng,
     sortType,
   });
 

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -16,10 +16,7 @@ export const PlaceMarkingList = () => {
     hasNextPage,
     isFetchingNextPage,
   } = useGetMarkingList({
-    southWestLat: bounds?.southWestLat,
-    southWestLng: bounds?.southWestLng,
-    northEastLat: bounds?.northEastLat,
-    northEastLng: bounds?.northEastLng,
+    ...bounds,
     sortType,
   });
 


### PR DESCRIPTION
# 관련 이슈 번호

#407 

# 설명

## 리팩토링

### useResearchMarkingList가 반환하는 bounds 변경

```typescript
// before
{
        northEast: { lat: northEastLat, lng: northEastLng },
        southWest: { lat: southWestLat, lng: southWestLng },
}
// after
{
        northEastLat,
        northEastLng,
        southWestLat,
        southWestLng,
}
```

### [FooterNavigationBar](https://github.com/dogandme/frontend/pull/423/files#diff-4ac6c6d586f4919b4b31a80932220766d7a0833dc2469a05735ae6c66878519c)에 있는 맵 nav link 컴포넌트 생성

맵 페이지에 있는 상태에서 지도 `NavLink`를 클릭하면, 파라미터가 없어지고 경로가 `/map`으로 되는 문제가 있었습니다.
그래서 맵 페이지에 있는 상태에서 지도 탭을 눌러도 url이 유지되도록 하였습니다.

```typescript
const MapPageNavLink = () => {
  const { active, inactive, base } = footerNavigationBarStyles;

  const getMapPagePath = () => {
    const { pathname } = window.location;

    const mapPagePaths: string[] = [ROUTER_PATH.MAP, ROUTER_PATH.PLACE];

    if (mapPagePaths.includes(pathname)) {
      return window.location;
    }

    return ROUTER_PATH.MAP;
  };

  return (
    <NavLink
      to={getMapPagePath()}
      className={({ isActive }) => `${isActive ? active : inactive} ${base}`}
    >
      <MapIcon />
      지도
    </NavLink>
  );
};
```

### 맵과 관련된 라우터 처리

children의 element는 **바텀 시트에 들어갈 컨텐츠**입니다.

경로가 `/map`으로 시작하면 동네 마킹 바텀시트이고,
`/map/place`로 시작하면 이 장소 마킹 바텀 시트입니다.

```
      {
        path: ROUTER_PATH.MAP,
        element: <MapPage />,
        children: [
          {
            index: true,
            element: <LocalMarkingList />, // 동네 마킹
          },
          {
            path: ROUTER_PATH.PLACE,
            element: <PlaceMarkingList />, // 이 장소 마킹
          },
        ],
      },
```
### MapBottomSheet에 있었던 동네 마킹 컴포넌트 생성

기존의 MapBottomSheet의 Sheet.Scroller 하위에 있던 동네 마킹 리스트들을 컴포넌트(`LocalMarkingList`)로 만들었습니다.

## 기능

### 마커 또는 동네 마킹의 썸네일을 클릭했을 경우

마커 또는 동네 마킹의 썸네일을 클릭했을 경우, 아래 과정처럼 작동됩니다.

1. 이 동네 마킹 바텀시트로 이동
2. 클릭한 마커(또는 썸네일)의 바운더리 정보 가지고 (현재 바운더리는 임의로 지정해뒀습니다.)
  a. 맵에 클릭한 마커만 표시
  b. url 변경되어 마킹과 마커 리스트 다시 get 요청

### [인기순], [최신순] 필터

필터가 바뀔 때 url의 파라미터인 sortType 변경되면서, 마킹 리스트를 업데이트합니다.
단 마커 리스트는 필터와 상관없이 동일한 데이터이므로 다시 요청하지 않습니다.

## 고민

방금 클릭한 마커가 바텀 시트 뒤에 가려지는 경우가 있더라구요. 
용현님 말씀처럼 마커나 썸네일을 클릭했을 때, 맵의 중심을 옮겨야 할 것 같습니다.

https://github.com/user-attachments/assets/21f638e7-509d-4352-a613-be259b814b63

