### PR TITLE
[Feat] [동네 마킹] 버튼을 클릭하면 동네 마킹 바텀 시트 노출

### DIFF
--- a/src/entities/marking/api/getAddressFromLatLng.ts
+++ b/src/entities/marking/api/getAddressFromLatLng.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { skipToken, useQuery } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { REVERSE_GEOCODING_END_POINT } from "../constants";
@@ -27,10 +27,17 @@ const getAddressFromLatLng = async ({
 export const useGetAddressFromLatLng = ({
   lat,
   lng,
-}: GetAddressFromLatLngRequest) => {
+}: {
+  lat: number | null;
+  lng: number | null;
+}) => {
+  const { isIdle } = useMapStore.getState();
+
   return useQuery({
     queryKey: ["address", lat, lng],
-    queryFn: () => getAddressFromLatLng({ lat, lng }),
-    enabled: useMapStore.getState().isIdle,
+    queryFn:
+      isIdle && typeof lat === "number" && typeof lng === "number"
+        ? () => getAddressFromLatLng({ lat, lng })
+        : skipToken,
   });
 };

--- a/src/features/map/ui/mapControlButton.tsx
+++ b/src/features/map/ui/mapControlButton.tsx
@@ -19,6 +19,7 @@ import {
   useCurrentLocation,
   useGetMapCurrentBounds,
   useMapMode,
+  useMapQueryParams,
 } from "../hooks";
 import { useMapStore } from "../store";
 
@@ -124,8 +125,11 @@ export const ShowMyMarkingButton = () => {
 };
 
 export const ShowAroundMarkingButton = () => {
-  // todo 상태 전역으로 관리하기
-  const shouldShowAroundMarking = false;
+  const navigate = useNavigate();
+  const mapMode = useMapMode();
+  const { boundsParams } = useMapQueryParams();
+
+  const shouldShowAroundMarking = mapMode === "MAP";
 
   return (
     <Button
@@ -136,7 +140,9 @@ export const ShowAroundMarkingButton = () => {
       className={`${buttonBaseStyles} rounded-t-none`}
       aria-label="주변 마킹 보기"
       onClick={() => {
-        // todo 주변 마킹 보기로 상태 변경
+        navigate(
+          `${ROUTER_PATH.MAP}?boundsNELat=${boundsParams.northEastLat}&boundsNELng=${boundsParams.northEastLng}&boundsSWLat=${boundsParams.southWestLat}&boundsSWLng=${boundsParams.southWestLng}&sortType=POPULARITY`,
+        );
       }}
     >
       <DogFootIcon />

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from "react-router-dom";
-import { useMap } from "@vis.gl/react-google-maps";
 import { useMapQueryParams } from "@/features/map/hooks";
 import { RangeFilter, SortTypeFilter } from "@/features/marking/ui";
 import {
@@ -31,11 +30,17 @@ export const LocalMarkingList = () => {
     }
   });
 
-  const map = useMap();
-  const center = map.getCenter();
+  const { northEastLat, northEastLng, southWestLat, southWestLng } =
+    boundsParams;
 
-  const lat = center.lat();
-  const lng = center.lng();
+  const lat =
+    typeof northEastLat === "number" && typeof southWestLat === "number"
+      ? (northEastLat + southWestLat) / 2
+      : null;
+  const lng =
+    typeof northEastLng === "number" && typeof southWestLng === "number"
+      ? (northEastLng + southWestLng) / 2
+      : null;
 
   const { data } = useGetAddressFromLatLng({
     lat,


### PR DESCRIPTION
# 관련 이슈 번호

#235 

# 설명

맵에 띄워져 있는 [동네 마킹] 버튼 기능을 구현했습니다.
클릭하면 맵에는 동네에 기록된 마커들이, 바텀 시트에는 동네 마킹 데이터가 노출됩니다.

https://github.com/user-attachments/assets/811ca896-e4f6-4503-8abf-18784e34e33e

### 동네 마킹 바텀시트에 표시할 주소 데이터 요청

이전에는 맵이 움직일 때마다 주소 데이터를 서버에 요청했습니다.
이 요청은 불필요한 요청이고, 파라미터가 바뀔 때만 요청하면 됩니다.
따라서 파라미터 boundary 값이 바뀔 때마다 lat과 lng 평균을 구하여 주소 요청을 보냅니다.

```typescript
  const { northEastLat, northEastLng, southWestLat, southWestLng } =
    boundsParams;

  const lat =
    typeof northEastLat === "number" && typeof southWestLat === "number"
      ? (northEastLat + southWestLat) / 2
      : null;
  const lng =
    typeof northEastLng === "number" && typeof southWestLng === "number"
      ? (northEastLng + southWestLng) / 2
      : null;

  const { data } = useGetAddressFromLatLng({
    lat,
    lng,
  });
```

이 때 boundary 파라미터가 없을 수 있으므로 useGetAddressFromLatLng의 lat과 lng 타입에 null를 추가했습니다.
skipToken을 통해 lat과 lng 타입이 number가 아닐 경우 요청을 보내지 않습니다.

```typescript
export const useGetAddressFromLatLng = ({
  lat,
  lng,
}: {
  lat: number | null;
  lng: number | null;
}) => {
  const { isIdle } = useMapStore.getState();

  return useQuery({
    queryKey: ["address", lat, lng],
    queryFn:
      isIdle && typeof lat === "number" && typeof lng === "number"
        ? () => getAddressFromLatLng({ lat, lng })
        : skipToken,
  });
};
```