### PR TITLE
[Feat] 내 활동 바텀 시트 - 저장됨

### DIFF
--- a/src/entities/marking/api/getMyLikedMarkingList.ts
+++ b/src/entities/marking/api/getMyLikedMarkingList.ts
@@ -26,20 +26,21 @@ export interface GetMyLikedMarkingListResponse {
   };
 }
 
-export const useGetMyLikedMarkingList = () => {
+export const useGetMyLikedMarkingList = ({ enabled }: { enabled: boolean }) => {
   const { token } = useAuthStore.getState();
 
   return useInfiniteQuery({
     queryKey: ["myLikedMarkingList"],
-    queryFn: token
-      ? ({ pageParam = 0 }) =>
-          apiClient.get<GetMyLikedMarkingListResponse>(
-            MARKING_END_POINT.MY_LIKED({ offset: pageParam }),
-            {
-              withToken: true,
-            },
-          )
-      : skipToken,
+    queryFn:
+      token && enabled
+        ? ({ pageParam = 0 }) =>
+            apiClient.get<GetMyLikedMarkingListResponse>(
+              MARKING_END_POINT.MY_LIKED({ offset: pageParam }),
+              {
+                withToken: true,
+              },
+            )
+        : skipToken,
     getNextPageParam: ({ totalPages, pageAble }) => {
       return pageAble.pageNumber < totalPages - 1
         ? pageAble.pageNumber + 1
@@ -47,9 +48,7 @@ export const useGetMyLikedMarkingList = () => {
     },
     initialPageParam: 0,
     select: (data) => data.pages.flatMap((page) => page.markings),
-
     refetchOnWindowFocus: false,
-
     gcTime: 0,
   });
 };

--- a/src/entities/marking/api/getMySavedMarkerList.ts
+++ b/src/entities/marking/api/getMySavedMarkerList.ts
@@ -1,0 +1,56 @@
+import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
+import { apiClient } from "@/shared/lib";
+import { useAuthStore } from "@/shared/store";
+import { MARKING_END_POINT } from "../constants";
+import type { Marking } from "./getMarkingList";
+
+export interface GetMySavedMarkingListRequest {
+  offset: number;
+}
+
+export interface GetMySavedMarkingListResponse {
+  markings: Marking[];
+  totalElements: number;
+  totalPages: number;
+  pageAble: {
+    pageNumber: number;
+    pageSize: number;
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    offset: number;
+    paged: boolean;
+    unpaged: boolean;
+  };
+}
+
+export const useGetMySavedMarkingList = ({ enabled }: { enabled: boolean }) => {
+  const { token } = useAuthStore.getState();
+
+  return useInfiniteQuery({
+    queryKey: ["mySavedMarkingList"],
+    queryFn:
+      token && enabled
+        ? ({ pageParam = 0 }) =>
+            apiClient.get<GetMySavedMarkingListResponse>(
+              MARKING_END_POINT.MY_LIKED({ offset: pageParam }),
+              {
+                withToken: true,
+              },
+            )
+        : skipToken,
+    getNextPageParam: ({ totalPages, pageAble }) => {
+      return pageAble.pageNumber < totalPages - 1
+        ? pageAble.pageNumber + 1
+        : null;
+    },
+    initialPageParam: 0,
+    select: (data) => data.pages.flatMap((page) => page.markings),
+
+    enabled,
+    refetchOnWindowFocus: false,
+    gcTime: 0,
+  });
+};

--- a/src/entities/marking/api/index.ts
+++ b/src/entities/marking/api/index.ts
@@ -5,3 +5,5 @@ export * from "./getTemporaryMarkingList";
 export * from "./getUserMarkingList";
 export * from "./getMyMakerList";
 export * from "./getMyLikedMarkingList";
+export * from "./getMyLikedMarkingList";
+export * from "./getMySavedMarkerList";

--- a/src/entities/marking/hooks/index.ts
+++ b/src/entities/marking/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useGetMyActivityMarkingList";

--- a/src/entities/marking/hooks/useGetMyActivityMarkingList.ts
+++ b/src/entities/marking/hooks/useGetMyActivityMarkingList.ts
@@ -1,0 +1,16 @@
+import { useGetMyLikedMarkingList, useGetMySavedMarkingList } from "../api";
+
+export const useGetMyActivityMarkingList = (activeTab: "LIKED" | "SAVED") => {
+  const likedMarkingListResult = useGetMyLikedMarkingList({
+    enabled: activeTab === "LIKED",
+  });
+  const savedMarkingListResult = useGetMySavedMarkingList({
+    enabled: activeTab === "SAVED",
+  });
+
+  if (activeTab === "LIKED") {
+    return likedMarkingListResult;
+  }
+
+  return savedMarkingListResult;
+};

--- a/src/features/marking/api/deleteSavedMarking.ts
+++ b/src/features/marking/api/deleteSavedMarking.ts
@@ -1,4 +1,10 @@
-import { useMutation } from "@tanstack/react-query";
+import {
+  type InfiniteData,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useMapMode } from "@/features/map/hooks";
+import { GetMySavedMarkingListResponse } from "@/entities/marking/api";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -13,7 +19,37 @@ const deleteSavedMarking = async ({ markingId }: DeleteSavedMarkingRequest) => {
 };
 
 export const useDeleteSavedMarking = () => {
+  const queryClient = useQueryClient();
+  const mode = useMapMode();
+
   return useMutation<unknown, Error, DeleteSavedMarkingRequest>({
     mutationFn: deleteSavedMarking,
+    onSuccess: (_, { markingId }) => {
+      if (mode === "MY_ACTIVITY") {
+        queryClient.setQueryData<InfiniteData<GetMySavedMarkingListResponse>>(
+          ["mySavedMarkingList"],
+          (oldData) => {
+            if (!oldData) return oldData;
+
+            const { pages } = oldData;
+            const newPages = pages.map((page) => ({
+              ...page,
+              markings: page.markings.filter(
+                (marking) => marking.markingId !== markingId,
+              ),
+            }));
+
+            return {
+              ...oldData,
+              pages: newPages,
+            };
+          },
+        );
+
+        queryClient.invalidateQueries({
+          queryKey: ["mySavedMarkingList"],
+        });
+      }
+    },
   });
 };

--- a/src/widgets/map/ui/myActivityList.tsx
+++ b/src/widgets/map/ui/myActivityList.tsx
@@ -1,6 +1,7 @@
+import { useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MarkingItem } from "@/features/marking/ui";
-import { useGetMyLikedMarkingList } from "@/entities/marking/api";
+import { useGetMyActivityMarkingList } from "@/entities/marking/hooks";
 import { useInfiniteScroll } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { MarkingList } from "./markingList";
@@ -9,12 +10,14 @@ export const MyActivityList = () => {
   const map = useMap();
   const token = useAuthStore((state) => state.token);
 
+  const [activeTab, setActiveTab] = useState<"LIKED" | "SAVED">("LIKED");
+
   const {
-    data: myLikedMarkingList,
+    data: markingList,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useGetMyLikedMarkingList();
+  } = useGetMyActivityMarkingList(activeTab);
 
   const [setNode] = useInfiniteScroll(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -30,16 +33,24 @@ export const MyActivityList = () => {
   return (
     <div className="px-4">
       <div className="p-4 flex gap-4">
-        <button type="button" className="title-1 text-grey-900">
+        <button
+          type="button"
+          className={`title-1 ${activeTab === "LIKED" ? "text-grey-900" : "text-grey-300"}`}
+          onClick={() => setActiveTab("LIKED")}
+        >
           좋아요
         </button>
-        <button type="button" className="title-1 text-grey-300">
+        <button
+          type="button"
+          className={`title-1 ${activeTab === "SAVED" ? "text-grey-900" : "text-grey-300"}`}
+          onClick={() => setActiveTab("SAVED")}
+        >
           저장됨
         </button>
       </div>
 
       <MarkingList display="list">
-        {myLikedMarkingList?.map((marking) => (
+        {markingList?.map((marking) => (
           <MarkingItem
             key={marking.markingId}
             onRegionClick={() => {
@@ -52,6 +63,8 @@ export const MyActivityList = () => {
             // todo isLiked, isBookmarked 설정
             isLiked={false}
             isBookmarked={false}
+            // todo isFollowing 삭제
+            isFollowing={false}
             {...marking}
           />
         ))}


### PR DESCRIPTION
# 관련 이슈 번호

#433 

# 설명

## 내 활동 바텀시트에서 보여줄 query를 반환하는 훅

useGetMyActivityMarkingList은 바텀 시트에서 활성화된 탭(activeTab)에 따라 다른 query 결과를 반환합니다.

탭으로 인해 useGetMyLikedMarkingList와 useGetMySavedMarkingList에서 enabled 설정을 해야 합니다.

```typescript
export const useGetMyActivityMarkingList = (activeTab: "LIKED" | "SAVED") => {
  const likedMarkingListResult = useGetMyLikedMarkingList({
    enabled: activeTab === "LIKED",
  });
  const savedMarkingListResult = useGetMySavedMarkingList({
    enabled: activeTab === "SAVED",
  });

  if (activeTab === "LIKED") {
    return likedMarkingListResult;
  }

  return savedMarkingListResult;
};
```

## optimistic update

저장된 마킹을 저장 취소할 때를 대비하여 optimistic update를 적용했습니다.

```typescript
export const useDeleteSavedMarking = () => {
  const queryClient = useQueryClient();
  const mode = useMapMode();

  return useMutation<unknown, Error, DeleteSavedMarkingRequest>({
    mutationFn: deleteSavedMarking,
    onSuccess: (_, { markingId }) => {
      if (mode === "MY_ACTIVITY") {
        queryClient.setQueryData<InfiniteData<GetMySavedMarkingListResponse>>(
          ["mySavedMarkingList"],
          (oldData) => {
            if (!oldData) return oldData;

            const { pages } = oldData;
            const newPages = pages.map((page) => ({
              ...page,
              markings: page.markings.filter(
                (marking) => marking.markingId !== markingId,
              ),
            }));

            return {
              ...oldData,
              pages: newPages,
            };
          },
        );

        queryClient.invalidateQueries({
          queryKey: ["mySavedMarkingList"],
        });
      }
    },
  });
};
```