### PR TITLE
 [Refactor] 마킹 모달 공개 범위 기본값 설정 

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,15 +23,6 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
-      "no-unused-vars": [
-        "error",
-        {
-          vars: "all",
-          args: "after-used",
-          ignoreRestSiblings: true,
-          argsIgnorePattern: "^_", // 언더스코어로 시작하는 매개변수는 무시
-        },
-      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/src/app/MainLayout.tsx
+++ b/src/app/MainLayout.tsx
@@ -9,6 +9,15 @@ export const MainLayout = ({ children }: { children: React.ReactNode }) => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (
+      (
+        window as Window &
+          typeof globalThis & { __STORYBOOK_ADDONS_CHANNEL__?: unknown }
+      ).__STORYBOOK_ADDONS_CHANNEL__
+    ) {
+      return;
+    }
+
     getAccessTokenByRefreshToken().then(({ authorization, role, nickname }) => {
       useAuthStore.setState({ token: authorization, role, nickname });
       if (authorization === "ROLE_NONE") {

--- a/src/entities/follow/api/getFollowerList.ts
+++ b/src/entities/follow/api/getFollowerList.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import type { Nickname, PetInfo, UserId } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { FOLLOW_ENDPOINT } from "../constants";
+import { FOLLOW_END_POINT } from "../constants";
 
 // TODO 리팩토링 시 해당 타입 정의 위치 의논
 interface PageAbleInformation {
@@ -39,7 +39,7 @@ const getFollowerList = ({
   nickname,
 }: GetFollowerListRequest & { pageParam: number }) => {
   return apiClient.get<GetFollowerListResponse>(
-    FOLLOW_ENDPOINT.FOLLOWER_LIST(nickname, pageParam),
+    FOLLOW_END_POINT.FOLLOWER_LIST(nickname, pageParam),
     {
       withToken: true,
     },

--- a/src/entities/follow/api/getFollowingList.ts
+++ b/src/entities/follow/api/getFollowingList.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import type { Nickname, PetInfo, UserId } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { FOLLOW_ENDPOINT } from "../constants";
+import { FOLLOW_END_POINT } from "../constants";
 
 // TODO 리팩토링 시 해당 타입 정의 위치 의논
 interface PageAbleInformation {
@@ -39,7 +39,7 @@ const getFollowingList = ({
   nickname,
 }: GetFollowingListRequest & { pageParam: number }) => {
   return apiClient.get<GetFollowingListResponse>(
-    FOLLOW_ENDPOINT.FOLLOWING_LIST(nickname, pageParam),
+    FOLLOW_END_POINT.FOLLOWING_LIST(nickname, pageParam),
     {
       withToken: true,
     },

--- a/src/entities/follow/constants/endpoint.ts
+++ b/src/entities/follow/constants/endpoint.ts
@@ -1,6 +1,6 @@
 import { API_BASE_URL } from "@/shared/constants";
 
-export const FOLLOW_ENDPOINT = {
+export const FOLLOW_END_POINT = {
   FOLLOWER_LIST: (nickname: string, offset: number) =>
     `${API_BASE_URL}/users/follows/followers/${nickname}?offset=${offset}`,
   FOLLOWING_LIST: (nickname: string, offset: number) =>

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -5,7 +5,7 @@ import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import {
   SEARCH_MARKING_END_POINT,
-  type PostVisibilityValue,
+  type MarkingVisibilityKey,
 } from "../constants";
 
 interface Address {
@@ -47,7 +47,7 @@ export interface Marking {
   markingId: number;
   region: string;
   content: string;
-  isVisible: PostVisibilityValue;
+  isVisible: MarkingVisibilityKey;
   regDt: string;
   previewImage: string;
   userId: number;

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -3,7 +3,10 @@ import { useMap } from "@vis.gl/react-google-maps";
 import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { SEARCH_MARKING_END_POINT } from "../constants";
+import {
+  SEARCH_MARKING_END_POINT,
+  type PostVisibilityValue,
+} from "../constants";
 
 interface Address {
   id: number;
@@ -44,7 +47,7 @@ export interface Marking {
   markingId: number;
   region: string;
   content: string;
-  isVisible: "PUBLIC" | "FOLLOWERS_ONLY" | "PRIVATE";
+  isVisible: PostVisibilityValue;
   regDt: string;
   previewImage: string;
   userId: number;

--- a/src/entities/marking/api/getTemporaryMarkingList.ts
+++ b/src/entities/marking/api/getTemporaryMarkingList.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { Nickname, UserId } from "@/entities/profile/api";
 import { apiClient, formatDateToYearMonthDay } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MY_MARKING_END_POINT, type PostVisibilityValue } from "../constants";
+import { MY_MARKING_END_POINT, type MarkingVisibilityKey } from "../constants";
 
 export interface TempMarkingFileInfo {
   id: number;
@@ -15,7 +15,7 @@ export interface TempMarkingInfo {
   markingId: number;
   region: string;
   content: string | null;
-  isVisible: PostVisibilityValue;
+  isVisible: MarkingVisibilityKey;
   regDt: string;
   previewImage: string | null;
   userId: UserId;

--- a/src/entities/marking/api/getTemporaryMarkingList.ts
+++ b/src/entities/marking/api/getTemporaryMarkingList.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { Nickname, UserId } from "@/entities/profile/api";
 import { apiClient, formatDateToYearMonthDay } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MY_MARKING_END_POINT } from "../constants";
+import { MY_MARKING_END_POINT, type PostVisibilityValue } from "../constants";
 
 export interface TempMarkingFileInfo {
   id: number;
@@ -15,7 +15,7 @@ export interface TempMarkingInfo {
   markingId: number;
   region: string;
   content: string | null;
-  isVisible: "PUBLIC" | "FOLLOWERS_ONLY" | "PRIVATE";
+  isVisible: PostVisibilityValue;
   regDt: string;
   previewImage: string | null;
   userId: UserId;

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -37,21 +37,12 @@ export const MY_MARKING_END_POINT = {
     `${API_BASE_URL}/markings/temps?offset=${offset}`,
 };
 
-export const POST_VISIBILITY_MAP = {
-  "전체 공개": "PUBLIC",
-  "팔로우 공개": "FOLLOWERS_ONLY",
-  "나만 보기": "PRIVATE",
+export const MARKING_VISIBILITY_MAP = {
+  PUBLIC: "전체 공개",
+  PRIVATE: "나만 보기",
+  FOLLOW_ONLY: "팔로우 공개",
 } as const;
 
-export type PostVisibilityName = keyof typeof POST_VISIBILITY_MAP;
-export type PostVisibilityValue =
-  (typeof POST_VISIBILITY_MAP)[PostVisibilityName];
-
-export const REVERSE_POST_VISIBILITY_MAP: Record<
-  PostVisibilityValue,
-  PostVisibilityName
-> = {
-  PUBLIC: "전체 공개",
-  FOLLOWERS_ONLY: "팔로우 공개",
-  PRIVATE: "나만 보기",
-};
+export type MarkingVisibilityKey = keyof typeof MARKING_VISIBILITY_MAP;
+export type MarkingVisibilityValue =
+  (typeof MARKING_VISIBILITY_MAP)[MarkingVisibilityKey];

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -36,3 +36,22 @@ export const MY_MARKING_END_POINT = {
   TEMPORARY: (offset: number) =>
     `${API_BASE_URL}/markings/temps?offset=${offset}`,
 };
+
+export const POST_VISIBILITY_MAP = {
+  "전체 공개": "PUBLIC",
+  "팔로우 공개": "FOLLOWERS_ONLY",
+  "나만 보기": "PRIVATE",
+} as const;
+
+export type PostVisibilityName = keyof typeof POST_VISIBILITY_MAP;
+export type PostVisibilityValue =
+  (typeof POST_VISIBILITY_MAP)[PostVisibilityName];
+
+export const REVERSE_POST_VISIBILITY_MAP: Record<
+  PostVisibilityValue,
+  PostVisibilityName
+> = {
+  PUBLIC: "전체 공개",
+  FOLLOWERS_ONLY: "팔로우 공개",
+  PRIVATE: "나만 보기",
+};

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -46,3 +46,7 @@ export const MARKING_VISIBILITY_MAP = {
 export type MarkingVisibilityKey = keyof typeof MARKING_VISIBILITY_MAP;
 export type MarkingVisibilityValue =
   (typeof MARKING_VISIBILITY_MAP)[MarkingVisibilityKey];
+
+export const MARKING_VISIBILITY_ENTRIES = Object.entries(
+  MARKING_VISIBILITY_MAP,
+) as [MarkingVisibilityKey, MarkingVisibilityValue][];

--- a/src/features/marking/api/postAddMarking.tsx
+++ b/src/features/marking/api/postAddMarking.tsx
@@ -1,10 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
 import type { LatLng } from "@/entities/auth/api";
-import {
-  MARKING_VISIBILITY_MAP,
-  type MarkingVisibilityKey,
-} from "@/entities/marking/constants";
+import type { MarkingVisibilityKey } from "@/entities/marking/constants";
 import { apiClient, useSnackBar } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 import { useMarkingFormStore } from "../store";
@@ -17,21 +14,13 @@ export interface PostAddMarkingRequest extends LatLng {
   images: File[];
 }
 const postAddMarking = async (formObj: PostAddMarkingRequest) => {
-  const { isVisible, images, ...rest } = formObj;
+  const { images, ...rest } = formObj;
 
   const formData = new FormData();
 
   formData.append(
     "markingAddDto",
-    new Blob(
-      [
-        JSON.stringify({
-          isVisible: MARKING_VISIBILITY_MAP[isVisible],
-          ...rest,
-        }),
-      ],
-      { type: "application/json" },
-    ),
+    new Blob([JSON.stringify(rest)], { type: "application/json" }),
   );
 
   images.forEach((image) => {

--- a/src/features/marking/api/postAddMarking.tsx
+++ b/src/features/marking/api/postAddMarking.tsx
@@ -1,18 +1,21 @@
 import { useMutation } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
 import type { LatLng } from "@/entities/auth/api";
+import {
+  POST_VISIBILITY_MAP,
+  type PostVisibilityName,
+} from "@/entities/marking/constants";
 import { apiClient, useSnackBar } from "@/shared/lib";
-import { MARKING_END_POINT, POST_VISIBILITY_MAP } from "../constants";
+import { MARKING_END_POINT } from "../constants";
 import { useMarkingFormStore } from "../store";
 
 // Marking Form 저장 API
 export interface PostAddMarkingRequest extends LatLng {
   region: string;
-  isVisible: keyof typeof POST_VISIBILITY_MAP;
+  isVisible: PostVisibilityName;
   content: string;
   images: File[];
 }
-
 const postAddMarking = async (formObj: PostAddMarkingRequest) => {
   const { isVisible, images, ...rest } = formObj;
 

--- a/src/features/marking/api/postAddMarking.tsx
+++ b/src/features/marking/api/postAddMarking.tsx
@@ -2,8 +2,8 @@ import { useMutation } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
 import type { LatLng } from "@/entities/auth/api";
 import {
-  POST_VISIBILITY_MAP,
-  type PostVisibilityName,
+  MARKING_VISIBILITY_MAP,
+  type MarkingVisibilityKey,
 } from "@/entities/marking/constants";
 import { apiClient, useSnackBar } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
@@ -12,7 +12,7 @@ import { useMarkingFormStore } from "../store";
 // Marking Form 저장 API
 export interface PostAddMarkingRequest extends LatLng {
   region: string;
-  isVisible: PostVisibilityName;
+  isVisible: MarkingVisibilityKey;
   content: string;
   images: File[];
 }
@@ -26,7 +26,7 @@ const postAddMarking = async (formObj: PostAddMarkingRequest) => {
     new Blob(
       [
         JSON.stringify({
-          isVisible: POST_VISIBILITY_MAP[isVisible],
+          isVisible: MARKING_VISIBILITY_MAP[isVisible],
           ...rest,
         }),
       ],

--- a/src/features/marking/api/postAddTempMarking.tsx
+++ b/src/features/marking/api/postAddTempMarking.tsx
@@ -2,8 +2,8 @@
 import { useMutation } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
 import {
-  POST_VISIBILITY_MAP,
-  type PostVisibilityName,
+  MARKING_VISIBILITY_MAP,
+  MarkingVisibilityKey,
 } from "@/entities/marking/constants";
 import { apiClient, useSnackBar } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
@@ -12,7 +12,7 @@ import type { PostAddMarkingRequest } from "./postAddMarking";
 
 interface PostAddTempMarkingRequestData
   extends Omit<PostAddMarkingRequest, "isVisible"> {
-  isVisible: PostVisibilityName;
+  isVisible: MarkingVisibilityKey;
 }
 
 const postAddTempMarking = async (formObj: PostAddTempMarkingRequestData) => {
@@ -26,7 +26,7 @@ const postAddTempMarking = async (formObj: PostAddTempMarkingRequestData) => {
       [
         JSON.stringify({
           region,
-          isVisible: POST_VISIBILITY_MAP[isVisible],
+          isVisible: MARKING_VISIBILITY_MAP[isVisible],
           content,
           lat,
           lng,

--- a/src/features/marking/api/postAddTempMarking.tsx
+++ b/src/features/marking/api/postAddTempMarking.tsx
@@ -1,10 +1,7 @@
 // Marking Form 임시 저장 API
 import { useMutation } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
-import {
-  MARKING_VISIBILITY_MAP,
-  MarkingVisibilityKey,
-} from "@/entities/marking/constants";
+import { MarkingVisibilityKey } from "@/entities/marking/constants";
 import { apiClient, useSnackBar } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 import { useMarkingFormStore } from "../store";
@@ -26,7 +23,7 @@ const postAddTempMarking = async (formObj: PostAddTempMarkingRequestData) => {
       [
         JSON.stringify({
           region,
-          isVisible: MARKING_VISIBILITY_MAP[isVisible],
+          isVisible,
           content,
           lat,
           lng,

--- a/src/features/marking/api/postAddTempMarking.tsx
+++ b/src/features/marking/api/postAddTempMarking.tsx
@@ -1,14 +1,18 @@
 // Marking Form 임시 저장 API
 import { useMutation } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
+import {
+  POST_VISIBILITY_MAP,
+  type PostVisibilityName,
+} from "@/entities/marking/constants";
 import { apiClient, useSnackBar } from "@/shared/lib";
-import { MARKING_END_POINT, POST_VISIBILITY_MAP } from "../constants";
+import { MARKING_END_POINT } from "../constants";
 import { useMarkingFormStore } from "../store";
 import type { PostAddMarkingRequest } from "./postAddMarking";
 
 interface PostAddTempMarkingRequestData
   extends Omit<PostAddMarkingRequest, "isVisible"> {
-  isVisible: keyof typeof POST_VISIBILITY_MAP | "";
+  isVisible: PostVisibilityName;
 }
 
 const postAddTempMarking = async (formObj: PostAddTempMarkingRequestData) => {
@@ -22,7 +26,7 @@ const postAddTempMarking = async (formObj: PostAddTempMarkingRequestData) => {
       [
         JSON.stringify({
           region,
-          isVisible: POST_VISIBILITY_MAP[isVisible || "전체 공개"],
+          isVisible: POST_VISIBILITY_MAP[isVisible],
           content,
           lat,
           lng,

--- a/src/features/marking/constants/index.ts
+++ b/src/features/marking/constants/index.ts
@@ -1,9 +1,3 @@
-export const POST_VISIBILITY_MAP = {
-  "전체 공개": "PUBLIC",
-  "팔로우 공개": "FOLLOWERS_ONLY",
-  "나만 보기": "PRIVATE",
-} as const;
-
 export * from "./endPoint";
 export * from "./message";
 

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type { FileInfo } from "@/features/auth/store";
+import type { PostVisibilityName } from "@/entities/marking/constants";
 import { compressFileImage } from "@/shared/lib";
-import { POST_VISIBILITY_MAP } from "../constants";
 
 export interface MarkingFileInfo extends FileInfo {
   file: NonNullable<FileInfo["file"]>;
@@ -9,7 +9,7 @@ export interface MarkingFileInfo extends FileInfo {
 
 interface MarkingFormState {
   region: string;
-  isVisible: keyof typeof POST_VISIBILITY_MAP;
+  isVisible: PostVisibilityName;
   content: string;
   images: MarkingFileInfo[];
   isCompressing: boolean;
@@ -18,7 +18,7 @@ interface MarkingFormState {
 
 interface MarkingFormActions {
   setRegion: (region: string) => void;
-  setVisibility: (isVisible: keyof typeof POST_VISIBILITY_MAP) => void;
+  setVisibility: (isVisible: PostVisibilityName) => void;
   setContent: (content: string) => void;
   setImages: (images: MarkingFileInfo[]) => void;
   resetMarkingFormStore: () => void;

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -9,7 +9,7 @@ export interface MarkingFileInfo extends FileInfo {
 
 interface MarkingFormState {
   region: string;
-  isVisible: keyof typeof POST_VISIBILITY_MAP | "";
+  isVisible: keyof typeof POST_VISIBILITY_MAP;
   content: string;
   images: MarkingFileInfo[];
   isCompressing: boolean;
@@ -26,7 +26,7 @@ interface MarkingFormActions {
 
 const MarkingFormInitialState: MarkingFormState = {
   region: "",
-  isVisible: "",
+  isVisible: "전체 공개",
   content: "",
   images: [],
   isCompressing: false,

--- a/src/features/marking/store/markingForm.ts
+++ b/src/features/marking/store/markingForm.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { FileInfo } from "@/features/auth/store";
-import type { PostVisibilityName } from "@/entities/marking/constants";
+import type { MarkingVisibilityKey } from "@/entities/marking/constants";
 import { compressFileImage } from "@/shared/lib";
 
 export interface MarkingFileInfo extends FileInfo {
@@ -9,7 +9,7 @@ export interface MarkingFileInfo extends FileInfo {
 
 interface MarkingFormState {
   region: string;
-  isVisible: PostVisibilityName;
+  isVisible: MarkingVisibilityKey;
   content: string;
   images: MarkingFileInfo[];
   isCompressing: boolean;
@@ -18,7 +18,7 @@ interface MarkingFormState {
 
 interface MarkingFormActions {
   setRegion: (region: string) => void;
-  setVisibility: (isVisible: PostVisibilityName) => void;
+  setVisibility: (isVisible: MarkingVisibilityKey) => void;
   setContent: (content: string) => void;
   setImages: (images: MarkingFileInfo[]) => void;
   resetMarkingFormStore: () => void;
@@ -26,7 +26,7 @@ interface MarkingFormActions {
 
 const MarkingFormInitialState: MarkingFormState = {
   region: "",
-  isVisible: "전체 공개",
+  isVisible: "PUBLIC",
   content: "",
   images: [],
   isCompressing: false,

--- a/src/features/marking/store/tempMarkingForm.tsx
+++ b/src/features/marking/store/tempMarkingForm.tsx
@@ -8,9 +8,8 @@ import { MarkingFileInfo } from "./markingForm";
 // TODO 타입 스크립트 리팩토링 시 변경 하기
 
 export interface TempMarkingFormExternalState
-  extends Pick<TempMarkingInfo, "region" | "content"> {
+  extends Pick<TempMarkingInfo, "region" | "isVisible" | "content"> {
   externalImages: TempMarkingFileInfo[];
-  isVisible: MarkingVisibilityKey;
 }
 
 interface TempMarkingFormInternalState {

--- a/src/features/marking/store/tempMarkingForm.tsx
+++ b/src/features/marking/store/tempMarkingForm.tsx
@@ -1,14 +1,16 @@
 import { createContext, useContext, useRef } from "react";
 import { create, useStore } from "zustand";
 import { TempMarkingFileInfo, TempMarkingInfo } from "@/entities/marking/api";
+import type { PostVisibilityName } from "@/entities/marking/constants";
 import { compressFileImage } from "@/shared/lib";
 import { MarkingFileInfo } from "./markingForm";
 
 // TODO 타입 스크립트 리팩토링 시 변경 하기
 
 export interface TempMarkingFormExternalState
-  extends Pick<TempMarkingInfo, "region" | "isVisible" | "content"> {
+  extends Pick<TempMarkingInfo, "region" | "content"> {
   externalImages: TempMarkingFileInfo[];
+  isVisible: PostVisibilityName;
 }
 
 interface TempMarkingFormInternalState {
@@ -22,7 +24,7 @@ type TempMarkingFormState = TempMarkingFormExternalState &
   TempMarkingFormInternalState;
 
 interface TempMarkingFormAction {
-  setIsVisible: (isVisible: TempMarkingInfo["isVisible"]) => void;
+  setIsVisible: (isVisible: PostVisibilityName) => void;
   setContent: (content: string | null) => void;
   setExternalImages: (images: TempMarkingFileInfo[]) => void;
   setRemovedIds: (removedIds: TempMarkingFileInfo["id"][]) => void;

--- a/src/features/marking/store/tempMarkingForm.tsx
+++ b/src/features/marking/store/tempMarkingForm.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useRef } from "react";
 import { create, useStore } from "zustand";
 import { TempMarkingFileInfo, TempMarkingInfo } from "@/entities/marking/api";
-import type { PostVisibilityName } from "@/entities/marking/constants";
+import type { MarkingVisibilityKey } from "@/entities/marking/constants";
 import { compressFileImage } from "@/shared/lib";
 import { MarkingFileInfo } from "./markingForm";
 
@@ -10,7 +10,7 @@ import { MarkingFileInfo } from "./markingForm";
 export interface TempMarkingFormExternalState
   extends Pick<TempMarkingInfo, "region" | "content"> {
   externalImages: TempMarkingFileInfo[];
-  isVisible: PostVisibilityName;
+  isVisible: MarkingVisibilityKey;
 }
 
 interface TempMarkingFormInternalState {
@@ -24,7 +24,7 @@ type TempMarkingFormState = TempMarkingFormExternalState &
   TempMarkingFormInternalState;
 
 interface TempMarkingFormAction {
-  setIsVisible: (isVisible: PostVisibilityName) => void;
+  setIsVisible: (isVisible: MarkingVisibilityKey) => void;
   setContent: (content: string | null) => void;
   setExternalImages: (images: TempMarkingFileInfo[]) => void;
   setRemovedIds: (removedIds: TempMarkingFileInfo["id"][]) => void;

--- a/src/features/marking/ui/markingFormModal.stories.tsx
+++ b/src/features/marking/ui/markingFormModal.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof MarkingFormModal>;
 export const Default: Story = {
   decorators: [
     (Story) => {
-      useAuthStore.setState({ token: "Bearer token" });
+      useAuthStore.setState({ token: "freshAccessToken" });
       useMapStore.setState({ mode: "view" });
 
       return (
@@ -136,9 +136,9 @@ export const Default: Story = {
       const $markingModalTriggerButton =
         await canvas.findByText("여기에 마킹하기");
       await userEvent.click($markingModalTriggerButton);
+      const $publicVisibilityElements = await canvas.findAllByText("전체 공개");
 
-      const $postVisibilityOpener =
-        await canvas.findByText(/공개 범위를 선택해주세요/);
+      const $postVisibilityOpener = $publicVisibilityElements[0];
       const $textArea =
         await canvas.findByPlaceholderText(/마킹에 대한 메모를 남겨주세요/);
       const $fileUploadInput = canvasElement.querySelector(
@@ -147,7 +147,7 @@ export const Default: Story = {
 
       // 공개 범위 설정
       await $postVisibilityOpener.click();
-      const $publicVisibility = await canvas.findByText("전체 공개");
+      const $publicVisibility = $publicVisibilityElements[1];
       await $publicVisibility.click();
 
       // 이미지 파일 업로드
@@ -277,7 +277,7 @@ export const Default: Story = {
 
         const { content, isVisible, images } = useMarkingFormStore.getState();
         expect(content).toBe("");
-        expect(isVisible).toBe("");
+        expect(isVisible).toBe("전체 공개");
         expect(images).toHaveLength(0);
 
         const $markingButton = await canvas.findByText("마킹하기");
@@ -306,10 +306,10 @@ export const Default: Story = {
         ];
         await userEvent.upload($fileUploadInput, dummyFiles);
 
-        const $postVisibilityOpener =
-          await canvas.findByText(/공개 범위를 선택해주세요/);
+        const $postVisibilityElements = await canvas.findAllByText("전체 공개");
+        const $postVisibilityOpener = $postVisibilityElements[0];
         await $postVisibilityOpener.click();
-        const $publicVisibility = await canvas.findByText("전체 공개");
+        const $publicVisibility = $postVisibilityElements[1];
         await $publicVisibility.click();
 
         const $textArea =
@@ -325,7 +325,7 @@ export const Default: Story = {
 
         const { content, isVisible, images } = useMarkingFormStore.getState();
         expect(content).toBe("");
-        expect(isVisible).toBe("");
+        expect(isVisible).toBe("전체 공개");
         expect(images).toHaveLength(0);
       },
     );
@@ -351,10 +351,10 @@ export const Default: Story = {
         ];
         await userEvent.upload($fileUploadInput, dummyFiles);
 
-        const $postVisibilityOpener =
-          await canvas.findByText(/공개 범위를 선택해주세요/);
+        const $postVisibilityElements = await canvas.findAllByText("전체 공개");
+        const $postVisibilityOpener = $postVisibilityElements[0];
         await $postVisibilityOpener.click();
-        const $publicVisibility = await canvas.findByText("전체 공개");
+        const $publicVisibility = $postVisibilityElements[1];
         await $publicVisibility.click();
 
         const $textArea =
@@ -370,7 +370,7 @@ export const Default: Story = {
 
         const { content, isVisible, images } = useMarkingFormStore.getState();
         expect(content).toBe("");
-        expect(isVisible).toBe("");
+        expect(isVisible).toBe("전체 공개");
         expect(images).toHaveLength(0);
       },
     );

--- a/src/features/marking/ui/markingFormModal.stories.tsx
+++ b/src/features/marking/ui/markingFormModal.stories.tsx
@@ -166,7 +166,7 @@ export const Default: Story = {
 
       const { content, isVisible, images } = useMarkingFormStore.getState();
       expect(content).toBe("여기는 진짜 대박이긴 해요");
-      expect(isVisible).toBe("전체 공개");
+      expect(isVisible).toBe("PUBLIC");
       expect(images).toHaveLength(4);
       expect(images.map((file) => file.name)).toEqual(
         dummyFiles.map((file) => file.name),
@@ -277,7 +277,7 @@ export const Default: Story = {
 
         const { content, isVisible, images } = useMarkingFormStore.getState();
         expect(content).toBe("");
-        expect(isVisible).toBe("전체 공개");
+        expect(isVisible).toBe("PUBLIC");
         expect(images).toHaveLength(0);
 
         const $markingButton = await canvas.findByText("마킹하기");
@@ -325,7 +325,7 @@ export const Default: Story = {
 
         const { content, isVisible, images } = useMarkingFormStore.getState();
         expect(content).toBe("");
-        expect(isVisible).toBe("전체 공개");
+        expect(isVisible).toBe("PUBLIC");
         expect(images).toHaveLength(0);
       },
     );
@@ -370,7 +370,7 @@ export const Default: Story = {
 
         const { content, isVisible, images } = useMarkingFormStore.getState();
         expect(content).toBe("");
-        expect(isVisible).toBe("전체 공개");
+        expect(isVisible).toBe("PUBLIC");
         expect(images).toHaveLength(0);
       },
     );

--- a/src/features/marking/ui/markingFormModal.stories.tsx
+++ b/src/features/marking/ui/markingFormModal.stories.tsx
@@ -79,19 +79,25 @@ export const Default: Story = {
       expect($addModeSnackbar).toBeVisible();
     });
 
-    await step("exit 버튼을 누르면 view 모드로 변경 된다.", async () => {
-      const $markingModalTriggerButton =
-        await canvas.findByText("여기에 마킹하기")!;
-      const $addModeExitButton =
-        await canvas.findByLabelText("마커 추가 모드 종료하기")!;
+    await step(
+      "exit 버튼을 누르면 마킹 나가기 확인 모달이 나타난다.",
+      async () => {
+        const $markingModalTriggerButton =
+          await canvas.findByText("여기에 마킹하기")!;
+        const $addModeExitButton =
+          await canvas.findByLabelText("마커 추가 모드 종료하기")!;
+        await userEvent.click($addModeExitButton);
 
-      await userEvent.click($addModeExitButton);
+        const $exitButton = await canvas.findByText("나가기");
+        expect($exitButton).toBeVisible();
+        await userEvent.click($exitButton);
 
-      const $markingButton = await canvas.findByText("마킹하기");
-      expect($markingButton).toBeVisible();
-      expect($markingModalTriggerButton).not.toBeInTheDocument();
-      expect($addModeExitButton).not.toBeInTheDocument();
-    });
+        const $markingButton = await canvas.findByText(/마킹하기/);
+        expect($markingButton).toBeVisible();
+        expect($markingModalTriggerButton).not.toBeInTheDocument();
+        expect($addModeExitButton).not.toBeInTheDocument();
+      },
+    );
 
     await step(
       "add 모드에서 여기에 마킹하기 버튼을 클릭하면 모달 폼이 나타난다.",
@@ -234,18 +240,6 @@ export const Default: Story = {
       },
     );
 
-    await step("나가기 버튼을 클릭하면 확인 모달이 나타난다.", async () => {
-      const $exitButton = canvas.getByLabelText("작성중인 마킹 게시글 닫기");
-      await userEvent.click($exitButton);
-
-      const $confirmModal = await canvas.findByText("화면을 나가시겠습니까");
-      await expect($confirmModal).toBeVisible();
-
-      const $cancelButton = await canvas.findByText("취소");
-      await userEvent.click($cancelButton);
-      await expect($confirmModal).not.toBeVisible();
-    });
-
     await step(
       "add 모드를 유지한 채로 나갔다가 다시 모달을 열어도 내용이 유지 된다.",
       async () => {
@@ -265,15 +259,16 @@ export const Default: Story = {
     await step(
       "나갈 때 view 모드로 나갈 경우엔 모달 내부 내용이 초기화 된다.",
       async () => {
-        const $exitButton =
-          await canvas.findByLabelText("작성중인 마킹 게시글 닫기");
+        const $exitButton = await canvas.findByLabelText(/모달창 닫기/);
         await userEvent.click($exitButton);
 
-        const $confirmModal = await canvas.findByText("화면을 나가시겠습니까");
-        await expect($confirmModal).toBeVisible();
+        const $addModeExitButton =
+          await canvas.findByLabelText("마커 추가 모드 종료하기")!;
+        await userEvent.click($addModeExitButton);
 
-        const $exitAddModeButton = await canvas.findByText("나가기");
-        await userEvent.click($exitAddModeButton);
+        const $exitButtonInModal = await canvas.findByText("나가기");
+        expect($exitButtonInModal).toBeVisible();
+        await userEvent.click($exitButtonInModal);
 
         const { content, isVisible, images } = useMarkingFormStore.getState();
         expect(content).toBe("");

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -2,6 +2,10 @@ import { useEffect, useRef, useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { SelectOpener } from "@/entities/auth/ui";
 import { useGetAddressFromLatLng } from "@/entities/marking/api";
+import {
+  POST_VISIBILITY_MAP,
+  type PostVisibilityName,
+} from "@/entities/marking/constants";
 import { useModal } from "@/shared/lib/overlay";
 import { useAuthStore } from "@/shared/store";
 import { Badge } from "@/shared/ui/badge";
@@ -12,11 +16,7 @@ import { Modal } from "@/shared/ui/modal";
 import { Select } from "@/shared/ui/select";
 import { TextArea } from "@/shared/ui/textarea";
 import { usePostAddMarking, usePostAddTempMarking } from "../api";
-import {
-  MARKING_ADD_ERROR_MESSAGE,
-  MAX_IMAGE_LENGTH,
-  POST_VISIBILITY_MAP,
-} from "../constants";
+import { MARKING_ADD_ERROR_MESSAGE, MAX_IMAGE_LENGTH } from "../constants";
 import { useMarkingFormStore } from "../store";
 import { MarkingFormCloseModal } from "./markingFormCloseModal";
 
@@ -40,7 +40,7 @@ export const MarkingFormModal = ({
         {/* 메모하기 */}
         <MarkingTextArea />
         {/* 제출 버튼들 */}
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gapS-2">
           <SaveButton />
           <TemporarySaveButton />
         </div>
@@ -121,7 +121,9 @@ const CurrentLocation = ({ onCloseMarkingModal }: MarkingFormModalProps) => {
 
 const PostVisibilitySelect = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const VISIBILITY_LIST = Object.keys(POST_VISIBILITY_MAP);
+  const visibilityNames = Object.keys(
+    POST_VISIBILITY_MAP,
+  ) as PostVisibilityName[];
 
   const isVisible = useMarkingFormStore((state) => state.isVisible);
   const setVisibility = useMarkingFormStore((state) => state.setVisibility);
@@ -146,7 +148,7 @@ const PostVisibilitySelect = () => {
         <Select.OptionList
           className={` ${isOpen ? "visible" : "hidden"} rounded-2xl shadow-custom-1 absolute top-[calc(100%+0.5rem)] w-full bg-grey-0 z-[9999]`}
         >
-          {VISIBILITY_LIST.map((option) => {
+          {visibilityNames.map((option) => {
             return (
               <Select.Option
                 key={option}

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -3,8 +3,8 @@ import { useMap } from "@vis.gl/react-google-maps";
 import { SelectOpener } from "@/entities/auth/ui";
 import { useGetAddressFromLatLng } from "@/entities/marking/api";
 import {
-  POST_VISIBILITY_MAP,
-  type PostVisibilityName,
+  MARKING_VISIBILITY_MAP,
+  visibilityEntries,
 } from "@/entities/marking/constants";
 import { useModal } from "@/shared/lib/overlay";
 import { useAuthStore } from "@/shared/store";
@@ -121,16 +121,13 @@ const CurrentLocation = ({ onCloseMarkingModal }: MarkingFormModalProps) => {
 
 const PostVisibilitySelect = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const visibilityNames = Object.keys(
-    POST_VISIBILITY_MAP,
-  ) as PostVisibilityName[];
 
   const isVisible = useMarkingFormStore((state) => state.isVisible);
   const setVisibility = useMarkingFormStore((state) => state.setVisibility);
 
   const handleCloseSelectList = () => setIsOpen(false);
 
-  const handleSelect = (value: keyof typeof POST_VISIBILITY_MAP) => {
+  const handleSelect = (value: keyof typeof MARKING_VISIBILITY_MAP) => {
     setVisibility(value);
     handleCloseSelectList();
   };
@@ -141,24 +138,21 @@ const PostVisibilitySelect = () => {
         label="보기권한 설정"
         essential
         onClick={() => setIsOpen(!isOpen)}
-        value={isVisible}
+        value={MARKING_VISIBILITY_MAP[isVisible]}
       />
-
       <Select isOpen={isOpen} onClose={handleCloseSelectList}>
         <Select.OptionList
           className={` ${isOpen ? "visible" : "hidden"} rounded-2xl shadow-custom-1 absolute top-[calc(100%+0.5rem)] w-full bg-grey-0 z-[9999]`}
         >
-          {visibilityNames.map((option) => {
+          {visibilityEntries.map(([key, value]) => {
             return (
               <Select.Option
-                key={option}
-                value={option}
-                isSelected={option === isVisible}
-                onClick={() =>
-                  handleSelect(option as keyof typeof POST_VISIBILITY_MAP)
-                }
+                key={key}
+                value={value}
+                isSelected={key === isVisible}
+                onClick={() => handleSelect(key)}
               >
-                {option}
+                {value}
               </Select.Option>
             );
           })}
@@ -368,7 +362,7 @@ const TemporarySaveButton = () => {
       lat,
       lng,
       region,
-      isVisible: isVisible || "전체 공개",
+      isVisible: isVisible,
       images: compressedFiles,
       content,
     });

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -139,7 +139,6 @@ const PostVisibilitySelect = () => {
         label="보기권한 설정"
         essential
         onClick={() => setIsOpen(!isOpen)}
-        placeholder="공개 범위를 선택해주세요"
         value={isVisible}
       />
 

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -4,7 +4,7 @@ import { SelectOpener } from "@/entities/auth/ui";
 import { useGetAddressFromLatLng } from "@/entities/marking/api";
 import {
   MARKING_VISIBILITY_MAP,
-  visibilityEntries,
+  MARKING_VISIBILITY_ENTRIES,
 } from "@/entities/marking/constants";
 import { useModal } from "@/shared/lib/overlay";
 import { useAuthStore } from "@/shared/store";
@@ -144,7 +144,7 @@ const PostVisibilitySelect = () => {
         <Select.OptionList
           className={` ${isOpen ? "visible" : "hidden"} rounded-2xl shadow-custom-1 absolute top-[calc(100%+0.5rem)] w-full bg-grey-0 z-[9999]`}
         >
-          {visibilityEntries.map(([key, value]) => {
+          {MARKING_VISIBILITY_ENTRIES.map(([key, value]) => {
             return (
               <Select.Option
                 key={key}

--- a/src/features/marking/ui/tempMarkingFormModal.tsx
+++ b/src/features/marking/ui/tempMarkingFormModal.tsx
@@ -1,6 +1,10 @@
 import { useRef, useState } from "react";
 import { SelectOpener } from "@/entities/auth/ui";
 import { TempMarkingInfo } from "@/entities/marking/api";
+import {
+  POST_VISIBILITY_MAP,
+  PostVisibilityName,
+} from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
 import { useSnackBar } from "@/shared/lib";
 import { Badge } from "@/shared/ui/badge";
@@ -11,11 +15,7 @@ import { Modal } from "@/shared/ui/modal";
 import { Select } from "@/shared/ui/select";
 import { TextArea } from "@/shared/ui/textarea";
 import { usePutModifyTempMarking } from "../api";
-import {
-  MARKING_ADD_ERROR_MESSAGE,
-  MAX_IMAGE_LENGTH,
-  POST_VISIBILITY_MAP,
-} from "../constants";
+import { MARKING_ADD_ERROR_MESSAGE, MAX_IMAGE_LENGTH } from "../constants";
 import {
   TempMarkingFormExternalState,
   TempMarkingFormProvider,
@@ -80,15 +80,13 @@ const TempPostVisibilitySelect = () => {
 
   const isVisible = useTempMarkingForm((state) => state.isVisible);
   const setIsVisible = useTempMarkingForm((state) => state.setIsVisible);
-
-  const VISIBILITY_ENTRIES = Object.entries(POST_VISIBILITY_MAP);
-  const selectedValue = VISIBILITY_ENTRIES.find(
-    ([_, value]) => value === isVisible,
-  )?.[0];
-
   const handleCloseSelectList = () => setIsOpen(false);
 
-  const handleSelect = (value: TempMarkingInfo["isVisible"]) => {
+  const visibilityNames = Object.keys(
+    POST_VISIBILITY_MAP,
+  ) as PostVisibilityName[];
+
+  const handleSelect = (value: PostVisibilityName) => {
     setIsVisible(value);
     handleCloseSelectList();
   };
@@ -99,27 +97,23 @@ const TempPostVisibilitySelect = () => {
         label="보기권한 설정"
         essential
         onClick={() => setIsOpen(!isOpen)}
-        value={selectedValue}
+        value={isVisible}
       />
 
       <Select isOpen={isOpen} onClose={handleCloseSelectList}>
         <Select.OptionList
           className={` ${isOpen ? "visible" : "hidden"} rounded-2xl shadow-custom-1 absolute top-[calc(100%+0.5rem)] w-full bg-grey-0 z-[9999]`}
         >
-          {VISIBILITY_ENTRIES.map(([name, value]) => {
-            return (
-              <Select.Option
-                key={name}
-                value={value}
-                isSelected={value === isVisible}
-                onClick={() =>
-                  handleSelect(value as TempMarkingInfo["isVisible"])
-                }
-              >
-                {name}
-              </Select.Option>
-            );
-          })}
+          {visibilityNames.map((name) => (
+            <Select.Option
+              key={name}
+              value={name}
+              isSelected={name === isVisible}
+              onClick={() => handleSelect(name)}
+            >
+              {name}
+            </Select.Option>
+          ))}
         </Select.OptionList>
       </Select>
     </div>
@@ -295,7 +289,7 @@ const TempMarkingSaveButton = ({
       removeIds: removedIds,
       isTempSaved: false,
       images: images.map(({ file }) => file),
-      isVisible,
+      isVisible: POST_VISIBILITY_MAP[isVisible],
     });
   };
 
@@ -333,7 +327,7 @@ const TempMarkingTempSaveButton = ({
       removeIds: removedIds,
       isTempSaved: true,
       images: images.map(({ file }) => file),
-      isVisible,
+      isVisible: POST_VISIBILITY_MAP[isVisible],
     });
   };
 

--- a/src/features/marking/ui/tempMarkingFormModal.tsx
+++ b/src/features/marking/ui/tempMarkingFormModal.tsx
@@ -2,8 +2,9 @@ import { useRef, useState } from "react";
 import { SelectOpener } from "@/entities/auth/ui";
 import { TempMarkingInfo } from "@/entities/marking/api";
 import {
-  POST_VISIBILITY_MAP,
-  PostVisibilityName,
+  MARKING_VISIBILITY_MAP,
+  visibilityEntries,
+  type MarkingVisibilityKey,
 } from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
 import { useSnackBar } from "@/shared/lib";
@@ -82,11 +83,7 @@ const TempPostVisibilitySelect = () => {
   const setIsVisible = useTempMarkingForm((state) => state.setIsVisible);
   const handleCloseSelectList = () => setIsOpen(false);
 
-  const visibilityNames = Object.keys(
-    POST_VISIBILITY_MAP,
-  ) as PostVisibilityName[];
-
-  const handleSelect = (value: PostVisibilityName) => {
+  const handleSelect = (value: MarkingVisibilityKey) => {
     setIsVisible(value);
     handleCloseSelectList();
   };
@@ -97,21 +94,21 @@ const TempPostVisibilitySelect = () => {
         label="보기권한 설정"
         essential
         onClick={() => setIsOpen(!isOpen)}
-        value={isVisible}
+        value={MARKING_VISIBILITY_MAP[isVisible]}
       />
 
       <Select isOpen={isOpen} onClose={handleCloseSelectList}>
         <Select.OptionList
           className={` ${isOpen ? "visible" : "hidden"} rounded-2xl shadow-custom-1 absolute top-[calc(100%+0.5rem)] w-full bg-grey-0 z-[9999]`}
         >
-          {visibilityNames.map((name) => (
+          {visibilityEntries.map(([key, value]) => (
             <Select.Option
-              key={name}
-              value={name}
-              isSelected={name === isVisible}
-              onClick={() => handleSelect(name)}
+              key={key}
+              value={value}
+              isSelected={key === isVisible}
+              onClick={() => handleSelect(key)}
             >
-              {name}
+              {value}
             </Select.Option>
           ))}
         </Select.OptionList>
@@ -289,7 +286,7 @@ const TempMarkingSaveButton = ({
       removeIds: removedIds,
       isTempSaved: false,
       images: images.map(({ file }) => file),
-      isVisible: POST_VISIBILITY_MAP[isVisible],
+      isVisible,
     });
   };
 
@@ -327,7 +324,7 @@ const TempMarkingTempSaveButton = ({
       removeIds: removedIds,
       isTempSaved: true,
       images: images.map(({ file }) => file),
-      isVisible: POST_VISIBILITY_MAP[isVisible],
+      isVisible,
     });
   };
 

--- a/src/features/marking/ui/tempMarkingFormModal.tsx
+++ b/src/features/marking/ui/tempMarkingFormModal.tsx
@@ -3,7 +3,7 @@ import { SelectOpener } from "@/entities/auth/ui";
 import { TempMarkingInfo } from "@/entities/marking/api";
 import {
   MARKING_VISIBILITY_MAP,
-  visibilityEntries,
+  MARKING_VISIBILITY_ENTRIES,
   type MarkingVisibilityKey,
 } from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
@@ -101,7 +101,7 @@ const TempPostVisibilitySelect = () => {
         <Select.OptionList
           className={` ${isOpen ? "visible" : "hidden"} rounded-2xl shadow-custom-1 absolute top-[calc(100%+0.5rem)] w-full bg-grey-0 z-[9999]`}
         >
-          {visibilityEntries.map(([key, value]) => (
+          {MARKING_VISIBILITY_ENTRIES.map(([key, value]) => (
             <Select.Option
               key={key}
               value={value}

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -6,7 +6,6 @@ import {
   LOGIN_END_POINT,
   SIGN_UP_END_POINT,
 } from "@/features/auth/constants";
-import { MY_MARKING_ENDPOINT } from "@/features/follow/constants";
 import { DeleteTemporaryMarkingRequest } from "@/features/marking/api";
 import { MARKING_END_POINT } from "@/features/marking/constants";
 import { PostChangeRegionRequest } from "@/features/setting/api";

--- a/src/widgets/marking/api/getDashboardMarkingThumbnail.ts
+++ b/src/widgets/marking/api/getDashboardMarkingThumbnail.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { Nickname } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKING_THUMBNAIL_ENDPOINT } from "../constants";
+import { MARKING_THUMBNAIL_END_POINT } from "../constants";
 
 interface GetDashboardMarkingThumbnailRequest {
   nickname: Nickname;
@@ -45,7 +45,7 @@ export const useGetDashboardMarkingThumbnail = (
     queryFn: token
       ? ({ pageParam = 0 }) =>
           apiClient.get<GetDashboardMarkingThumbnailResponse>(
-            MARKING_THUMBNAIL_ENDPOINT.DASHBOARD(nickname, pageParam),
+            MARKING_THUMBNAIL_END_POINT.DASHBOARD(nickname, pageParam),
             {
               withToken: true,
             },

--- a/src/widgets/marking/constants/index.ts
+++ b/src/widgets/marking/constants/index.ts
@@ -1,7 +1,7 @@
 import type { Nickname } from "@/entities/profile/api";
 import { API_BASE_URL } from "@/shared/constants";
 
-export const MARKING_THUMBNAIL_ENDPOINT = {
+export const MARKING_THUMBNAIL_END_POINT = {
   DASHBOARD: (nickname: Nickname, pageParams: number) =>
     `${API_BASE_URL}/markings/marks/${nickname}?offset=${pageParams}`,
 };

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -2,7 +2,7 @@ import { DeleteTemporaryMarkingButton } from "@/features/marking/ui";
 import { TempMarkingFormModal } from "@/features/marking/ui";
 import { TempMarkingInfo } from "@/entities/marking/api";
 import {
-  REVERSE_POST_VISIBILITY_MAP,
+  REVERSE_MARKING_VISIBILITY_MAP,
   type PostVisibilityName,
 } from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
@@ -19,7 +19,7 @@ export const TemporaryMarkingItem = ({
   markingId,
   content,
 }: Omit<TempMarkingInfo, "regDt">) => {
-  const isVisibleName = REVERSE_POST_VISIBILITY_MAP[isVisible];
+  const isVisibleName = REVERSE_MARKING_VISIBILITY_MAP[isVisible];
 
   return (
     <li className="py-4 px-4 border border-grey-300 rounded-2xl flex flex-col self-stretch">

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -1,10 +1,7 @@
 import { DeleteTemporaryMarkingButton } from "@/features/marking/ui";
 import { TempMarkingFormModal } from "@/features/marking/ui";
 import { TempMarkingInfo } from "@/entities/marking/api";
-import {
-  REVERSE_MARKING_VISIBILITY_MAP,
-  type PostVisibilityName,
-} from "@/entities/marking/constants";
+import { MARKING_VISIBILITY_MAP } from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
 import { useModal } from "@/shared/lib";
 import { Button } from "@/shared/ui/button";
@@ -19,8 +16,6 @@ export const TemporaryMarkingItem = ({
   markingId,
   content,
 }: Omit<TempMarkingInfo, "regDt">) => {
-  const isVisibleName = REVERSE_MARKING_VISIBILITY_MAP[isVisible];
-
   return (
     <li className="py-4 px-4 border border-grey-300 rounded-2xl flex flex-col self-stretch">
       {/* 마킹바 헤더 */}
@@ -30,7 +25,7 @@ export const TemporaryMarkingItem = ({
           <p className="body-2 text-grey-500">{region}</p>
         </div>
         <div className="flex gap-2">
-          <InfoChip size="small">{isVisibleName}</InfoChip>
+          <InfoChip size="small">{MARKING_VISIBILITY_MAP[isVisible]}</InfoChip>
           <DeleteTemporaryMarkingButton markingId={markingId} />
         </div>
       </header>
@@ -53,7 +48,7 @@ export const TemporaryMarkingItem = ({
       <footer className="mt-4">
         <TempMarkingModalOpenButton
           region={region}
-          isVisible={isVisibleName}
+          isVisible={isVisible}
           content={content}
           images={images}
           markingId={markingId}
@@ -65,10 +60,8 @@ export const TemporaryMarkingItem = ({
 
 type TempMarkingModalOpenButtonProps = Pick<
   TempMarkingInfo,
-  "region" | "content" | "images" | "markingId"
-> & {
-  isVisible: PostVisibilityName;
-};
+  "region" | "content" | "images" | "markingId" | "isVisible"
+>;
 
 const TempMarkingModalOpenButton = ({
   region,

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -1,6 +1,10 @@
 import { DeleteTemporaryMarkingButton } from "@/features/marking/ui";
 import { TempMarkingFormModal } from "@/features/marking/ui";
 import { TempMarkingInfo } from "@/entities/marking/api";
+import {
+  REVERSE_POST_VISIBILITY_MAP,
+  type PostVisibilityName,
+} from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
 import { useModal } from "@/shared/lib";
 import { Button } from "@/shared/ui/button";
@@ -15,12 +19,7 @@ export const TemporaryMarkingItem = ({
   markingId,
   content,
 }: Omit<TempMarkingInfo, "regDt">) => {
-  // TODO 리팩토링 시 shared 로 옮기기
-  const VISIBILITY_MAP = {
-    PUBLIC: "전체 공개",
-    FOLLOWERS_ONLY: "팔로우 공개",
-    PRIVATE: "나만 보기",
-  };
+  const isVisibleName = REVERSE_POST_VISIBILITY_MAP[isVisible];
 
   return (
     <li className="py-4 px-4 border border-grey-300 rounded-2xl flex flex-col self-stretch">
@@ -31,7 +30,7 @@ export const TemporaryMarkingItem = ({
           <p className="body-2 text-grey-500">{region}</p>
         </div>
         <div className="flex gap-2">
-          <InfoChip size="small">{VISIBILITY_MAP[isVisible]}</InfoChip>
+          <InfoChip size="small">{isVisibleName}</InfoChip>
           <DeleteTemporaryMarkingButton markingId={markingId} />
         </div>
       </header>
@@ -54,7 +53,7 @@ export const TemporaryMarkingItem = ({
       <footer className="mt-4">
         <TempMarkingModalOpenButton
           region={region}
-          isVisible={isVisible}
+          isVisible={isVisibleName}
           content={content}
           images={images}
           markingId={markingId}
@@ -66,8 +65,10 @@ export const TemporaryMarkingItem = ({
 
 type TempMarkingModalOpenButtonProps = Pick<
   TempMarkingInfo,
-  "region" | "isVisible" | "content" | "images" | "markingId"
->;
+  "region" | "content" | "images" | "markingId"
+> & {
+  isVisible: PostVisibilityName;
+};
 
 const TempMarkingModalOpenButton = ({
   region,


### PR DESCRIPTION
# 관련 이슈 번호
 close #426 
# 설명

# 자동 로그인 스토리북에서 시행하지 않도록 수정 
![image](https://github.com/user-attachments/assets/a81ad408-b2ec-470b-bc0d-34a4f02e7b04)

 마킹모달 측에서 자동로그인에 의한 에러가 떠 스토리북 환경에서 시행되지 않도록 수정했습니다 

# 공개범위 상수화 
```tsx
export const POST_VISIBILITY_MAP = {
  "전체 공개": "PUBLIC",
  "팔로우 공개": "FOLLOWERS_ONLY",
  "나만 보기": "PRIVATE",
} as const;

export type PostVisibilityName = keyof typeof POST_VISIBILITY_MAP;
export type PostVisibilityValue =
  (typeof POST_VISIBILITY_MAP)[PostVisibilityName];

export const REVERSE_POST_VISIBILITY_MAP: Record<
  PostVisibilityValue,
  PostVisibilityName
> = {
  PUBLIC: "전체 공개",
  FOLLOWERS_ONLY: "팔로우 공개",
  PRIVATE: "나만 보기",
};
```

공개범위에 사용 할 변수들을 상수화 해 생성해주었습니다.

앞으로 서버에게 보내거나 받는 isVisible 의 타입은 PostVisbilityValue  이며

스토어나 컴포넌트에서 다루는 isVisible의 값은 PostVisibilityName 입니다.

다른 유틸리티 타입이나 근사한 방법으로 구현 할 수 있었겠지만 우선은 시간이 없어 두 개의 상수와 타입 방식으로 구현해두고 올립니다

PS. END_POINT 로 다른 파일들의 타입을 통일시켰습니다.
es-lint에서 경고가 뜨던 린트를 제거했습니다.




# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
