### PR TITLE
[Feat] 좋아요 , 북마크 누른 마커 가져오기 쿼리문 생성

### DIFF
--- a/src/entities/marking/api/getMyActivityMarkerList.ts
+++ b/src/entities/marking/api/getMyActivityMarkerList.ts
@@ -1,0 +1,42 @@
+// TODO 타입 리팩토링 시 공통 타입으로 선언
+import { skipToken, useQuery } from "@tanstack/react-query";
+import { useTiling } from "@/entities/map/lib";
+import { apiClient } from "@/shared/lib";
+import { useAuthStore } from "@/shared/store";
+import { MARKER_END_POINT } from "../constants";
+
+interface Marker {
+  markingId: number;
+  previewImage: string;
+  lat: number;
+  lng: number;
+}
+type GetMyActivityMarkerListRequest = "LIKED" | "SAVED";
+type GetMyActivityMarkerListResponse = Marker[];
+
+const ACTIVITY_MAP = {
+  LIKED: "likes",
+  SAVED: "saves",
+} as const;
+
+export const useGetMyActivityMarkerList = (
+  activity: GetMyActivityMarkerListRequest,
+) => {
+  const getTiles = useTiling();
+  const token = useAuthStore((state) => state.token);
+
+  return useQuery({
+    queryKey: ["marker", "myActivity", activity],
+    queryFn: token
+      ? () =>
+          apiClient.get<GetMyActivityMarkerListResponse>(
+            MARKER_END_POINT.MY_ACTIVITY(ACTIVITY_MAP[activity]),
+            {
+              withToken: true,
+            },
+          )
+      : skipToken,
+    staleTime: 1000 * 60 * 5,
+    select: (data) => getTiles(data, activity),
+  });
+};

--- a/src/entities/marking/api/index.ts
+++ b/src/entities/marking/api/index.ts
@@ -8,3 +8,4 @@ export * from "./getMyLikedMarkingList";
 export * from "./getMyLikedMarkingList";
 export * from "./getMySavedMarkerList";
 export * from "./getMarkingDetail";
+export * from "./getMyActivityMarkerList";

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -78,6 +78,8 @@ export const MARKER_END_POINT = {
     `${API_BASE_URL}/markings/marks?southBottomLat=${southWestLat}&northTopLat=${northEastLat}&southLeftLng=${southWestLng}&northRightLng=${northEastLng}`,
 
   MY: `${API_BASE_URL}/markings/my-marks`,
+  MY_ACTIVITY: (activity: "likes" | "saves") =>
+    `${API_BASE_URL}/markings/marks/${activity}`,
 };
 
 export const MY_MARKING_END_POINT = {

--- a/src/mocks/data/markerList.ts
+++ b/src/mocks/data/markerList.ts
@@ -1,6 +1,7 @@
-export const getMockMarkerList = ()=> Array.from({length  : 100} , (_,index)=>({
-  markingId : index + 1,
-  previewImage : "fa805c91-8228-4ec4-927f-9eb876a480c3",
-  lat : 37.123456 + Math.random() * 0.1,
-  lng : 127.123456 + Math.random() * 0.1,
-}))
+export const getMockMarkerList = () =>
+  Array.from({ length: 100 }, (_, index) => ({
+    markingId: index + 1,
+    previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
+    lat: 37.123456 + Math.random() * 0.1,
+    lng: 127.123456 + Math.random() * 0.1,
+  }));

--- a/src/mocks/data/markerList.ts
+++ b/src/mocks/data/markerList.ts
@@ -1,0 +1,6 @@
+export const getMockMarkerList = ()=> Array.from({length  : 100} , (_,index)=>({
+  markingId : index + 1,
+  previewImage : "fa805c91-8228-4ec4-927f-9eb876a480c3",
+  lat : 37.123456 + Math.random() * 0.1,
+  lng : 127.123456 + Math.random() * 0.1,
+}))

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -20,6 +20,7 @@ import { MY_INFO_END_POINT } from "@/entities/auth/constants";
 import { Marking, SortType } from "@/entities/marking/api";
 import { MARKER_END_POINT } from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
+import { getMockMarkerList } from "./data/markerList";
 // data
 import { getMockMarkingList } from "./data/markingList";
 import userInfoData from "./data/myInfo.json";
@@ -1834,6 +1835,54 @@ const getMyMarkerList = [
   }),
 ];
 
