### PR TITLE
[Feat] 마킹 삭제하기

### DIFF
--- a/src/features/marking/api/deleteMarking.ts
+++ b/src/features/marking/api/deleteMarking.ts
@@ -13,11 +13,14 @@ const deleteMarking = async ({ markingId }: DeleteMarkingRequest) => {
   });
 };
 
-export const useDeleteMarking = () => {
+export const useDeleteMarking = ({ onSuccess }: { onSuccess?: () => void }) => {
   return useMutation<unknown, Error, DeleteMarkingRequest>({
     mutationFn: deleteMarking,
     onSuccess: () => {
-      // todo 기존에 캐시된 내 마킹 데이터 삭제하기
+      onSuccess?.();
+    },
+    onError: () => {
+      // todo: 에러 핸들링
     },
   });
 };

--- a/src/features/marking/ui/markingItem.tsx
+++ b/src/features/marking/ui/markingItem.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Marking } from "@/entities/marking/api";
 import type { PetInfo } from "@/entities/profile/api";
 import { API_BASE_URL } from "@/shared/constants";
-import { formatDateToYearMonthDay } from "@/shared/lib";
+import { formatDateToYearMonthDay, useClickOutside } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { Button } from "@/shared/ui/button";
 import { DividerLine } from "@/shared/ui/divider";
@@ -24,24 +24,9 @@ const MarkingManageButton = ({
   markingId,
 }: Pick<MarkingItemProps, "markingId">) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-
   const ref = useRef<HTMLDivElement>(null);
 
-  const handleClickOutside = (e: MouseEvent) => {
-    const isClickedOutside =
-      ref.current && !ref.current.contains(e.target as Node);
-
-    if (isClickedOutside) {
-      setIsOpen(false);
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener("click", handleClickOutside);
-    return () => {
-      document.removeEventListener("click", handleClickOutside);
-    };
-  }, []);
+  useClickOutside(ref, () => setIsOpen(false));
 
   const { mutate: deleteMarking } = useDeleteMarking();
 

--- a/src/features/marking/ui/markingItem.tsx
+++ b/src/features/marking/ui/markingItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { Marking } from "@/entities/marking/api";
 import type { PetInfo } from "@/entities/profile/api";
 import { API_BASE_URL } from "@/shared/constants";
@@ -16,19 +16,25 @@ import { MarkingLikeToggle } from "./markingLikeToggle";
 interface MarkingItemProps
   extends Omit<Marking, "isVisible" | "isTempSaved" | "userId" | "pet"> {
   onRegionClick: () => void;
+  onDelete?: () => void;
   pet: Pick<PetInfo, "petId" | "profile" | "name">;
   isLiked: boolean;
   isBookmarked: boolean;
 }
 const MarkingManageButton = ({
   markingId,
-}: Pick<MarkingItemProps, "markingId">) => {
+  onDelete,
+}: Pick<MarkingItemProps, "markingId" | "onDelete">) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useClickOutside(ref, () => setIsOpen(false));
 
