### PR TITLE
[Fix] 내 마킹 페이지에서 sortType 기본값 설정 및 필터 기능 구현

### DIFF
--- a/src/features/map/ui/mapControlButton.tsx
+++ b/src/features/map/ui/mapControlButton.tsx
@@ -114,7 +114,7 @@ export const ShowMyMarkingButton = () => {
           getCurrentBounds();
 
         navigate(
-          `${ROUTER_PATH.MY_MARK}?boundsNELat=${northEastLat}&boundsNELng=${northEastLng}&boundsSWLat=${southWestLat}&boundsSWLng=${southWestLng}&sortType=POPULARITY`,
+          `${ROUTER_PATH.MY_MARK}?boundsNELat=${northEastLat}&boundsNELng=${northEastLng}&boundsSWLat=${southWestLat}&boundsSWLng=${southWestLng}&sortType=RECENT`,
         );
       }}
     >

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -3,6 +3,7 @@ import { useMap } from "@vis.gl/react-google-maps";
 import {
   useCurrentLocation,
   useGetMapCurrentBounds,
+  useMapMode,
   useMapQueryParams,
 } from "@/features/map/hooks";
 import { useMapStore } from "@/features/map/store";
@@ -10,6 +11,7 @@ import { CurrentLocationLoading } from "@/entities/map/ui";
 
 export const MapInitializer = () => {
   const map = useMap();
+  const mapMode = useMapMode();
 
   const { loading, setCurrentLocation } = useCurrentLocation();
 
@@ -26,6 +28,8 @@ export const MapInitializer = () => {
   useEffect(() => {
     if (!map || !isMapIdle) return;
 
+    const defaultSortType = mapMode === "MY_MARK" ? "RECENT" : "POPULARITY";
+
     // map 인스턴스가 생기고 나서, 현재 위치를 가져옵니다.
     setCurrentLocation({
       onSuccess: ({ coords }) => {
@@ -33,7 +37,6 @@ export const MapInitializer = () => {
 
         const currentLocationOfUser = { lat: latitude, lng: longitude };
 
-        // /map으로 접속했을 때, 현재 위치로 query string를 설정합니다.
         if (!hasBoundsParams) {
           map.setCenter(currentLocationOfUser);
 
@@ -41,19 +44,17 @@ export const MapInitializer = () => {
             setIsCenteredOnMyLocation(true);
           }, 0);
 
-          // todo 내 마킹일 경우 파라미터 처리
           setMapQueryParams({
             bounds: getMapBounds(),
-            sortType: "POPULARITY",
+            sortType: defaultSortType,
           });
         }
       },
       onError: () => {
         if (!hasBoundsParams) {
-          // todo 내 마킹일 경우 파라미터 처리
           setMapQueryParams({
             bounds: getMapBounds(),
-            sortType: "POPULARITY",
+            sortType: defaultSortType,
           });
         }
       },
@@ -70,10 +71,9 @@ export const MapInitializer = () => {
         east: northEastLng,
       });
 
-      // todo 내 마킹일 경우 파라미터 처리
       setMapQueryParams({
         bounds: getMapBounds(),
-        sortType: sortTypeParam || "POPULARITY",
+        sortType: sortTypeParam ?? defaultSortType,
       });
     }
 

--- a/src/widgets/map/ui/myMarkingList.tsx
+++ b/src/widgets/map/ui/myMarkingList.tsx
@@ -15,7 +15,8 @@ import { MarkingList } from "./markingList";
 export const MyMarkingList = () => {
   const map = useMap();
 
-  const { sortTypeParam, boundsParams } = useMapQueryParams();
+  const { sortTypeParam, boundsParams, setMapQueryParams } =
+    useMapQueryParams();
 
   const nickname = useAuthStore.getState().nickname;
 
@@ -59,6 +60,9 @@ export const MyMarkingList = () => {
           <SortTypeFilter
             options={["RECENT", "POPULARITY", "DISTANCE"]}
             selectedOption={sortTypeParam || "RECENT"}
+            onSelect={(sortType) => {
+              setMapQueryParams({ sortType });
+            }}
           />
         </div>
 


### PR DESCRIPTION
# 관련 이슈 번호

#424 

# 설명

내 마킹 페이지에서 정렬 옵션 기본값은 **최신순**입니다.
sortType의 기본값을 RECENT로 바꾸고, MapInitializer에서 내 마킹 페이지일 경우 sortType을 RECENT로 설정했습니다.

그리고 내 마킹 페이지에서 정렬 필터가 작동되지 않았습니다.
원인은 SortTypeFilter에 onSelect에 핸들러를 넘겨주지 않았기 때문이었습니다.
onSelect 핸들러로 setMapQueryParams를 호출하여 선택한 옵션으로 파라미터가 변경되도록 하였습니다.
