### PR TITLE
[Feat] 비밀번호 확인 상태 메시지 변경

### DIFF
--- a/src/features/auth/ui/SignUpByEmailForm.stories.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.stories.tsx
@@ -481,7 +481,7 @@ export const Test: Story = {
             await userEvent.type($passwordConfirmInput, validPassword);
 
             const $statusText =
-              await canvas.findByText("사용가능한 비밀번호 입니다");
+              await canvas.findByText("비밀번호가 일치합니다");
 
             expect($statusText).toBeInTheDocument();
             expect($statusText).toHaveClass(statusTextColor.valid);

--- a/src/features/auth/ui/SignUpByEmailForm.tsx
+++ b/src/features/auth/ui/SignUpByEmailForm.tsx
@@ -391,7 +391,7 @@ const PasswordConfirm = () => {
   let statusText = "";
 
   if (isValidPassword) {
-    if (isValidConfirmPassword) statusText = "사용가능한 비밀번호 입니다";
+    if (isValidConfirmPassword) statusText = "비밀번호가 일치합니다";
     else statusText = "비밀번호가 서로 일치하지 않습니다";
   } else {
     if (isValidConfirmPassword) statusText = "";


### PR DESCRIPTION
# 관련 이슈 번호
close #437 
# 설명

 디자인 변경에 맞춰 비밀번호 확인란 상태메시지를 변경 합니다 

> 비밀번호 변경 모달에선 이미 비밀번호 컨펌 상태 텍스트가 비밀번호가 일치합니다더군요 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
