### PR TITLE
[Feat] 스낵바 애니메이션 생성 및 타이머 로직 리팩토링

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -176,3 +176,57 @@ img[alt="Google"] {
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
+
+/* 스낵바 오픈 애니메이션 */
+@keyframes snackbar-open-default {
+  from {
+    transform: translateY(-100%) translateX(-50%);
+  }
+  to {
+    transform: translateY(1rem) translateX(-50%);
+  }
+}
+
+@keyframes snackbar-open-map {
+  from {
+    transform: translateY(-100%) translateX(-50%);
+  }
+  to {
+    transform: translateY(5rem) translateX(-50%);
+  }
+}
+
+/* 스낵바 클로즈 애니메이션 */
+@keyframes snackbar-close-default {
+  from {
+    transform: translateY(1rem) translateX(-50%);
+  }
+  to {
+    transform: translateY(-100%) translateX(-50%);
+  }
+}
+
+@keyframes snackbar-close-map {
+  from {
+    transform: translateY(5rem) translateX(-50%);
+  }
+  to {
+    transform: translateY(-100%) translateX(-50%);
+  }
+}
+
+.snackbar-open-default {
+  animation: snackbar-open-default 0.5s ease-in-out forwards;
+}
+
+.snackbar-open-map {
+  animation: snackbar-open-map 0.5s ease-in-out forwards;
+}
+
+.snackbar-close-default {
+  animation: snackbar-close-default 0.5s ease-in-out forwards;
+}
+
+.snackbar-close-map {
+  animation: snackbar-close-map 0.5s ease-in-out forwards;
+}

--- a/src/shared/lib/snackbar.tsx
+++ b/src/shared/lib/snackbar.tsx
@@ -10,7 +10,7 @@ import { Snackbar, SnackBarProps } from "../ui/snackbar";
  * @returns {Function} handleOpenSnackbar - 스낵바를 여는 함수.
  * @param {React.ReactNode} text - 스낵바에 표시할 텍스트.
  * @param {Object} [snackbarOptions] - 스낵바 옵션.
- * @param {number} [snackbarOptions.autoHideDuratio sn=1000] - 스낵바가 자동으로 닫히기까지의 시간(ms).
+ * @param {number} [snackbarOptions.autoHideDuratio] - 스낵바가 자동으로 닫히기까지의 시간(ms).
  * @param {Omit<SnackBarProps, "children">} [snackbarOptions] - 스낵바 컴포넌트의 기타 속성.
  */
 export const useSnackBar = () => {

--- a/src/shared/lib/snackbar.tsx
+++ b/src/shared/lib/snackbar.tsx
@@ -1,4 +1,4 @@
-import { flushSync } from "react-dom";
+import { useEffect, useState } from "react";
 import { SNACKBAR_ID } from "../constants";
 import { useOverlayStore } from "../store/overlay";
 import { Snackbar, SnackBarProps } from "../ui/snackbar";
@@ -10,29 +10,38 @@ import { Snackbar, SnackBarProps } from "../ui/snackbar";
  * @returns {Function} handleOpenSnackbar - 스낵바를 여는 함수.
  * @param {React.ReactNode} text - 스낵바에 표시할 텍스트.
  * @param {Object} [snackbarOptions] - 스낵바 옵션.
- * @param {number} [snackbarOptions.autoHideDuratio] - 스낵바가 자동으로 닫히기까지의 시간(ms).
+ * @param {number} [snackbarOptions.autoHideDuration] - 스낵바가 자동으로 닫히기까지의 시간(ms).
  * @param {Omit<SnackBarProps, "children">} [snackbarOptions] - 스낵바 컴포넌트의 기타 속성.
  */
 export const useSnackBar = () => {
   const addOverlay = useOverlayStore((state) => state.addOverlay);
   const removeOverlay = useOverlayStore((state) => state.removeOverlay);
+  const [snackbarProps, setSnackbarProps] = useState<SnackBarProps | null>(
+    null,
+  );
 
-  const handleOpenSnackbar = (
-    text: React.ReactNode,
-    snackbarOptions?: Omit<SnackBarProps, "children">,
-  ) => {
-    // 열려있는 스낵바가 있다면 제거합니다.
-    // ! handleOpenSnackbar 함수는 동기적으로 동작해야 하므로 flushSync를 사용합니다.
-    flushSync(() => {
-      removeOverlay(SNACKBAR_ID);
-    });
+  useEffect(() => {
+    if (snackbarProps === null) return;
 
+    const { children, ...snackbarOptions } = snackbarProps;
     addOverlay({
       id: SNACKBAR_ID,
-      component: <Snackbar {...snackbarOptions}>{text}</Snackbar>,
+      component: <Snackbar {...snackbarOptions}>{children}</Snackbar>,
       options: {
         disableInteraction: false,
       },
+    });
+  }, [snackbarProps]);
+
+  const handleOpenSnackbar = (
+    children: React.ReactNode,
+    snackbarOptions?: Omit<SnackBarProps, "children">,
+  ) => {
+    removeOverlay(SNACKBAR_ID);
+
+    setSnackbarProps({
+      ...snackbarOptions,
+      children,
     });
   };
 

--- a/src/shared/lib/snackbar.tsx
+++ b/src/shared/lib/snackbar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { flushSync } from "react-dom";
 import { SNACKBAR_ID } from "../constants";
 import { useOverlayStore } from "../store/overlay";
 import { Snackbar, SnackBarProps } from "../ui/snackbar";
@@ -10,69 +10,26 @@ import { Snackbar, SnackBarProps } from "../ui/snackbar";
  * @returns {Function} handleOpenSnackbar - 스낵바를 여는 함수.
  * @param {React.ReactNode} text - 스낵바에 표시할 텍스트.
  * @param {Object} [snackbarOptions] - 스낵바 옵션.
- * @param {number} [snackbarOptions.autoHideDuration=1000] - 스낵바가 자동으로 닫히기까지의 시간(ms).
+ * @param {number} [snackbarOptions.autoHideDuratio sn=1000] - 스낵바가 자동으로 닫히기까지의 시간(ms).
  * @param {Omit<SnackBarProps, "children">} [snackbarOptions] - 스낵바 컴포넌트의 기타 속성.
  */
 export const useSnackBar = () => {
   const addOverlay = useOverlayStore((state) => state.addOverlay);
   const removeOverlay = useOverlayStore((state) => state.removeOverlay);
 
-  const timerId = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const SNACKBAR_POSITION_CLASS_NAME = {
-    default: "absolute top-4 left-1/2 transform -translate-x-1/2",
-    map: "absolute top-16 left-1/2 transform -translate-x-1/2 translate-y-1/2",
-  } as const;
-
-  useEffect(() => {
-    return () => {
-      if (timerId.current) {
-        clearTimeout(timerId.current);
-      }
-    };
-  }, []);
-
   const handleOpenSnackbar = (
     text: React.ReactNode,
-    snackbarOptions?: {
-      autoHideDuration?: number;
-      type?: keyof typeof SNACKBAR_POSITION_CLASS_NAME;
-    } & Omit<SnackBarProps, "children">,
+    snackbarOptions?: Omit<SnackBarProps, "children">,
   ) => {
-    // TODO authHideDuration 기간 정하기
-
-    const {
-      autoHideDuration,
-      type = "default",
-      className,
-      ...snackbarProps
-    } = {
-      autoHideDuration: 1000,
-      type: "default",
-      className: "",
-      ...snackbarOptions,
-    };
-    // autoHideDuration 시간 후 스낵바를 닫습니다.
-    // 이 때 타이머 발동 전 기존 스낵바가 다시 열리게 되면 clearTimeout을 호출하여 이전 타이머를 초기화 합니다.
-    if (timerId.current) {
-      clearTimeout(timerId.current);
-    }
-    timerId.current = setTimeout(() => {
-      removeOverlay(SNACKBAR_ID);
-    }, autoHideDuration);
-
     // 열려있는 스낵바가 있다면 제거합니다.
-    removeOverlay(SNACKBAR_ID);
+    // ! handleOpenSnackbar 함수는 동기적으로 동작해야 하므로 flushSync를 사용합니다.
+    flushSync(() => {
+      removeOverlay(SNACKBAR_ID);
+    });
 
     addOverlay({
       id: SNACKBAR_ID,
-      component: (
-        <Snackbar
-          {...snackbarProps}
-          className={`${SNACKBAR_POSITION_CLASS_NAME[type]} ${className}`}
-        >
-          {text}
-        </Snackbar>
-      ),
+      component: <Snackbar {...snackbarOptions}>{text}</Snackbar>,
       options: {
         disableInteraction: false,
       },

--- a/src/shared/ui/snackbar/Snackbar.stories.tsx
+++ b/src/shared/ui/snackbar/Snackbar.stories.tsx
@@ -74,8 +74,7 @@ export const Default: Story = {
           className="px-2 py-2 bg-grey-200"
           onClick={() =>
             handleOpenSnackbar("2번 스낵바 오픈", {
-              className:
-                "absolute top-16 left-1/2 transform -translate-x-1/2 translate-y-1/2 bg-grey-200",
+              type: "map",
             })
           }
         >

--- a/src/shared/ui/snackbar/Snackbar.tsx
+++ b/src/shared/ui/snackbar/Snackbar.tsx
@@ -1,10 +1,12 @@
+import { useState, useRef, useEffect } from "react";
 import { SNACKBAR_ID } from "@/shared/constants";
 import { useOverlayStore } from "@/shared/store/overlay";
 import { CloseIcon } from "../icon";
 
 export interface SnackBarProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
-  autoHideDuration?: number | null;
+  children?: React.ReactNode;
+  type?: "default" | "map";
+  autoHideDuration?: number;
   className?: string;
 }
 
@@ -15,16 +17,47 @@ export interface SnackBarProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 export const Snackbar = ({
   children,
-  className = "absolute top-4 left-1/2 transform -translate-x-1/2",
+  autoHideDuration = 2000,
+  type = "default",
+  className = "",
   ...props
 }: SnackBarProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(true);
   const removeOverlay = useOverlayStore((state) => state.removeOverlay);
+  const ANIMATION_DURATION = 500;
+  // 스낵바가 닫히는 애니메이션을 위한 타이머
+  const closeAnimationTimeId = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  // 스낵바가 닫히는 타이머
+  const closeTimerId = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const baseClassName =
-    "shadow-custom-2 inline-flex min-w-[328px] max-w-96 items-center justify-between rounded-2xl bg-grey-0 py-1 pl-4 pr-3";
+  useEffect(() => {
+    closeAnimationTimeId.current = setTimeout(() => {
+      setIsOpen(false);
+    }, autoHideDuration - ANIMATION_DURATION);
+
+    closeTimerId.current = setTimeout(() => {
+      removeOverlay(SNACKBAR_ID);
+    }, autoHideDuration);
+
+    return () => {
+      if (closeAnimationTimeId.current) {
+        clearTimeout(closeAnimationTimeId.current);
+      }
+      if (closeTimerId.current) {
+        clearTimeout(closeTimerId.current);
+      }
+    };
+  }, []);
 
   return (
-    <div className={`${baseClassName} ${className}`} {...props}>
+    <div
+      className={`${isOpen ? `snackbar-open-${type}` : `snackbar-close-${type}`} 
+      fixed left-1/2 top-0 shadow-custom-2 inline-flex min-w-[328px] max-w-96 items-center justify-between rounded-2xl bg-grey-0 py-1 pl-4 pr-3
+      ${className}`}
+      {...props}
+    >
       <div className="body-2 text-grey-700 flex flex-col">{children}</div>
       <button
         className="h-10"


### PR DESCRIPTION
# 관련 이슈 번호
close #441 
# 설명
![snackbar2](https://github.com/user-attachments/assets/a86b3ae7-fbc4-46f7-9392-c17f5345d98a)
![sncakbar1](https://github.com/user-attachments/assets/ff4be081-2fc4-4d6e-9e60-54040df46fbb)

우선 애니메이션은 단순히 뷰포트 밖에서 원하는 레이아웃에서 1rem 만큼 떨어진 곳 까지 translate 되도록 애니메이션을 생성하고 사용해줬습니다 

해당 애니메이션은 global.css 에서 정의 된 후 스낵바 컴포넌트에서 내부 타이머에 따라 변경되는 상태에 따라 다른 애니메이션을 시작 합니다, 

```tsx
.snackbar-open-default {
  animation: snackbar-open-default 0.5s ease-in-out forwards;
}

.snackbar-open-map {
  animation: snackbar-open-map 0.5s ease-in-out forwards;
}

.snackbar-close-default {
  animation: snackbar-close-default 0.5s ease-in-out forwards;
}

.snackbar-close-map {
  animation: snackbar-close-map 0.5s ease-in-out forwards;
}
```
```tsx
/**
 * InfoSnackBar 컴포넌트는 사용자에게 정보를 제공하는 메시지를 표시합니다.
 * @param children - 스낵바에 표시할 메시지
 * @param className - 스낵바의 위치를 지정하는 클래스명
 */
export const Snackbar = ({
  children,
  autoHideDuration = 2000,
  type = "default",
  className = "",
  ...props
}: SnackBarProps) => {
  const [isOpen, setIsOpen] = useState<boolean>(true);
  const removeOverlay = useOverlayStore((state) => state.removeOverlay);
  const ANIMATION_DURATION = 500;
  // 스낵바가 닫히는 애니메이션을 위한 타이머
  const closeAnimationTimeId = useRef<ReturnType<typeof setTimeout> | null>(
    null,
  );
  // 스낵바가 닫히는 타이머
  const closeTimerId = useRef<ReturnType<typeof setTimeout> | null>(null);

  useEffect(() => {
    closeAnimationTimeId.current = setTimeout(() => {
      setIsOpen(false);
    }, autoHideDuration - ANIMATION_DURATION);

    closeTimerId.current = setTimeout(() => {
      removeOverlay(SNACKBAR_ID);
    }, autoHideDuration);

    return () => {
      if (closeAnimationTimeId.current) {
        clearTimeout(closeAnimationTimeId.current);
      }
      if (closeTimerId.current) {
        clearTimeout(closeTimerId.current);
      }
    };
  }, []);

  return (
    <div
      className={`${isOpen ? `snackbar-open-${type}` : `snackbar-close-${type}`} 
      fixed left-1/2 top-0 shadow-custom-2 inline-flex min-w-[328px] max-w-96 items-center justify-between rounded-2xl bg-grey-0 py-1 pl-4 pr-3
      ${className}`}
      {...props}
    >
      <div className="body-2 text-grey-700 flex flex-col">{children}</div>
      <button
        className="h-10"
        onClick={() => removeOverlay(SNACKBAR_ID)}
        aria-label="스낵바 닫기"
      >
        <CloseIcon />
      </button>
    </div>
  );
};
```

이전과 달라진 로직으로는 스낵바를 자동으로 닫게 하는 타이머의 로직이 커스텀훅이 아닌 컴포넌트 내부의  useEffect 로 이동 되었다는 점과 

애니메이션을 동작시키기 위해 ` 닫히는 시간 - 애니메이션 동작 시간` 후에 발동되는 타이머가 추가되었다는 점입니다, 

> 추가로 top 을 이용해 스낵바의 위치를 지정하던 로직에서 translate 를 이용해 위치를 지정해주도록 변경했습니다
> 애니메이션 기간 동안 지속적으로 top 을 계산해 레이아웃 단계를 거치고 싶지 않았기 때문입니다

# 왜 타이머 이벤트를 커스텀 훅이 아닌 컴포넌트 내부로 옮겼을까 ?

애니메이션을 주기 위해선 오버레이에서 제거 되기 전 애니메이션이 발동 될 수 있도록 클래스 명을 변경해줘야했습니다 

그리고 이렇게 변경해주는 로직은 이미 추가 된 컴포넌트 내에서만 일어날 수 있습니다.
> 만약 컴포넌트 외부에서 애니메이션을 주입 시키고 싶다면 오픈 애니메이션이 들어간 스낵바를 오버레이에 추가하고 , 닫아야 할 때 기존 컴포넌트를 언마운트 하고 클로즈 애니메이션이 들어간 컴포넌트를 마운트 시켜야 할 겁니다 
>  
> 아니면 직접 액추얼돔에 접근하거나 (이 방법은 피하고 싶었습니다)

그래서 애니메이션을 위한 타이머와 제거 되는 타이머를 한 곳에서 관리하기 위해 컴포넌트 내부로 옮겨주었습니다 

또, 타이머가 발화되고 제거되는 것은 컴포넌트 생명주기와 관련있기에 컴포넌트 내부에 있는 편이 더 나아 보이기도 했고요 

# useSnackbar 에서  flushSync 추가 

 ```tsx
export const useSnackBar = () => {
  const addOverlay = useOverlayStore((state) => state.addOverlay);
  const removeOverlay = useOverlayStore((state) => state.removeOverlay);

  const handleOpenSnackbar = (
    text: React.ReactNode,
    snackbarOptions?: Omit<SnackBarProps, "children">,
  ) => {
    // 열려있는 스낵바가 있다면 제거합니다.
    // ! handleOpenSnackbar 함수는 동기적으로 동작해야 하므로 flushSync를 사용합니다.
    flushSync(() => {
      removeOverlay(SNACKBAR_ID);
    });

    addOverlay({
      id: SNACKBAR_ID,
      component: <Snackbar {...snackbarOptions}>{text}</Snackbar>,
      options: {
        disableInteraction: false,
      },
    });
  };

  return handleOpenSnackbar;
};
```

핸들 오픈 스낵바가 호출 될 때 기존에 존재하는 스낵바를 지우고 다시 스낵바를 추가하는 로직이 있었는데 

이 부분이 정상적으로 작동하지 않더군요, 스낵바가 하나 띄워지고 나서 해당 스낵바가 언마운트 되기 전 까지 새로운 스낵바가 나타나지 않았습니다   

> 아마 이전 작업에서 새로운 스낵바가 생길 때 마다 언마운트 되고 새로운 스낵바가 나타난 거처럼 보인것은 실제 스낵바가 새롭게 나타난게 아니라 
> 타이머만 초기화 되어서 그렇게 보였던듯 싶습니다 

아마 하나의 함수 내에서 동일한 스토어의 상반되는 상태 변경을 처리 하고 있기에 그런 문제가 발생한 거 같습니다.

그래서 flushSync 를 이용해 명시적으로 오버레이에서 스낵바를 지운 후 스낵바를 추가하는 쪽으로 변경하여 문제를 해결했습니다 

공식 문서에서도 최대한 사용을 지양하라고 해서 추후 해결 방안을 생각해봐야 할 듯 싶습니다 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