+const getLikedMarkerListHandler = [
+  http.get(`${API_BASE_URL}/markings/marks/likes`, async ({ request }) => {
+    const token = request.headers.get("Authorization");
+
+    if (!token || token === "staleAccessToken") {
+      return HttpResponse.json(
+        {
+          code: 401,
+          message: "토큰 검증에 실패 했습니다.",
+        },
+        {
+          status: 401,
+        },
+      );
+    }
+
+    return HttpResponse.json({
+      code: 200,
+      message: "success",
+      content: getMockMarkerList(),
+    });
+  }),
+];
+
+const getSavedMarkerListHandler = [
+  http.get(`${API_BASE_URL}/markings/marks/saves`, async ({ request }) => {
+    const token = request.headers.get("Authorization");
+
+    if (!token || token === "staleAccessToken") {
+      return HttpResponse.json(
+        {
+          code: 401,
+          message: "토큰 검증에 실패 했습니다.",
+        },
+        {
+          status: 401,
+        },
+      );
+    }
+
+    return HttpResponse.json({
+      code: 200,
+      message: "success",
+      content: getMockMarkerList(),
+    });
+  }),
+];
+
 // * 나중에 msw 사용을 대비하여 만들었습니다.
 export const handlers = [
   ...signUpByEmailHandlers,
@@ -1860,10 +1909,12 @@ export const handlers = [
   ...postFollowingHandler,
   ...deleteFollowingHandler,
   ...deleteFollowerHandler,
-  ...getProfileThumbnailHandler,
   ...getTemporaryMarkingListHandler,
   ...deleteTemporaryMarkingHandler,
   ...putModifyTempMarkingHandler,
   ...getUserMarkingListHandler,
   ...getMyMarkerList,
+  ...getLikedMarkerListHandler,
+  ...getSavedMarkerListHandler,
+  ...getProfileThumbnailHandler,
 ];

--- a/src/widgets/map/ui/myActivityList.tsx
+++ b/src/widgets/map/ui/myActivityList.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MarkingItem } from "@/features/marking/ui";
+import { MarkingPins } from "@/entities/map/ui";
+import { useGetMyActivityMarkerList } from "@/entities/marking/api";
 import { useGetMyActivityMarkingList } from "@/entities/marking/hooks";
 import { useInfiniteScroll } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
@@ -19,6 +21,8 @@ export const MyActivityList = () => {
     isFetchingNextPage,
   } = useGetMyActivityMarkingList(activeTab);
 
+  const { data: markerTiles } = useGetMyActivityMarkerList(activeTab);
+
   const [setNode] = useInfiniteScroll(() => {
     if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
@@ -31,45 +35,48 @@ export const MyActivityList = () => {
   }
 
   return (
-    <div className="px-4">
-      <div className="p-4 flex gap-4">
-        <button
-          type="button"
-          className={`title-1 ${activeTab === "LIKED" ? "text-grey-900" : "text-grey-300"}`}
-          onClick={() => setActiveTab("LIKED")}
-        >
-          좋아요
-        </button>
-        <button
-          type="button"
-          className={`title-1 ${activeTab === "SAVED" ? "text-grey-900" : "text-grey-300"}`}
-          onClick={() => setActiveTab("SAVED")}
-        >
-          저장됨
-        </button>
-      </div>
+    <>
+      {markerTiles && <MarkingPins tiles={markerTiles} />}
+      <div className="px-4">
+        <div className="p-4 flex gap-4">
+          <button
+            type="button"
+            className={`title-1 ${activeTab === "LIKED" ? "text-grey-900" : "text-grey-300"}`}
+            onClick={() => setActiveTab("LIKED")}
+          >
+            좋아요
+          </button>
+          <button
+            type="button"
+            className={`title-1 ${activeTab === "SAVED" ? "text-grey-900" : "text-grey-300"}`}
+            onClick={() => setActiveTab("SAVED")}
+          >
+            저장됨
+          </button>
+        </div>
 
-      <MarkingList display="list">
-        {markingList?.map((marking) => (
-          <MarkingItem
-            key={marking.markingId}
-            onRegionClick={() => {
-              map.setCenter({
-                lat: marking.lat,
-                lng: marking.lng,
-              });
-              map.setZoom(19);
-            }}
-            // todo isLiked, isBookmarked 설정
-            isLiked={false}
-            isBookmarked={false}
-            // todo isFollowing 삭제
-            isFollowing={false}
-            {...marking}
-          />
-        ))}
-      </MarkingList>
-      <div className="h-[.125rem]" ref={setNode} />
-    </div>
+        <MarkingList display="list">
+          {markingList?.map((marking) => (
+            <MarkingItem
+              key={marking.markingId}
+              onRegionClick={() => {
+                map.setCenter({
+                  lat: marking.lat,
+                  lng: marking.lng,
+                });
+                map.setZoom(19);
+              }}
+              // todo isLiked, isBookmarked 설정
+              isLiked={false}
+              isBookmarked={false}
+              // todo isFollowing 삭제
+              isFollowing={false}
+              {...marking}
+            />
+          ))}
+        </MarkingList>
+        <div className="h-[.125rem]" ref={setNode} />
+      </div>
+    </>
   );
 };


### PR DESCRIPTION
# 관련 이슈 번호
close #466 
# 설명

좋아요 , 북마크를 가져오는 쿼리문을 생성했습니다.

두 마커에 대한 엔드포인트는 응답값도 같고 엔드포인트 마지막 부분만 /likes , saves 로 다른데요 

그래서 두 가지 쿼리문을 만들기보다 하나의 쿼리문에서 마지막 주소만 받아 다르게 요청 보내도록 하였습니다.

추후 staleTime 에 따라 캐싱된 컴포넌트를 효과적으로 다루기 위한 로직이 추가되어야 하며 

쿼리키 저장 양식을 수정해야 합니다.


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
