### PR TITLE
[Feat] 내 마킹 바텀 시트

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -43,7 +43,7 @@ export const router = createBrowserRouter([
             element: <PlaceMarkingList />,
           },
           {
-            path: ROUTER_PATH.USER_MARK,
+            path: ROUTER_PATH.MY_MARK,
             element: <UserMarkingList />,
           },
         ],

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -15,7 +15,7 @@ import { TemporaryMarkingPage } from "@/pages/temporary-marking";
 import {
   LocalMarkingList,
   PlaceMarkingList,
-  UserMarkingList,
+  MyMarkingList,
 } from "@/widgets/map/ui";
 import { ROUTER_PATH } from "@/shared/constants";
 import { MainPage } from "../pages";
@@ -44,7 +44,7 @@ export const router = createBrowserRouter([
           },
           {
             path: ROUTER_PATH.MY_MARK,
-            element: <UserMarkingList />,
+            element: <MyMarkingList />,
           },
         ],
       },

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -12,7 +12,11 @@ import { SignUpPage } from "@/pages/sign-up";
 import PetInfoPage from "@/pages/sign-up/pet-info/page";
 import { UserInfoRegistrationPage } from "@/pages/sign-up/user-info";
 import { TemporaryMarkingPage } from "@/pages/temporary-marking";
-import { LocalMarkingList, PlaceMarkingList } from "@/widgets/map/ui";
+import {
+  LocalMarkingList,
+  PlaceMarkingList,
+  UserMarkingList,
+} from "@/widgets/map/ui";
 import { ROUTER_PATH } from "@/shared/constants";
 import { MainPage } from "../pages";
 import { AppProviderLayout } from "./AppProviderLayout";
@@ -37,6 +41,10 @@ export const router = createBrowserRouter([
           {
             path: ROUTER_PATH.PLACE,
             element: <PlaceMarkingList />,
+          },
+          {
+            path: ROUTER_PATH.USER_MARK,
+            element: <UserMarkingList />,
           },
         ],
       },

--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -81,7 +81,13 @@ export const useGetBoundaryMarkerList = ({
         : skipToken,
 
     refetchOnWindowFocus: false,
-    enabled,
+    enabled:
+      enabled &&
+      isMapIdle &&
+      !!southWestLat &&
+      !!southWestLng &&
+      !!northEastLat &&
+      !!northEastLng,
 
     gcTime: 0,
   });

