### PR TITLE
[Refactor] CompressFile 압축 후 이미지 확장자 명 원본 이미지 확장자로 저장

### DIFF
--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -2,8 +2,8 @@ interface compressFileImageOptions {
   maxSize: number;
   compactSize: number;
   quality: number;
-  extension: "jpeg" | "webp" | "png";
 }
+
 type compressFileImage = (
   file: File,
   options?: compressFileImageOptions,
@@ -13,7 +13,6 @@ const defaultCompressOptions: compressFileImageOptions = {
   maxSize: 2 ** 20, // 최대 파일 크기 1MB
   compactSize: 2 ** 10 * 100, // 압축 후 최대 파일 크기 100KB
   quality: 0.7,
-  extension: "webp",
 };
 
 /**
@@ -27,7 +26,7 @@ const defaultCompressOptions: compressFileImageOptions = {
  * @param options maxSize: 압축할 파일의 최대 크기, compactSize: 압축된 파일의 최소 크기 , quality: 압축 품질, extension: 압축할 파일의 확장자
  */
 export const compressFileImage: compressFileImage = async (file, options) => {
-  const { maxSize, compactSize, quality, extension } = {
+  const { maxSize, compactSize, quality } = {
     ...defaultCompressOptions,
     ...options,
   };
@@ -77,6 +76,7 @@ export const compressFileImage: compressFileImage = async (file, options) => {
   canvas.height = height * ratio;
   context.drawImage(image, 0, 0, canvas.width, canvas.height);
 
+  const [fileName, fileExtension] = file.name.split(".");
   const compressedFile: Promise<File> = new Promise((resolve) => {
     canvas.toBlob(
       (blob) => {
@@ -86,13 +86,13 @@ export const compressFileImage: compressFileImage = async (file, options) => {
           return;
         }
         resolve(
-          new File([blob], file.name, {
-            type: `image/${extension}`,
+          new File([blob], fileName, {
+            type: `image/${fileExtension}`,
             lastModified: Date.now(),
           }),
         );
       },
-      `image/${extension}`,
+      `image/${fileExtension}`,
       quality,
     );
   });

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -76,7 +76,8 @@ export const compressFileImage: compressFileImage = async (file, options) => {
   canvas.height = height * ratio;
   context.drawImage(image, 0, 0, canvas.width, canvas.height);
 
-  const [fileName, fileExtension] = file.name.split(".");
+  const [fileExtension, ...fileName] = file.name.split(".").reverse();
+
   const compressedFile: Promise<File> = new Promise((resolve) => {
     canvas.toBlob(
       (blob) => {
@@ -86,7 +87,7 @@ export const compressFileImage: compressFileImage = async (file, options) => {
           return;
         }
         resolve(
-          new File([blob], fileName, {
+          new File([blob], fileName.join("."), {
             type: `image/${fileExtension}`,
             lastModified: Date.now(),
           }),


### PR DESCRIPTION
# 관련 이슈 번호
 close #419   
# 설명

5일 전에 작업 한 건데 깜박하고 피알을 안올렸더군요 

compressFile 에서 압축 후 반환하는 파일의 확장자 명을 webp가 아닌 원본 파일 확장자 명으로 변경하여 저장합니다 

파일의 확장자를 억지로 바꿨을 때 발생 가능한 문제를 정확히 가늠하고 있지 못하고 원본 확장자 명으로 변경 할 때와 webp로 변경했을 때의 용량 차이가 없거나 크지 않았기 때문입니다 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