-  const { mutate: deleteMarking } = useDeleteMarking();
+  const { mutate: deleteMarking } = useDeleteMarking({
+    onSuccess: () => {
+      onDelete?.();
+    },
+  });
 
   const handleDeleteMarking = () => {
     const { token, role } = useAuthStore.getState();
@@ -76,6 +82,7 @@ const MarkingManageButton = ({
 export const MarkingItem = ({
   markingId,
   onRegionClick,
+  onDelete,
   nickName,
   region,
   pet,
@@ -100,7 +107,9 @@ export const MarkingItem = ({
           <h2 className="btn-2 text-grey-900">{region}</h2>
         </div>
 
-        {isOwner && <MarkingManageButton markingId={markingId} />}
+        {isOwner && (
+          <MarkingManageButton markingId={markingId} onDelete={onDelete} />
+        )}
       </div>
 
       <div className="flex justify-between items-center gap-1 flex-1">

--- a/src/features/marking/ui/markingItem.tsx
+++ b/src/features/marking/ui/markingItem.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { FollowingToggle } from "@/features/follow/ui";
 import type { Marking } from "@/entities/marking/api";
 import type { PetInfo } from "@/entities/profile/api";
 import { API_BASE_URL } from "@/shared/constants";
-import { formatDateToYearMonthDay, useClickOutside } from "@/shared/lib";
+import { formatDateToYearMonthDay, useDropdown } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { DividerLine } from "@/shared/ui/divider";
 import { MoreIcon, MyLocationIcon } from "@/shared/ui/icon";
@@ -26,10 +26,8 @@ const MarkingManageButton = ({
   markingId,
   onDelete,
 }: Pick<MarkingItemProps, "markingId" | "onDelete">) => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
   const ref = useRef<HTMLDivElement>(null);
-
-  useClickOutside(ref, () => setIsOpen(false));
+  const { isOpen, setIsOpen } = useDropdown(ref);
 
   const { mutate: deleteMarking } = useDeleteMarking({
     onSuccess: () => {

--- a/src/shared/lib/clickOutside.ts
+++ b/src/shared/lib/clickOutside.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+/**
+ * 요소 외부를 클릭했을 때 실행할 함수를 등록하는 Hook
+ *
+ * @param ref ref가 참조하는 요소 외부를 클릭했을 때 onOutsideClick 실행
+ * @param onOutsideClick 외부를 클릭했을 때 실행할 함수
+ */
+
+export const useClickOutside = (
+  ref: React.RefObject<HTMLElement>,
+  onOutsideClick: (event?: MouseEvent) => void,
+) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onOutsideClick(event);
+      }
+    };
+
+    document.addEventListener("click", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [ref, onOutsideClick]);
+};

--- a/src/shared/lib/dropdown.ts
+++ b/src/shared/lib/dropdown.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { RefObject, useEffect, useRef, useState } from "react";
 
 /**
  * 요소 외부를 클릭했을 때 실행할 함수를 등록하는 Hook
@@ -7,14 +7,13 @@ import { useEffect } from "react";
  * @param onOutsideClick 외부를 클릭했을 때 실행할 함수
  */
 
-export const useClickOutside = (
-  ref: React.RefObject<HTMLElement>,
-  onOutsideClick: (event?: MouseEvent) => void,
-) => {
+export const useDropdown = (ref: RefObject<HTMLElement>) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (ref.current && !ref.current.contains(event.target as Node)) {
-        onOutsideClick(event);
+        setIsOpen(false);
       }
     };
 
@@ -24,4 +23,6 @@ export const useClickOutside = (
       document.removeEventListener("click", handleClickOutside);
     };
   }, [ref, onOutsideClick]);
+
+  return { isOpen, setIsOpen };
 };

--- a/src/shared/lib/dropdown.ts
+++ b/src/shared/lib/dropdown.ts
@@ -1,10 +1,11 @@
-import { RefObject, useEffect, useRef, useState } from "react";
+import { RefObject, useEffect, useState } from "react";
 
 /**
- * 요소 외부를 클릭했을 때 실행할 함수를 등록하는 Hook
+ * 드롭다운 요소를 관리하는 커스텀 훅
+ * 외부를 클릭하면 요소를 표시하지 않습니다.
  *
- * @param ref ref가 참조하는 요소 외부를 클릭했을 때 onOutsideClick 실행
- * @param onOutsideClick 외부를 클릭했을 때 실행할 함수
+ * @param isOpen 요소 표시 여부
+ * @param setIsOpen 요소 표시 여부를 변경하는 함수
  */
 
 export const useDropdown = (ref: RefObject<HTMLElement>) => {

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,5 +1,3 @@
-import { useState, useEffect } from "react";
-
 export * from "./cookie";
 export * from "./overlay";
 export * from "./debounce";
@@ -9,30 +7,4 @@ export * from "./apiClient";
 export * from "./error";
 export * from "./snackbar";
 export * from "./scroll";
-// TODO refactoring 시 해당 훅 제거 하기
-/**
- * useDebounce 훅은 입력된 콜백 함수를 지연시간만큼 지연시킨 후 실행합니다.
- * 첫 번째 인수인 콜백 함수는 디바운스 될 값을 반환해야 합니다.
- * 두 번째 인수인 initialValue는 디바운스 되기 전 초기 값을 설정합니다.
- * 세 번째 인수인 delay는 디바운스 지연시간을 설정합니다.
- */
-export const useDebounce = <F extends (...args: unknown[]) => ReturnType<F>>(
-  callbackFn: F,
-  initialValue: ReturnType<F>,
-  delay: number = 500,
-) => {
-  const [debouncedValue, setDebouncedValue] =
-    useState<ReturnType<F>>(initialValue);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(callbackFn());
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [callbackFn, delay]);
-
-  return debouncedValue;
-};
+export * from "./clickOutside";

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -7,4 +7,4 @@ export * from "./apiClient";
 export * from "./error";
 export * from "./snackbar";
 export * from "./scroll";
-export * from "./clickOutside";
+export * from "./dropdown";

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { useMap } from "@vis.gl/react-google-maps";
 import {
   useGetMapCurrentBounds,
@@ -12,6 +13,7 @@ import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
 import { MarkingList } from "./markingList";
 
 export const PlaceMarkingList = () => {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { boundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
@@ -62,6 +64,11 @@ export const PlaceMarkingList = () => {
                 lng: marking.lng,
               });
               map.setZoom(19);
+            }}
+            onDelete={() => {
+              queryClient.invalidateQueries({
+                queryKey: ["markingList"],
+              });
             }}
             // todo isLiked, isBookmarked 설정
             isLiked={false}


### PR DESCRIPTION
# 관련 이슈 번호

#155 

# 설명

## 요소의 외부를 클릭하면 함수를 실행하는 훅 생성

마킹에서 더보기 버튼을 클릭하면 나타나는 모달은 모달 외부를 클릭하면 닫혀야 합니다.
그 로직이 MarkingManageButton에 있어서 분리했습니다.

```typescript
export const useClickOutside = (
  ref: React.RefObject<HTMLElement>,
  onOutsideClick: (event?: MouseEvent) => void,
) => {
  useEffect(() => {
    const handleClickOutside = (event: MouseEvent) => {
      if (ref.current && !ref.current.contains(event.target as Node)) {
        onOutsideClick(event);
      }
    };

    document.addEventListener("click", handleClickOutside);

    return () => {
      document.removeEventListener("click", handleClickOutside);
    };
  }, [ref, onOutsideClick]);
};
```

## useDeleteMarking props에 onSuccess 추가

마킹은 모든 바텀 시트에서 삭제가 가능합니다. 어디서 삭제되느냐에 따라 무효화해야 할 쿼리키가 달라집니다.
MarkingItem에 onDelete를 추가하여 무효화를 진행합니다.

```typescript
<MarkingItem
           onDelete={() => {
              queryClient.invalidateQueries({
                queryKey: ["markingList"],
              });
            }}
/>
```

MarkingItem 내부에서 useDeleteMarking의 onSuccess로 onDelete가 전달됩니다.

```typescript
const MarkingManageButton = ({
  markingId,
  onDelete,
}: Pick<MarkingItemProps, "markingId" | "onDelete">) => {
  // ...

  const { mutate: deleteMarking } = useDeleteMarking({
    onSuccess: () => {
      onDelete?.();
    },
  });
}
```
