### PR TITLE
[Refactor] 동네마킹 api url 경로 수정

### DIFF
--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -59,6 +59,7 @@ export interface Marking {
 }
 
 export type SortType = "RECENT" | "DISTANCE" | "POPULARITY";
+export type SearchType = "NEARBY" | "LOCATION";
 
 export interface GetMarkingListRequest {
   southWestLat: number;
@@ -69,6 +70,7 @@ export interface GetMarkingListRequest {
   lng: number | null;
   offset: number; // 페이지 번호
   sortType: SortType;
+  searchType: SearchType;
 }
 
 // sort, paged, unpaged은 사용하지 x
@@ -98,6 +100,7 @@ const getMarkingList = async ({
   lat,
   lng,
   sortType,
+  searchType,
   offset,
 }: GetMarkingListRequest) => {
   const hasToken = !!useAuthStore.getState().token;
@@ -111,6 +114,7 @@ const getMarkingList = async ({
       lat,
       lng,
       sortType,
+      searchType,
       offset,
     }),
     {
@@ -125,12 +129,14 @@ export const useGetMarkingList = ({
   northEastLat,
   northEastLng,
   sortType,
+  searchType,
 }: {
   southWestLat: number | null;
   southWestLng: number | null;
   northEastLat: number | null;
   northEastLng: number | null;
   sortType: SortType | null;
+  searchType: SearchType;
 }) => {
   const lat = useMapStore((state) => state.userInfo.currentLocation.lat);
   const lng = useMapStore((state) => state.userInfo.currentLocation.lng);
@@ -164,6 +170,7 @@ export const useGetMarkingList = ({
               lng,
               offset: pageParam,
               sortType,
+              searchType,
             })
         : skipToken,
 

--- a/src/entities/marking/api/getUserMarkingList.ts
+++ b/src/entities/marking/api/getUserMarkingList.ts
@@ -3,11 +3,19 @@ import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { MARKING_END_POINT } from "../constants";
-import type {
-  GetMarkingListRequest,
-  Marking,
-  SortType,
-} from "./getMarkingList";
+import type { Marking, SortType } from "./getMarkingList";
+
+export interface GetUserMarkingListRequest {
+  nickname: string;
+  southWestLat: number;
+  southWestLng: number;
+  northEastLat: number;
+  northEastLng: number;
+  lat: number | null;
+  lng: number | null;
+  offset: number; // 페이지 번호
+  sortType: SortType;
+}
 
 interface GetUserMarkingListResponse {
   markings: Marking[];
@@ -26,10 +34,6 @@ interface GetUserMarkingListResponse {
     unpaged: boolean;
   };
 }
-
-export type GetUserMarkingListRequest = GetMarkingListRequest & {
-  nickname: string;
-};
 
 const getUserMarkingList = async ({
   nickname,

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -27,10 +27,11 @@ export const MARKING_END_POINT = {
     lng,
     sortType,
     offset,
+    searchType,
   }: GetMarkingListRequest) => {
     const latLngQueryParams = lat && lng ? `&lat=${lat}&lng=${lng}` : "";
 
-    return `${API_BASE_URL}/markings/bounds?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&sortType=${sortType}&offset=${offset}${latLngQueryParams}`;
+    return `${API_BASE_URL}/markings/bounds?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}&sortType=${sortType}&searchType=${searchType}&offset=${offset}${latLngQueryParams}`;
   },
 
   USER: ({

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -14,6 +14,7 @@ export const LocalMarkingList = () => {
   const navigate = useNavigate();
   const { boundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
+
   const {
     data: markingList,
     fetchNextPage,
@@ -22,6 +23,7 @@ export const LocalMarkingList = () => {
   } = useGetMarkingList({
     ...boundsParams,
     sortType: sortTypeParam,
+    searchType: "NEARBY",
   });
 
   const [setNode] = useInfiniteScroll(() => {

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -29,6 +29,7 @@ export const PlaceMarkingList = () => {
   } = useGetMarkingList({
     ...boundsParams,
     sortType: sortTypeParam,
+    searchType: "LOCATION",
   });
 
   const [setNode] = useInfiniteScroll(() => {


### PR DESCRIPTION
# 관련 이슈 번호

#235

# 설명

[동네 마킹 api](https://documenter.getpostman.com/view/26924668/2sAXqndjDZ#b3ae81b3-3820-475b-bcb4-88c32ef973cc)에 searchType 파라미터가 존재합니다..

searchType 값이 NEARBY이면 동네마킹, LOCATION이면 이 장소 마킹입니다.