--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -66,6 +66,7 @@ export const useGetBoundaryMarkerList = ({
     ],
 
     queryFn:
+      enabled &&
       isMapIdle &&
       !!southWestLat &&
       !!southWestLng &&
@@ -81,13 +82,6 @@ export const useGetBoundaryMarkerList = ({
         : skipToken,
 
     refetchOnWindowFocus: false,
-    enabled:
-      enabled &&
-      isMapIdle &&
-      !!southWestLat &&
-      !!southWestLng &&
-      !!northEastLat &&
-      !!northEastLng,
 
     gcTime: 0,
   });

--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -46,11 +46,13 @@ export const useGetBoundaryMarkerList = ({
   southWestLng,
   northEastLat,
   northEastLng,
+  enabled = true,
 }: {
   southWestLat: number | null;
   southWestLng: number | null;
   northEastLat: number | null;
   northEastLng: number | null;
+  enabled?: boolean;
 }) => {
   const { isIdle: isMapIdle } = useMapStore.getState();
 
@@ -79,6 +81,7 @@ export const useGetBoundaryMarkerList = ({
         : skipToken,
 
     refetchOnWindowFocus: false,
+    enabled,
 
     gcTime: 0,
   });

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -65,8 +65,8 @@ export interface GetMarkingListRequest {
   southWestLng: number;
   northEastLat: number;
   northEastLng: number;
-  lat: number;
-  lng: number;
+  lat: number | null;
+  lng: number | null;
   offset: number; // 페이지 번호
   sortType: SortType;
 }
@@ -153,8 +153,6 @@ export const useGetMarkingList = ({
       !!southWestLng &&
       !!northEastLat &&
       !!northEastLng &&
-      !!lat &&
-      !!lng &&
       !!sortType
         ? ({ pageParam }) =>
             getMarkingList({

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -1,9 +1,8 @@
 import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
-import { useMap } from "@vis.gl/react-google-maps";
 import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { SEARCH_MARKING_END_POINT } from "../constants";
+import { MARKING_END_POINT } from "../constants";
 
 interface Address {
   id: number;
@@ -104,7 +103,7 @@ const getMarkingList = async ({
   const hasToken = !!useAuthStore.getState().token;
 
   return apiClient.get<GetMarkingListResponse>(
-    SEARCH_MARKING_END_POINT({
+    MARKING_END_POINT.BOUNDARY({
       southWestLat,
       southWestLng,
       northEastLat,
@@ -133,11 +132,8 @@ export const useGetMarkingList = ({
   northEastLng: number | null;
   sortType: SortType | null;
 }) => {
-  const map = useMap();
-  const mapCenter = map?.getCenter();
-
-  const lat = mapCenter?.lat();
-  const lng = mapCenter?.lng();
+  const lat = useMapStore((state) => state.userInfo.currentLocation.lat);
+  const lng = useMapStore((state) => state.userInfo.currentLocation.lng);
 
   const { isIdle: isMapIdle } = useMapStore.getState();
 

--- a/src/entities/marking/api/getMyMakerList.ts
+++ b/src/entities/marking/api/getMyMakerList.ts
@@ -1,0 +1,28 @@
+import { skipToken, useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/shared/lib";
+import { useAuthStore } from "@/shared/store";
+import { MARKER_END_POINT } from "../constants";
+
+interface Marker {
+  markingId: number;
+  previewImage: string;
+  lat: number;
+  lng: number;
+}
+
+type GetMyMarkerListResponse = Marker[];
+
+export const useGetMyMakerList = () => {
+  const { token } = useAuthStore.getState();
+
+  return useQuery({
+    queryKey: ["myMarkerList"],
+    queryFn: token
+      ? () => {
+          return apiClient.get<GetMyMarkerListResponse>(MARKER_END_POINT.MY, {
+            withToken: true,
+          });
+        }
+      : skipToken,
+  });
+};

--- a/src/entities/marking/api/getUserMarkingList.ts
+++ b/src/entities/marking/api/getUserMarkingList.ts
@@ -1,0 +1,130 @@
+import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
+import { useMapStore } from "@/features/map/store";
+import { apiClient } from "@/shared/lib";
+import { useAuthStore } from "@/shared/store";
+import { MARKING_END_POINT } from "../constants";
+import type {
+  GetMarkingListRequest,
+  Marking,
+  SortType,
+} from "./getMarkingList";
+
+interface GetUserMarkingListResponse {
+  markings: Marking[];
+  totalElements: number;
+  totalPages: number;
+  pageAble: {
+    pageNumber: number;
+    pageSize: number;
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    offset: number;
+    paged: boolean;
+    unpaged: boolean;
+  };
+}
+
+export type GetUserMarkingListRequest = GetMarkingListRequest & {
+  nickname: string;
+};
+
+const getUserMarkingList = async ({
+  nickname,
+  southWestLat,
+  southWestLng,
+  northEastLat,
+  northEastLng,
+  lat,
+  lng,
+  sortType,
+  offset,
+}: GetUserMarkingListRequest) => {
+  const hasToken = !!useAuthStore.getState().token;
+
+  return apiClient.get<GetUserMarkingListResponse>(
+    MARKING_END_POINT.USER({
+      nickname,
+      southWestLat,
+      southWestLng,
+      northEastLat,
+      northEastLng,
+      lat,
+      lng,
+      sortType,
+      offset,
+    }),
+    {
+      withToken: hasToken,
+    },
+  );
+};
+
+export const useGetUserMarkingList = ({
+  nickname,
+  southWestLat,
+  southWestLng,
+  northEastLat,
+  northEastLng,
+  sortType,
+}: {
+  nickname: string;
+  southWestLat: number | null;
+  southWestLng: number | null;
+  northEastLat: number | null;
+  northEastLng: number | null;
+  sortType: SortType | null;
+}) => {
+  const lat = useMapStore((state) => state.userInfo.currentLocation.lat);
+  const lng = useMapStore((state) => state.userInfo.currentLocation.lng);
+
+  const { isIdle: isMapIdle } = useMapStore.getState();
+
+  return useInfiniteQuery({
+    queryKey: [
+      nickname,
+      "markingList",
+      southWestLat,
+      southWestLng,
+      northEastLat,
+      northEastLng,
+      sortType,
+    ],
+
+    queryFn:
+      isMapIdle &&
+      nickname &&
+      !!southWestLat &&
+      !!southWestLng &&
+      !!northEastLat &&
+      !!northEastLng &&
+      !!lat &&
+      !!lng &&
+      !!sortType
+        ? ({ pageParam }) =>
+            getUserMarkingList({
+              nickname,
+              southWestLat,
+              southWestLng,
+              northEastLat,
+              northEastLng,
+              lat,
+              lng,
+              offset: pageParam,
+              sortType,
+            })
+        : skipToken,
+
+    getNextPageParam: ({ pageAble: { pageNumber }, totalPages }) => {
+      return pageNumber < totalPages - 1 ? pageNumber + 1 : null;
+    },
+    initialPageParam: 0,
+    select: (data) => data.pages.flatMap((page) => page.markings),
+
+    refetchOnWindowFocus: false,
+
+    gcTime: 0,
+  });
+};

--- a/src/entities/marking/api/getUserMarkingList.ts
+++ b/src/entities/marking/api/getUserMarkingList.ts
@@ -95,13 +95,10 @@ export const useGetUserMarkingList = ({
 
     queryFn:
       isMapIdle &&
-      nickname &&
       !!southWestLat &&
       !!southWestLng &&
       !!northEastLat &&
       !!northEastLng &&
-      !!lat &&
-      !!lng &&
       !!sortType
         ? ({ pageParam }) =>
             getUserMarkingList({

--- a/src/entities/marking/api/getUserMarkingList.ts
+++ b/src/entities/marking/api/getUserMarkingList.ts
@@ -96,6 +96,7 @@ export const useGetUserMarkingList = ({
     queryFn:
       token &&
       isMapIdle &&
+      !!nickname &&
       !!southWestLat &&
       !!southWestLng &&
       !!northEastLat &&

--- a/src/entities/marking/api/getUserMarkingList.ts
+++ b/src/entities/marking/api/getUserMarkingList.ts
@@ -42,8 +42,6 @@ const getUserMarkingList = async ({
   sortType,
   offset,
 }: GetUserMarkingListRequest) => {
-  const hasToken = !!useAuthStore.getState().token;
-
   return apiClient.get<GetUserMarkingListResponse>(
     MARKING_END_POINT.USER({
       nickname,
@@ -57,7 +55,7 @@ const getUserMarkingList = async ({
       offset,
     }),
     {
-      withToken: hasToken,
+      withToken: true,
     },
   );
 };
@@ -77,6 +75,8 @@ export const useGetUserMarkingList = ({
   northEastLng: number | null;
   sortType: SortType | null;
 }) => {
+  const token = useAuthStore.getState().token;
+
   const lat = useMapStore((state) => state.userInfo.currentLocation.lat);
   const lng = useMapStore((state) => state.userInfo.currentLocation.lng);
 
@@ -94,6 +94,7 @@ export const useGetUserMarkingList = ({
     ],
 
     queryFn:
+      token &&
       isMapIdle &&
       !!southWestLat &&
       !!southWestLng &&

--- a/src/entities/marking/api/index.ts
+++ b/src/entities/marking/api/index.ts
@@ -2,3 +2,4 @@ export * from "./getAddressFromLatLng";
 export * from "./getMarkingList";
 export * from "./getBoundaryMarkerList";
 export * from "./getTemporaryMarkingList";
+export * from "./getUserMarkingList";

--- a/src/entities/marking/api/index.ts
+++ b/src/entities/marking/api/index.ts
@@ -3,3 +3,4 @@ export * from "./getMarkingList";
 export * from "./getBoundaryMarkerList";
 export * from "./getTemporaryMarkingList";
 export * from "./getUserMarkingList";
+export * from "./getMyMakerList";

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -22,6 +22,19 @@ export const MARKING_END_POINT = {
     offset,
   }: GetMarkingListRequest) =>
     `${API_BASE_URL}/markings/bounds?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&lat=${lat}&lng=${lng}&sortType=${sortType}&offset=${offset}`,
+
+  USER: ({
+    nickname,
+    southWestLat,
+    southWestLng,
+    northEastLat,
+    northEastLng,
+    lat,
+    lng,
+    sortType,
+    offset,
+  }: GetUserMarkingListRequest) =>
+    `${API_BASE_URL}/markings/users/${nickname}?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&lat=${lat}&lng=${lng}&sortType=${sortType}&offset=${offset}`,
 };
 
 export const MARKER_END_POINT = {

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -20,8 +20,11 @@ export const MARKING_END_POINT = {
     lng,
     sortType,
     offset,
-  }: GetMarkingListRequest) =>
-    `${API_BASE_URL}/markings/bounds?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&lat=${lat}&lng=${lng}&sortType=${sortType}&offset=${offset}`,
+  }: GetMarkingListRequest) => {
+    const latLngQueryParams = lat && lng ? `&lat=${lat}&lng=${lng}` : "";
+
+    return `${API_BASE_URL}/markings/bounds?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&sortType=${sortType}&offset=${offset}${latLngQueryParams}`;
+  },
 
   USER: ({
     nickname,
@@ -33,8 +36,11 @@ export const MARKING_END_POINT = {
     lng,
     sortType,
     offset,
-  }: GetUserMarkingListRequest) =>
-    `${API_BASE_URL}/markings/users/${nickname}?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&lat=${lat}&lng=${lng}&sortType=${sortType}&offset=${offset}`,
+  }: GetUserMarkingListRequest) => {
+    const latLngQueryParams = lat && lng ? `&lat=${lat}&lng=${lng}` : "";
+
+    return `${API_BASE_URL}/markings/users/${nickname}?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&sortType=${sortType}&offset=${offset}${latLngQueryParams}`;
+  },
 };
 
 export const MARKER_END_POINT = {

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from "@/shared/constants";
-import { GetMarkingListRequest } from "../api";
+import { GetMarkingListRequest, GetUserMarkingListRequest } from "../api";
 import { GetBoundaryMarkerListRequest } from "../api/getBoundaryMarkerList";
 
 export const REVERSE_GEOCODING_END_POINT = ({
@@ -10,17 +10,19 @@ export const REVERSE_GEOCODING_END_POINT = ({
   lng: number;
 }) => `${API_BASE_URL}/maps/reverse-geocode?lat=${lat}&lng=${lng}`;
 
-export const SEARCH_MARKING_END_POINT = ({
-  southWestLat,
-  southWestLng,
-  northEastLat,
-  northEastLng,
-  lat,
-  lng,
-  sortType,
-  offset,
-}: GetMarkingListRequest) =>
-  `${API_BASE_URL}/markings/nearby?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&lat=${lat}&lng=${lng}&sortType=${sortType}&offset=${offset}`;
+export const MARKING_END_POINT = {
+  BOUNDARY: ({
+    southWestLat,
+    southWestLng,
+    northEastLat,
+    northEastLng,
+    lat,
+    lng,
+    sortType,
+    offset,
+  }: GetMarkingListRequest) =>
+    `${API_BASE_URL}/markings/bounds?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&lat=${lat}&lng=${lng}&sortType=${sortType}&offset=${offset}`,
+};
 
 export const MARKER_END_POINT = {
   BOUNDARY: ({

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -51,6 +51,8 @@ export const MARKER_END_POINT = {
     northEastLng,
   }: GetBoundaryMarkerListRequest) =>
     `${API_BASE_URL}/markings/marks?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}`,
+
+  MY: `${API_BASE_URL}/markings/my-marks`,
 };
 
 export const MY_MARKING_END_POINT = {

--- a/src/entities/marking/hooks/index.ts
+++ b/src/entities/marking/hooks/index.ts
@@ -1,0 +1,28 @@
+// 맵에 보여줄 마커를 반환하는 훅
+import { useParams } from "react-router-dom";
+import { useAuthStore } from "@/shared/store";
+import { useGetBoundaryMarkerList } from "../api";
+import { useGetMyMakerList } from "../api/getMyMakerList";
+
+export const useGetMarkerList = (boundsParams: {
+  southWestLat: number | null;
+  southWestLng: number | null;
+  northEastLat: number | null;
+  northEastLng: number | null;
+}) => {
+  const { nickname } = useParams<{ nickname: string }>();
+
+  const boundaryMarkerListResult = useGetBoundaryMarkerList({
+    ...boundsParams,
+    enabled: !nickname,
+  });
+
+  const nicknameParams = nickname ? decodeURI(nickname.slice(1)) : null;
+  const isMyPage = nicknameParams === useAuthStore.getState().nickname;
+
+  const myMarkerListResult = useGetMyMakerList();
+
+  if (isMyPage) return myMarkerListResult;
+
+  return boundaryMarkerListResult;
+};

--- a/src/entities/marking/hooks/index.ts
+++ b/src/entities/marking/hooks/index.ts
@@ -1,6 +1,6 @@
 // 맵에 보여줄 마커를 반환하는 훅
-import { useParams } from "react-router-dom";
-import { useAuthStore } from "@/shared/store";
+import { useLocation } from "react-router-dom";
+import { ROUTER_PATH } from "@/shared/constants";
 import { useGetBoundaryMarkerList } from "../api";
 import { useGetMyMakerList } from "../api/getMyMakerList";
 
@@ -10,16 +10,14 @@ export const useGetMarkerList = (boundsParams: {
   northEastLat: number | null;
   northEastLng: number | null;
 }) => {
-  const { nickname } = useParams<{ nickname: string }>();
+  const { pathname } = useLocation();
+
+  const isMyPage = pathname === ROUTER_PATH.MY_MARK;
 
   const boundaryMarkerListResult = useGetBoundaryMarkerList({
     ...boundsParams,
-    enabled: !nickname,
+    enabled: !isMyPage,
   });
-
-  const nicknameParams = nickname ? decodeURI(nickname.slice(1)) : null;
-  const isMyPage = nicknameParams === useAuthStore.getState().nickname;
-
   const myMarkerListResult = useGetMyMakerList();
 
   if (isMyPage) return myMarkerListResult;

--- a/src/features/map/hooks/useMapQueryParams.ts
+++ b/src/features/map/hooks/useMapQueryParams.ts
@@ -1,6 +1,7 @@
 import { useSearchParams } from "react-router-dom";
 import type { SortType } from "@/entities/marking/api";
 import { sortTypeMap } from "../constants";
+import { useMapStore } from "../store";
 import type { Bounds } from "./useGetMapCurrentBounds";
 
 export interface Filter {
@@ -30,6 +31,10 @@ const getNumberParam = (
 
 export const useMapQueryParams = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+
+  const setIsLastSearchedLocation = useMapStore(
+    (state) => state.setIsLastSearchedLocation,
+  );
 
   const bounds: Bounds = {
     northEastLat: getNumberParam("boundsNELat", searchParams),
@@ -74,6 +79,7 @@ export const useMapQueryParams = () => {
       newSearchParams.set("sortType", mapParams.sortType);
     }
 
+    setIsLastSearchedLocation(true);
     setSearchParams(newSearchParams);
   };
 

--- a/src/features/map/hooks/useMapQueryParams.ts
+++ b/src/features/map/hooks/useMapQueryParams.ts
@@ -50,33 +50,23 @@ export const useMapQueryParams = () => {
   const hasSortTypeParam = !!sortTypeParam && sortTypeParam in sortTypeMap;
   const sortType = hasSortTypeParam ? (sortTypeParam as SortType) : null;
 
-  const setMapQueryParams = (mapParams: Filter) => {
+  const setMapQueryParams = ({ bounds, sortType }: Filter) => {
     const newSearchParams = new URLSearchParams(searchParams);
+
+    const { northEastLat, northEastLng, southWestLat, southWestLng } =
+      bounds || {};
     const hasNewBoundsParams =
-      mapParams.bounds &&
-      Object.values(mapParams.bounds).every((value) => value !== null);
+      northEastLat && northEastLng && southWestLat && southWestLng;
 
     if (hasNewBoundsParams) {
-      newSearchParams.set(
-        "boundsNELat",
-        mapParams.bounds!.northEastLat!.toString(),
-      );
-      newSearchParams.set(
-        "boundsNELng",
-        mapParams.bounds!.northEastLng!.toString(),
-      );
-      newSearchParams.set(
-        "boundsSWLat",
-        mapParams.bounds!.southWestLat!.toString(),
-      );
-      newSearchParams.set(
-        "boundsSWLng",
-        mapParams.bounds!.southWestLng!.toString(),
-      );
+      newSearchParams.set("boundsNELat", northEastLat.toString());
+      newSearchParams.set("boundsNELng", northEastLng.toString());
+      newSearchParams.set("boundsSWLat", southWestLat.toString());
+      newSearchParams.set("boundsSWLng", southWestLng.toString());
     }
 
-    if (mapParams.sortType) {
-      newSearchParams.set("sortType", mapParams.sortType);
+    if (sortType) {
+      newSearchParams.set("sortType", sortType);
     }
 
     setTimeout(() => {

--- a/src/features/map/hooks/useMapQueryParams.ts
+++ b/src/features/map/hooks/useMapQueryParams.ts
@@ -79,7 +79,9 @@ export const useMapQueryParams = () => {
       newSearchParams.set("sortType", mapParams.sortType);
     }
 
-    setIsLastSearchedLocation(true);
+    setTimeout(() => {
+      setIsLastSearchedLocation(true);
+    }, 0);
     setSearchParams(newSearchParams);
   };
 

--- a/src/features/map/ui/mapControlButton.tsx
+++ b/src/features/map/ui/mapControlButton.tsx
@@ -1,5 +1,7 @@
+import { useLocation, useNavigate } from "react-router-dom";
 import { useMap } from "@vis.gl/react-google-maps";
 import { CurrentLocationLoading } from "@/entities/map/ui";
+import { ROUTER_PATH } from "@/shared/constants";
 import { useModal, useSnackBar } from "@/shared/lib";
 import { Button } from "@/shared/ui/button";
 import {
@@ -9,7 +11,7 @@ import {
   MyLocationIcon,
 } from "@/shared/ui/icon";
 import { MarkingFormModal } from "../../marking/ui";
-import { useCurrentLocation } from "../hooks";
+import { useCurrentLocation, useMapQueryParams } from "../hooks";
 import { useMapStore } from "../store";
 
 /* ----------default mode 일 때 나타나는 버튼들입니다.---------- */
@@ -83,8 +85,12 @@ export const MyLocationButton = () => {
 const buttonBaseStyles = "border-none outline-none h-14 px-[.875rem]";
 
 export const ShowMyMarkingButton = () => {
-  // todo 상태 전역으로 관리하기
-  const shouldShowMyMarking = false;
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const shouldShowMyMarking = pathname === ROUTER_PATH.MY_MARK;
+
+  const { boundsParams, sortTypeParam, setMapQueryParams } =
+    useMapQueryParams();
 
   return (
     <Button
@@ -95,7 +101,11 @@ export const ShowMyMarkingButton = () => {
       className={`${buttonBaseStyles} rounded-b-none`}
       aria-label="내 마킹만 보기"
       onClick={() => {
-        // todo 내 마킹 보기로 상태 변경
+        navigate(ROUTER_PATH.MY_MARK);
+        setMapQueryParams({
+          bounds: boundsParams,
+          sortType: sortTypeParam || "POPULARITY",
+        });
       }}
     >
       <img src="/default-image.png" className="w-7 h-7 rounded-full" />

--- a/src/features/map/ui/mapControlButton.tsx
+++ b/src/features/map/ui/mapControlButton.tsx
@@ -13,11 +13,7 @@ import {
   MyLocationIcon,
 } from "@/shared/ui/icon";
 import { MarkingFormModal } from "../../marking/ui";
-import {
-  useCurrentLocation,
-  useGetMapCurrentBounds,
-  useMapQueryParams,
-} from "../hooks";
+import { useCurrentLocation, useGetMapCurrentBounds } from "../hooks";
 import { useMapStore } from "../store";
 
 /* ----------default mode 일 때 나타나는 버튼들입니다.---------- */
@@ -96,7 +92,6 @@ export const ShowMyMarkingButton = () => {
   const map = useMap();
 
   const shouldShowMyMarking = pathname === ROUTER_PATH.MY_MARK;
-  const { setMapQueryParams } = useMapQueryParams();
   const getCurrentBounds = useGetMapCurrentBounds();
 
   return (
@@ -109,11 +104,12 @@ export const ShowMyMarkingButton = () => {
       aria-label="내 마킹만 보기"
       onClick={() => {
         map.setZoom(10);
-        navigate(ROUTER_PATH.MY_MARK);
-        setMapQueryParams({
-          bounds: getCurrentBounds(),
-          sortType: "POPULARITY",
-        });
+        const { northEastLat, northEastLng, southWestLat, southWestLng } =
+          getCurrentBounds();
+
+        navigate(
+          `${ROUTER_PATH.MY_MARK}?boundsNELat=${northEastLat}&boundsNELng=${northEastLng}&boundsSWLat=${southWestLat}&boundsSWLng=${southWestLng}&sortType=POPULARITY`,
+        );
       }}
     >
       <img src="/default-image.png" className="w-7 h-7 rounded-full" />

--- a/src/features/map/ui/mapControlButton.tsx
+++ b/src/features/map/ui/mapControlButton.tsx
@@ -11,7 +11,11 @@ import {
   MyLocationIcon,
 } from "@/shared/ui/icon";
 import { MarkingFormModal } from "../../marking/ui";
-import { useCurrentLocation, useMapQueryParams } from "../hooks";
+import {
+  useCurrentLocation,
+  useGetMapCurrentBounds,
+  useMapQueryParams,
+} from "../hooks";
 import { useMapStore } from "../store";
 
 /* ----------default mode 일 때 나타나는 버튼들입니다.---------- */
@@ -87,10 +91,11 @@ const buttonBaseStyles = "border-none outline-none h-14 px-[.875rem]";
 export const ShowMyMarkingButton = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const shouldShowMyMarking = pathname === ROUTER_PATH.MY_MARK;
+  const map = useMap();
 
-  const { boundsParams, sortTypeParam, setMapQueryParams } =
-    useMapQueryParams();
+  const shouldShowMyMarking = pathname === ROUTER_PATH.MY_MARK;
+  const { setMapQueryParams } = useMapQueryParams();
+  const getCurrentBounds = useGetMapCurrentBounds();
 
   return (
     <Button
@@ -101,10 +106,11 @@ export const ShowMyMarkingButton = () => {
       className={`${buttonBaseStyles} rounded-b-none`}
       aria-label="내 마킹만 보기"
       onClick={() => {
+        map.setZoom(10);
         navigate(ROUTER_PATH.MY_MARK);
         setMapQueryParams({
-          bounds: boundsParams,
-          sortType: sortTypeParam || "POPULARITY",
+          bounds: getCurrentBounds(),
+          sortType: "POPULARITY",
         });
       }}
     >

--- a/src/features/map/ui/mapMarkers.tsx
+++ b/src/features/map/ui/mapMarkers.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { User, MultiplePin, Cluster, Pin } from "@/entities/map/ui";
 import { useGetMarkerList } from "@/entities/marking/hooks";
 import { API_BASE_URL, ROUTER_PATH } from "@/shared/constants";
@@ -20,6 +20,7 @@ export const UserMarker = () => {
 
 export const PinMarker = () => {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const { boundsParams, setMapQueryParams } = useMapQueryParams();
 
   const { data: markerList } = useGetMarkerList(boundsParams);
@@ -31,16 +32,18 @@ export const PinMarker = () => {
       imageUrl={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
       alt={`${markingId}의 이미지`}
       onClick={() => {
-        navigate(ROUTER_PATH.PLACE);
-        setMapQueryParams({
-          bounds: {
-            southWestLat: lat - 0.00001,
-            southWestLng: lng - 0.00001,
-            northEastLat: lat + 0.00001,
-            northEastLng: lng + 0.00001,
-          },
-          sortType: "POPULARITY",
-        });
+        if (pathname === ROUTER_PATH.MAP) {
+          navigate(ROUTER_PATH.PLACE);
+          setMapQueryParams({
+            bounds: {
+              southWestLat: lat - 0.00001,
+              southWestLng: lng - 0.00001,
+              northEastLat: lat + 0.00001,
+              northEastLng: lng + 0.00001,
+            },
+            sortType: "POPULARITY",
+          });
+        }
       }}
     />
   ));

--- a/src/features/map/ui/mapMarkers.tsx
+++ b/src/features/map/ui/mapMarkers.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { User, MultiplePin, Cluster, Pin } from "@/entities/map/ui";
-import { useGetBoundaryMarkerList } from "@/entities/marking/api";
+import { useGetMarkerList } from "@/entities/marking/hooks";
 import { API_BASE_URL, ROUTER_PATH } from "@/shared/constants";
 import { useMapQueryParams } from "../hooks";
 import { useMapStore } from "../store";
@@ -22,7 +22,7 @@ export const PinMarker = () => {
   const navigate = useNavigate();
   const { boundsParams, setMapQueryParams } = useMapQueryParams();
 
-  const { data: markerList } = useGetBoundaryMarkerList(boundsParams);
+  const { data: markerList } = useGetMarkerList(boundsParams);
 
   return markerList?.map(({ markingId, lat, lng, previewImage }) => (
     <Pin

--- a/src/features/marking/ui/markingFilter.tsx
+++ b/src/features/marking/ui/markingFilter.tsx
@@ -157,6 +157,16 @@ export const RangeFilter = ({
 
     setSelectedOption(rangeFilter);
 
+    if (rangeFilter === "ALL_VIEW") {
+      map.setZoom(10);
+      setMapQueryParams({
+        bounds: getMapBounds(),
+        sortType: sortTypeParam!,
+      });
+
+      return;
+    }
+
     if (rangeFilter === "CURRENT_LOCATION") {
       setCurrentLocation({
         onSuccess: ({ coords: { latitude, longitude } }) => {

--- a/src/mocks/data/myMark.ts
+++ b/src/mocks/data/myMark.ts
@@ -1,0 +1,50 @@
+import { profileMarkingThumbnail } from "./profileMarking";
+
+export const getMyMark = () => {
+  // 뽀송송의 마커 리스트
+  const myMarkerList = profileMarkingThumbnail["뽀송송"];
+  // 뽀송송의 마커 리스트를 가공하여 마킹 리스트 반환
+  const myMarkingList = myMarkerList.map((thumbnail, index) => ({
+    ...thumbnail,
+    region: "**시 **구 **동",
+    content: `Marking content ${index + 1}`,
+    isVisible: "PUBLIC",
+    regDt: new Date().toISOString(),
+    nickName: "뽀송송",
+    userId: index + 1,
+    isOwner: true,
+    isTempSaved: false,
+    address: {
+      id: index + 1,
+      province: "**시",
+      cityCounty: "**구",
+      district: null,
+      subDistrict: `district ${index + 1}`,
+    },
+    countData: {
+      likedCount: Math.floor(Math.random() * 100),
+      savedCount: Math.floor(Math.random() * 100),
+    },
+    pet: {
+      petId: 1,
+      name: `뽀송송 Pet`,
+      description: `Pet description ${index + 1}`,
+      profile: `profile_url_${index + 1}`,
+      breed: `뽀송송 Breed`,
+      personalities: ["personality1", "personality2"],
+    },
+    images: [
+      {
+        id: index + 1,
+        imageUrl: `image_url_${index + 1}`,
+        lank: 1,
+        regDt: new Date().toISOString(),
+      },
+    ],
+  }));
+
+  return {
+    myMarkerList,
+    myMarkingList,
+  };
+};

--- a/src/mocks/data/userMarkingList.ts
+++ b/src/mocks/data/userMarkingList.ts
@@ -1,0 +1,59 @@
+import type { Marking } from "@/entities/marking/api";
+
+export const getMockUserMarkingList = ({
+  nickname,
+  southBottomLat,
+  northTopLat,
+  southLeftLng,
+  northRightLng,
+}: {
+  nickname: string;
+  southBottomLat: number;
+  northTopLat: number;
+  southLeftLng: number;
+  northRightLng: number;
+}) => {
+  const markingList: Marking[] = Array.from({ length: 140 }, (_, index) => ({
+    markingId: index + 1,
+    region: "**시 **구 **동",
+    content: `Marking content ${index + 1}`,
+    previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
+    isVisible: "PUBLIC",
+    regDt: new Date().toISOString(),
+    nickName: nickname,
+    userId: index + 1,
+    isOwner: true,
+    isTempSaved: false,
+    lat: southBottomLat + Math.random() * (northTopLat - southBottomLat),
+    lng: southLeftLng + Math.random() * (northRightLng - southLeftLng),
+    address: {
+      id: index + 1,
+      province: "**시",
+      cityCounty: "**구",
+      district: null,
+      subDistrict: `district ${index + 1}`,
+    },
+    countData: {
+      likedCount: Math.floor(Math.random() * 100),
+      savedCount: Math.floor(Math.random() * 100),
+    },
+    pet: {
+      petId: 1,
+      name: `${nickname} Pet`,
+      description: `Pet description ${index + 1}`,
+      profile: `profile_url_${index + 1}`,
+      breed: `${nickname} Breed`,
+      personalities: ["personality1", "personality2"],
+    },
+    images: [
+      {
+        id: index + 1,
+        imageUrl: `image_url_${index + 1}`,
+        lank: 1,
+        regDt: new Date().toISOString(),
+      },
+    ],
+  }));
+
+  return markingList;
+};

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -6,7 +6,6 @@ import {
   LOGIN_END_POINT,
   SIGN_UP_END_POINT,
 } from "@/features/auth/constants";
-import { MY_MARKING_ENDPOINT } from "@/features/follow/constants";
 import { DeleteTemporaryMarkingRequest } from "@/features/marking/api";
 import { MARKING_END_POINT } from "@/features/marking/constants";
 import { PostChangeRegionRequest } from "@/features/setting/api";
@@ -28,6 +27,7 @@ import { profileMarkingThumbnail as _profileMarkingThumbnail } from "./data/prof
 import regionListData from "./data/regionList.json";
 import { temporaryMarkingList as _temporaryMarkingList } from "./data/tempMarkingList";
 import { User } from "./data/user";
+import { getMockUserMarkingList } from "./data/userMarkingList";
 
 interface UserInfo {
   nickname: string;
@@ -1203,7 +1203,7 @@ const getDistanceFromLatLonInKm = (
 const markingListDB: Record<string, Marking[]> = {};
 
 const getMarkingListHandler = [
-  http.get(`${API_BASE_URL}/markings/nearby`, async ({ request }) => {
+  http.get(`${API_BASE_URL}/markings/bounds`, async ({ request }) => {
     const url = new URL(request.url);
 
     const lat = Number(url.searchParams.get("lat"));
@@ -1693,6 +1693,102 @@ const putModifyTempMarkingHandler = [
   }),
 ];
 
+const getUserMarkingListHandler = [
+  http.get(
+    `${API_BASE_URL}/markings/users/:nickname`,
+    async ({ request, params }) => {
+      const { nickname } = params;
+
+      if (typeof nickname !== "string") {
+        return HttpResponse.json(
+          {
+            code: 400,
+            message: "잘못된 요청입니다.",
+          },
+          {
+            status: 400,
+          },
+        );
+      }
+
+      const url = new URL(request.url);
+
+      const southBottomLat = Number(url.searchParams.get("southBottomLat"));
+      const northTopLat = Number(url.searchParams.get("northTopLat"));
+      const southLeftLng = Number(url.searchParams.get("southLeftLng"));
+      const northRightLng = Number(url.searchParams.get("northRightLng"));
+
+      const markingList = getMockUserMarkingList({
+        nickname,
+        southBottomLat,
+        northTopLat,
+        southLeftLng,
+        northRightLng,
+      });
+
+      const sortType = url.searchParams.get("sortType") as SortType;
+
+      if (sortType === "POPULARITY") {
+        markingList.sort(
+          (a, b) => b.countData.likedCount - a.countData.likedCount,
+        );
+      } else if (sortType === "RECENT") {
+        markingList.sort(
+          (a, b) => new Date(b.regDt).getTime() - new Date(a.regDt).getTime(),
+        );
+      }
+
+      if (sortType === "DISTANCE") {
+        const lat = url.searchParams.get("lat");
+        const lng = url.searchParams.get("lng");
+
+        if (lat && lng) {
+          markingList.sort(
+            (a, b) =>
+              getDistanceFromLatLonInKm(
+                Number(lat),
+                Number(lng),
+                a.lat,
+                a.lng,
+              ) -
+              getDistanceFromLatLonInKm(Number(lat), Number(lng), b.lat, b.lng),
+          );
+        }
+      }
+
+      const pageNumber = Number(url.searchParams.get("offset") || 0);
+      const totalCount = markingList.length;
+      const pageSize = 20;
+      const lastPage = Math.ceil(totalCount / pageSize);
+
+      return HttpResponse.json({
+        code: 200,
+        message: "success",
+        content: {
+          markings: markingList.slice(
+            pageNumber * pageSize,
+            (pageNumber + 1) * pageSize,
+          ),
+          totalElements: totalCount,
+          totalPages: lastPage,
+          pageAble: {
+            pageNumber,
+            pageSize,
+            sort: {
+              sorted: false,
+              unsorted: true,
+              empty: true,
+            },
+            offset: pageNumber,
+            paged: true,
+            unpaged: false,
+          },
+        },
+      });
+    },
+  ),
+];
+
 // * 나중에 msw 사용을 대비하여 만들었습니다.
 export const handlers = [
   ...signUpByEmailHandlers,
@@ -1723,4 +1819,5 @@ export const handlers = [
   ...getTemporaryMarkingListHandler,
   ...deleteTemporaryMarkingHandler,
   ...putModifyTempMarkingHandler,
+  ...getUserMarkingListHandler,
 ];

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -18,10 +18,12 @@ import { SETTING_END_POINT } from "@/features/setting/constants";
 import { MyInfo } from "@/entities/auth/api";
 import { MY_INFO_END_POINT } from "@/entities/auth/constants";
 import { Marking, SortType } from "@/entities/marking/api";
+import { MARKER_END_POINT } from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
 // data
 import { getMockMarkingList } from "./data/markingList";
 import userInfoData from "./data/myInfo.json";
+import { getMyMark } from "./data/myMark";
 import { otherUsers } from "./data/otherUser";
 import { profileMarkingThumbnail as _profileMarkingThumbnail } from "./data/profileMarking";
 import regionListData from "./data/regionList.json";
@@ -1693,6 +1695,8 @@ const putModifyTempMarkingHandler = [
   }),
 ];
 
+const { myMarkerList, myMarkingList } = getMyMark();
+
 const getUserMarkingListHandler = [
   http.get(
     `${API_BASE_URL}/markings/users/:nickname`,
@@ -1718,13 +1722,16 @@ const getUserMarkingListHandler = [
       const southLeftLng = Number(url.searchParams.get("southLeftLng"));
       const northRightLng = Number(url.searchParams.get("northRightLng"));
 
-      const markingList = getMockUserMarkingList({
-        nickname,
-        southBottomLat,
-        northTopLat,
-        southLeftLng,
-        northRightLng,
-      });
+      const markingList =
+        nickname === "뽀송송"
+          ? myMarkingList
+          : getMockUserMarkingList({
+              nickname,
+              southBottomLat,
+              northTopLat,
+              southLeftLng,
+              northRightLng,
+            });
 
       const sortType = url.searchParams.get("sortType") as SortType;
 
@@ -1789,6 +1796,30 @@ const getUserMarkingListHandler = [
   ),
 ];
 
+const getMyMarkerList = [
+  http.get(MARKER_END_POINT.MY, ({ request }) => {
+    const token = request.headers.get("Authorization");
+
+    if (!token || token === "staleAccessToken") {
+      return HttpResponse.json(
+        {
+          code: 401,
+          message: "토큰 검증에 실패 했습니다.",
+        },
+        {
+          status: 401,
+        },
+      );
+    }
+
+    return HttpResponse.json({
+      code: 200,
+      message: "success",
+      content: myMarkerList,
+    });
+  }),
+];
+
 // * 나중에 msw 사용을 대비하여 만들었습니다.
 export const handlers = [
   ...signUpByEmailHandlers,
@@ -1820,4 +1851,5 @@ export const handlers = [
   ...deleteTemporaryMarkingHandler,
   ...putModifyTempMarkingHandler,
   ...getUserMarkingListHandler,
+  ...getMyMarkerList,
 ];

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -103,7 +103,7 @@ export const ROUTER_PATH = {
 
   MAP: `/map`,
   PLACE: "/map/place",
-  USER_MARK: "/map/:nickname",
+  MY_MARK: "/map/my",
 
   PROFILE: `/:nickname`,
   FOLLOWINGS: `followings`,

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -103,6 +103,7 @@ export const ROUTER_PATH = {
 
   MAP: `/map`,
   PLACE: "/map/place",
+  USER_MARK: "/map/:nickname",
 
   PROFILE: `/:nickname`,
   FOLLOWINGS: `followings`,

--- a/src/shared/lib/profile.ts
+++ b/src/shared/lib/profile.ts
@@ -18,7 +18,7 @@ export const useNicknameParams = () => {
     throw new Error("parameter에 nickname이 없습니다.");
   }
 
-  const nicknameParams = nickname.slice(1);
+  const nicknameParams = decodeURI(nickname.slice(1));
   const isMyPage = nicknameParams === useAuthStore.getState().nickname;
 
   return { nicknameParams, isMyPage };

--- a/src/widgets/map/ui/index.ts
+++ b/src/widgets/map/ui/index.ts
@@ -6,3 +6,4 @@ export * from "./mapInitializer";
 export * from "./mapBottomSheet";
 export * from "./localMarkingList";
 export * from "./placeMarkingList";
+export * from "./userMarkingList";

--- a/src/widgets/map/ui/index.ts
+++ b/src/widgets/map/ui/index.ts
@@ -6,4 +6,4 @@ export * from "./mapInitializer";
 export * from "./mapBottomSheet";
 export * from "./localMarkingList";
 export * from "./placeMarkingList";
-export * from "./userMarkingList";
+export * from "./myMarkingList";

--- a/src/widgets/map/ui/myMarkingList.tsx
+++ b/src/widgets/map/ui/myMarkingList.tsx
@@ -53,7 +53,9 @@ export const MyMarkingList = () => {
         )}
 
         <div className="flex w-full justify-end">
-          <RangeFilter options={["CURRENT_LOCATION", "MAP_LOCATION"]} />
+          <RangeFilter
+            options={["ALL_VIEW", "CURRENT_LOCATION", "MAP_LOCATION"]}
+          />
           <SortTypeFilter options={["POPULARITY", "RECENT", "DISTANCE"]} />
         </div>
 

--- a/src/widgets/map/ui/myMarkingList.tsx
+++ b/src/widgets/map/ui/myMarkingList.tsx
@@ -12,7 +12,7 @@ import { useInfiniteScroll } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { MarkingList } from "./markingList";
 
-export const UserMarkingList = () => {
+export const MyMarkingList = () => {
   const map = useMap();
 
   const { sortTypeParam, boundsParams } = useMapQueryParams();

--- a/src/widgets/map/ui/userMarkingList.tsx
+++ b/src/widgets/map/ui/userMarkingList.tsx
@@ -1,0 +1,87 @@
+import { useMap } from "@vis.gl/react-google-maps";
+import { useMapQueryParams } from "@/features/map/hooks";
+import {
+  MarkingItem,
+  RangeFilter,
+  SortTypeFilter,
+} from "@/features/marking/ui";
+import { useGetUserMarkingList } from "@/entities/marking/api";
+import { TemporaryMarkingBar } from "@/entities/marking/ui";
+import { useGetProfile } from "@/entities/profile/api";
+import { useInfiniteScroll } from "@/shared/lib";
+import { useNicknameParams } from "@/shared/lib/profile";
+import { useAuthStore } from "@/shared/store";
+import { MarkingList } from "./markingList";
+
+export const UserMarkingList = () => {
+  const map = useMap();
+  const { nicknameParams } = useNicknameParams();
+
+  const { sortTypeParam, boundsParams } = useMapQueryParams();
+
+  const myNickname = useAuthStore.getState().nickname;
+
+  const { data: profile } = useGetProfile({
+    nickname: nicknameParams,
+  });
+  const {
+    data: markingList,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useGetUserMarkingList({
+    ...boundsParams,
+    nickname: nicknameParams,
+    sortType: sortTypeParam,
+  });
+
+  const [setNode] = useInfiniteScroll(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  });
+
+  return (
+    <div className="px-4">
+      {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
+      <h1 className="title-1 text-grey-900 py-4">
+        {nicknameParams === myNickname ? "내 마킹" : `${nicknameParams}의 마킹`}
+      </h1>
+
+      <section className="pb-4 flex flex-col gap-4">
+        {nicknameParams === myNickname &&
+          typeof profile?.tempCnt === "number" &&
+          profile.tempCnt > 0 && (
+            <div className="pt-4">
+              <TemporaryMarkingBar tempCnt={profile.tempCnt} />
+            </div>
+          )}
+
+        <div className="flex w-full justify-end">
+          <RangeFilter options={["CURRENT_LOCATION", "MAP_LOCATION"]} />
+          <SortTypeFilter options={["POPULARITY", "RECENT", "DISTANCE"]} />
+        </div>
+
+        <MarkingList display="list">
+          {markingList?.map((marking) => (
+            <MarkingItem
+              key={marking.markingId}
+              onRegionClick={() => {
+                map.setCenter({
+                  lat: marking.lat,
+                  lng: marking.lng,
+                });
+                map.setZoom(19);
+              }}
+              // todo isLiked, isBookmarked 설정
+              isLiked={false}
+              isBookmarked={false}
+              {...marking}
+            />
+          ))}
+        </MarkingList>
+        <div className="h-[.125rem]" ref={setNode} />
+      </section>
+    </div>
+  );
+};

--- a/src/widgets/map/ui/userMarkingList.tsx
+++ b/src/widgets/map/ui/userMarkingList.tsx
@@ -9,21 +9,17 @@ import { useGetUserMarkingList } from "@/entities/marking/api";
 import { TemporaryMarkingBar } from "@/entities/marking/ui";
 import { useGetProfile } from "@/entities/profile/api";
 import { useInfiniteScroll } from "@/shared/lib";
-import { useNicknameParams } from "@/shared/lib/profile";
 import { useAuthStore } from "@/shared/store";
 import { MarkingList } from "./markingList";
 
 export const UserMarkingList = () => {
   const map = useMap();
-  const { nicknameParams } = useNicknameParams();
 
   const { sortTypeParam, boundsParams } = useMapQueryParams();
 
-  const myNickname = useAuthStore.getState().nickname;
+  const nickname = useAuthStore.getState().nickname;
 
-  const { data: profile } = useGetProfile({
-    nickname: nicknameParams,
-  });
+  const { data: profile } = useGetProfile({ nickname });
   const {
     data: markingList,
     fetchNextPage,
@@ -31,7 +27,7 @@ export const UserMarkingList = () => {
     isFetchingNextPage,
   } = useGetUserMarkingList({
     ...boundsParams,
-    nickname: nicknameParams,
+    nickname: nickname || "",
     sortType: sortTypeParam,
   });
 
@@ -41,21 +37,20 @@ export const UserMarkingList = () => {
     }
   });
 
+  // todo 회원이 아닐 경우
+  if (!nickname) return null;
+
   return (
     <div className="px-4">
       {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
-      <h1 className="title-1 text-grey-900 py-4">
-        {nicknameParams === myNickname ? "내 마킹" : `${nicknameParams}의 마킹`}
-      </h1>
+      <h1 className="title-1 text-grey-900 py-4">내 마킹</h1>
 
       <section className="pb-4 flex flex-col gap-4">
-        {nicknameParams === myNickname &&
-          typeof profile?.tempCnt === "number" &&
-          profile.tempCnt > 0 && (
-            <div className="pt-4">
-              <TemporaryMarkingBar tempCnt={profile.tempCnt} />
-            </div>
-          )}
+        {typeof profile?.tempCnt === "number" && profile.tempCnt > 0 && (
+          <div className="pt-4">
+            <TemporaryMarkingBar tempCnt={profile.tempCnt} />
+          </div>
+        )}
 
         <div className="flex w-full justify-end">
           <RangeFilter options={["CURRENT_LOCATION", "MAP_LOCATION"]} />


### PR DESCRIPTION
# 관련 이슈 번호

#424 

# 설명

## api 관련 훅

### useGetBoundaryMarkerList에 enabled 추가

이 훅이 반환하는 데이터는 내 마킹 바텀시트에서 사용되지 않습니다.
enabled를 추가하여, 만약 현재 보고 있는 페이지가 내 마킹일 경우 호출되지 않도록 하였습니다.

```typescript
export const useGetBoundaryMarkerList = ({
  southWestLat,
  southWestLng,
  northEastLat,
  northEastLng,
  enabled = true,
}: {
  southWestLat: number | null;
  southWestLng: number | null;
  northEastLat: number | null;
  northEastLng: number | null;
  enabled?: boolean;
}) => {
  return useQuery({
    queryFn:
      enabled &&
      // ...
}
```

### 동네 마킹 데이터 요청할 때 서버에게 보내는 lat과 lng 값 수정 (useGetMarkingList)

[동네 마킹 데이터](https://documenter.getpostman.com/view/26924668/2sAXqndjDZ#b3ae81b3-3820-475b-bcb4-88c32ef973cc)를 요청할 때 보내야 할 데이터인 lat과 lng은 사용자의 현재 위치입니다.
기존에는 맵의 center 값으로 잘못 보내고 있어서 수정했습니다.

### 나의 모든 마커를 요청하는 훅 (useGetMyMakerList)

[나의 모든 마커를 반환하는 api](https://documenter.getpostman.com/view/26924668/2sAXqndjDZ#9b37a142-7c4d-4f1e-a622-a088f4776789)에서 데이터를 받아 맵의 바운더리에 속하는 데이터를 추리자고 했었습니다.

근데 막상 필터링하니, [전체보기]일 때 어색했습니다.
지도에는 아무런 마커가 없어도 바텀 시트에는 모든 마킹 데이터가 표시되고,
확대를 줄여 마커를 찾아보려고 해도 이미 필터링된 상태라 보이지 않았습니다.

그래서 기존의 방식대로 모든 마커를 맵에 표시하는 것으로 바꿨습니다.

### 특정 유저의 마킹 리스트를 요청하는 훅 (useGetUserMarkingList)

원래 특정 유저의 마킹 리스트를 공유하는 것을 감안해서 네이밍에 User를 넣었습니다.
그러나, 현재 사용자의 마킹 리스트를 불러오는데만 사용하니까 useGetMyMarkingList로 해야하나 고민이긴합니다.


### 보고있는 페이지에 따라 적절한 마커를 반환하는 훅 

만약 내 마킹의 페이지일 경우 내 마커를 요청하는 query 결과값을 반환하고,
아니라면 바운더리 안에 있는 마커를 요청하는 query 결과값이 반환됩니다.

```typescript
// entities/marking/hooks
// 맵에 보여줄 마커를 반환하는 훅
import { useLocation } from "react-router-dom";
import { ROUTER_PATH } from "@/shared/constants";
import { useGetBoundaryMarkerList } from "../api";
import { useGetMyMakerList } from "../api/getMyMakerList";

export const useGetMarkerList = (boundsParams: {
  southWestLat: number | null;
  southWestLng: number | null;
  northEastLat: number | null;
  northEastLng: number | null;
}) => {
  const { pathname } = useLocation();

  const isMyPage = pathname === ROUTER_PATH.MY_MARK;

  const boundaryMarkerListResult = useGetBoundaryMarkerList({
    ...boundsParams,
    enabled: !isMyPage,
  });
  const myMarkerListResult = useGetMyMakerList();

  if (isMyPage) return myMarkerListResult;

  return boundaryMarkerListResult;
};
```

## 현 위치 재검색 버튼

저번 리팩토링 때 url 파라미터 값이 바뀌면 `isLastSearchedLocation` 상태를 true로 바꿨어야 했는데 놓쳤습니다 😓 
setMapQueryParams에 `setIsLastSearchedLocation(true)` 로직을 추가했습니다.

## [내위치] 버튼

현재 url의 path가 `/map/my`일 경우 버튼은 활성화됩니다.
이 버튼을 클릭했을 때, 줌을 최대한 아웃하여 그 때의 boundary 값으로 파라미터가 업데이트됩니다.
내 마킹의 기본 정렬값은  인기순이기 때문에 sortType을 "POPULARITY"로 설정했습니다.

```typescript
export const ShowMyMarkingButton = () => {
  const navigate = useNavigate();
  const { pathname } = useLocation();
  const map = useMap();

  const shouldShowMyMarking = pathname === ROUTER_PATH.MY_MARK;
  const { setMapQueryParams } = useMapQueryParams();
  const getCurrentBounds = useGetMapCurrentBounds();

  return (
    <Button
      type="button"
      variant={shouldShowMyMarking ? "filled" : "outlined"}
      colorType={shouldShowMyMarking ? "primary" : "tertiary"}
      size="medium"
      className={`${buttonBaseStyles} rounded-b-none`}
      aria-label="내 마킹만 보기"
      onClick={() => {
        map.setZoom(10);
        navigate(ROUTER_PATH.MY_MARK);
        setMapQueryParams({
          bounds: getCurrentBounds(),
          sortType: "POPULARITY",
        });
      }}
    >
   // ...
}
```

## 문제

### [현 지도에서 재검색]과 노출 범위 필터 동기화되지 않는 문제

[현 지도에서 재검색]을 눌렀을 때 마킹 노출 범위 필터가 업데이트되지 않는 문제가 있습니다. (현재 지도 중심으로 바뀌지 x)
이 문제는 모든 페이지에서 발생하고 있습니다.

https://github.com/user-attachments/assets/72b49f3c-a72b-444e-aa65-41b110d68eab

추후에 마킹 노출 범위 필터에서 선택된 값을 전역 상태로 관리하려고 합니다.
그래서, [현 지도에서 재검색]을 누르면 전역 상태를 `현재 지도 중심` 값으로 업데이트하여 필터와 동기화하려고 합니다.

### 뒤로 가기

`/map?sortType...` 에서 뒤로가기를 누르면 `/map`으로 이동되더라구요.
내 마킹도 마찬가지입니다.
replace값을 써도 해결되지 않아서 다른 풀리퀘에서 고치려고 합니다 😢 

https://github.com/user-attachments/assets/b965a074-123e-45c4-90d8-ed7eb49f5622


