### PR TITLE
[Refactor]  팔로잉 팔로우 토글 리팩토링 , 마킹 아이템 팔로잉 팔로우 아이템 장착

### DIFF
--- a/src/features/follow/ui/followingToggle.tsx
+++ b/src/features/follow/ui/followingToggle.tsx
@@ -4,20 +4,16 @@ import { Button } from "@/shared/ui/button";
 import { ButtonProps } from "@/shared/ui/button/Button";
 import { usePostFollowing, useDeleteFollowing } from "../api";
 
-type FollowingButtonType = "default" | "mini";
-
-interface FollowingToggleProps<T extends FollowingButtonType> {
+interface FollowingToggleProps {
   nickname: Nickname;
   isFollowing: boolean;
-  followingButtonType: T;
-  size: T extends "default" ? ButtonProps["size"] : never;
+  size: Extract<ButtonProps["size"], "small" | "xSmall">;
 }
-export const FollowingToggle = <T extends FollowingButtonType>({
+export const FollowingToggle = ({
   nickname,
   isFollowing,
-  followingButtonType,
   size,
-}: FollowingToggleProps<T>) => {
+}: FollowingToggleProps) => {
   const [_isFollowing, _setIsFollowing] = useState(() => isFollowing);
 
   const { mutate: postFollowing, isPending: isFollowingPending } =
@@ -59,60 +55,26 @@ export const FollowingToggle = <T extends FollowingButtonType>({
 
   if (_isFollowing) {
     return (
-      <UnFollowingButton onClick={handleOptimisticUnFollowing} size={size} />
-    );
-  }
-  return (
-    <FollowingButton
-      onClick={handleOptimisticFollowing}
-      buttonType={followingButtonType}
-      size={size}
-    />
-  );
-};
-
-interface FollowingButtonProps<T extends FollowingButtonType>
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  buttonType: T;
-  size?: T extends "default" ? ButtonProps["size"] : never;
-}
-
-export const FollowingButton = <T extends FollowingButtonType>({
-  buttonType,
-  size,
-  ...props
-}: FollowingButtonProps<T>) => {
-  if (buttonType === "default") {
-    return (
       <Button
-        size={size || "small"}
-        variant="filled"
-        colorType="primary"
+        variant="outlined"
+        colorType="tertiary"
         fullWidth={false}
-        {...props}
+        size={size}
+        onClick={handleOptimisticUnFollowing}
       >
-        팔로우
+        팔로잉
       </Button>
     );
   }
   return (
-    <button className="btn-3 text-tangerine-500" {...props}>
-      팔로우
-    </button>
-  );
-};
-
-export const UnFollowingButton = (
-  props: Omit<ButtonProps, "variant" | "colorType" | "children">,
-) => {
-  return (
     <Button
-      variant="outlined"
-      colorType="tertiary"
+      size={size}
+      variant="filled"
+      colorType="primary"
       fullWidth={false}
-      {...props}
+      onClick={handleOptimisticFollowing}
     >
-      팔로잉
+      팔로우
     </Button>
   );
 };

--- a/src/features/marking/ui/markingItem.stories.tsx
+++ b/src/features/marking/ui/markingItem.stories.tsx
@@ -66,6 +66,10 @@ const meta: Meta<typeof MarkingItem> = {
       description: "북마크 여부를 나타냅니다.",
       control: "boolean",
     },
+    isFollowing: {
+      description: "팔로잉 여부를 나타냅니다.",
+      control: "boolean",
+    },
   },
   args: {
     markingId: 1,
@@ -93,6 +97,7 @@ const meta: Meta<typeof MarkingItem> = {
     },
     isLiked: false,
     isBookmarked: false,
+    isFollowing: false,
   },
 };
 

--- a/src/features/marking/ui/markingItem.tsx
+++ b/src/features/marking/ui/markingItem.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
+import { FollowingToggle } from "@/features/follow/ui";
 import type { Marking } from "@/entities/marking/api";
 import type { PetInfo } from "@/entities/profile/api";
 import { API_BASE_URL } from "@/shared/constants";
 import { formatDateToYearMonthDay } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { Button } from "@/shared/ui/button";
 import { DividerLine } from "@/shared/ui/divider";
 import { MoreIcon, MyLocationIcon } from "@/shared/ui/icon";
 import { ImgSlider } from "@/shared/ui/imgSlider";
@@ -19,6 +19,7 @@ interface MarkingItemProps
   pet: Pick<PetInfo, "petId" | "profile" | "name">;
   isLiked: boolean;
   isBookmarked: boolean;
+  isFollowing: boolean;
 }
 const MarkingManageButton = ({
   markingId,
@@ -100,6 +101,7 @@ export const MarkingItem = ({
   isOwner = false,
   isLiked,
   isBookmarked,
+  isFollowing,
   countData: { likedCount, savedCount },
 }: MarkingItemProps) => {
   return (
@@ -129,14 +131,11 @@ export const MarkingItem = ({
         <span className="flex-1 body-2 text-grey-500">{pet.name}</span>
 
         {!isOwner && (
-          <Button
-            colorType="tertiary"
+          <FollowingToggle
+            nickname={nickName}
             size="xSmall"
-            variant="outlined"
-            fullWidth={false}
-          >
-            팔로우
-          </Button>
+            isFollowing={isFollowing}
+          />
         )}
       </div>
 

--- a/src/mocks/data/markingList.ts
+++ b/src/mocks/data/markingList.ts
@@ -20,7 +20,7 @@ export const getMockMarkingList = ({
     regDt: new Date().toISOString(),
     userId: index + 1,
     nickName: `User${index + 1}`,
-    isOwner: true,
+    isOwner: index === 0 ? true : false,
     isTempSaved: false,
     lat: southBottomLat + Math.random() * (northTopLat - southBottomLat),
     lng: southLeftLng + Math.random() * (northRightLng - southLeftLng),

--- a/src/widgets/follow/followerUserItem.tsx
+++ b/src/widgets/follow/followerUserItem.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useDeleteFollower, usePostFollowing } from "@/features/follow/api";
-import { FollowingButton, DeleteFollowerButton } from "@/features/follow/ui";
+import { DeleteFollowerButton } from "@/features/follow/ui";
 import { ProfileLink } from "@/features/profile/ui";
 import type {
   Nickname,
@@ -73,10 +73,12 @@ export const FollowerUserItem = ({
         <div className="flex gap-2">
           <p className="title-2 text-grey-700">{nickname}</p>
           {!_isFollowing && (
-            <FollowingButton
-              buttonType="mini"
+            <button
+              className="btn-3 text-tangerine-500"
               onClick={handleOptimisticFollowing}
-            />
+            >
+              팔로우
+            </button>
           )}
         </div>
         <p className="body-3 text-grey-500">{petName}</p>

--- a/src/widgets/follow/followingUserItem.tsx
+++ b/src/widgets/follow/followingUserItem.tsx
@@ -48,7 +48,6 @@ export const FollowingUserItem = ({
         <FollowingToggle
           nickname={nickname}
           isFollowing={isFollowing}
-          followingButtonType="default"
           size="small"
         />
       )}

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/features/map/hooks";
 import { MarkingItem, SortTypeFilter } from "@/features/marking/ui";
 import { useGetMarkingList } from "@/entities/marking/api";
+import { useGetMyFollowingIdsMap } from "@/entities/profile/api";
 import { ROUTER_PATH } from "@/shared/constants";
 import { useInfiniteScroll } from "@/shared/lib";
 import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
@@ -15,6 +16,7 @@ export const PlaceMarkingList = () => {
   const navigate = useNavigate();
   const { boundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
+  const { data: myFollowingMap } = useGetMyFollowingIdsMap();
   const getMapBounds = useGetMapCurrentBounds();
 
   const {
@@ -32,6 +34,11 @@ export const PlaceMarkingList = () => {
       fetchNextPage();
     }
   });
+
+  // TODO 로딩 상태 구현 하기
+  if (!markingList || !myFollowingMap) {
+    return null;
+  }
 
   const map = useMap();
 
@@ -66,6 +73,7 @@ export const PlaceMarkingList = () => {
             // todo isLiked, isBookmarked 설정
             isLiked={false}
             isBookmarked={false}
+            isFollowing={myFollowingMap[marking.userId]}
             {...marking}
           />
         ))}

--- a/src/widgets/profile/ui/profileOverview.tsx
+++ b/src/widgets/profile/ui/profileOverview.tsx
@@ -45,7 +45,6 @@ export const ProfileOverView = ({
           <FollowingToggle
             nickname={nickname}
             isFollowing={isFollowing}
-            followingButtonType="default"
             size="xSmall"
           />
         </div>


### PR DESCRIPTION
# 관련 이슈 번호
 close #418 
# 설명

5일전에 작업해놓고 깜박하고 안올려뒀었네요 

# 이슈 본문

문제 상황은 다음과 같습니다. 

팔로잉 ,팔로워 버튼은 다음과 같은 경우에 사용 됩니다. 

남의 프로필에서  , 마킹 게시글에서 , 팔로잉 리스트 목록에서 , 그리고 마지막으로 팔로워 리스트에서 

![image](https://github.com/user-attachments/assets/a4aa8f4d-a3f9-42b8-a0f4-468f41f391d1)

문제는 바로 팔로워 리스트에 존재하는 팔로잉 버튼입니다. 

얘는 토글도 아니예요 

얘 하나 때문에 현재 팔로잉 토글에서 `followingButtonType` 이라는 말도 안되는 `props` 를 받고 

`followingButtonType = mini` 면 `size` 를 `props` 로 받지 않는 둥 매우 요상합니다. 

![image](https://github.com/user-attachments/assets/e5adf78e-2f3d-4ba5-92f0-439af3692810)

이에 팔로잉 팔로워 토글은 단순히  `size` 만 `props` 로 받도록 리팩토링 합니다. 

미니 팔로잉 버튼은 따로 컴포넌트로 만들지 않고 `jsx` 로 생성하도록 합니다 

이제 팔로잉 , 팔로우 토글은 이렇게 생긴 버튼들만을 의미 합니다.

![image](https://github.com/user-attachments/assets/83036e97-6e13-43dc-81fc-02d011a405cb)

이전 팔로워 리스트에 존재하던 팔로우 버튼은 단순 jsx  로 변경되었습니다 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
