### PR TITLE
[Refactor] 쿼리키 팩토리 패턴으로 리팩토링

### DIFF
--- a/src/entities/auth/api/getMyInfo.ts
+++ b/src/entities/auth/api/getMyInfo.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
 import { MY_INFO_END_POINT, SOCIAL_TYPE } from "../constants";
+import { authQueryKey } from "../constants";
 import type { Region } from "./getRegion";
 
 export interface MyInfo {
@@ -21,7 +22,7 @@ const getMyInfo = async () => {
 
 export const useGetMyInfo = () => {
   return useQuery({
-    queryKey: ["myInfo"],
+    queryKey: authQueryKey.myInfo(),
     queryFn: getMyInfo,
   });
 };

--- a/src/entities/auth/api/getRegion.ts
+++ b/src/entities/auth/api/getRegion.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
 import { REGION_END_POINT } from "../constants";
+import { authQueryKey } from "../constants";
 
 export interface LatLng {
   lat: number;
@@ -33,7 +34,7 @@ export const useGetRegionByKeyword = ({
   enabled: boolean;
 }) => {
   return useQuery({
-    queryKey: ["regions", keyword],
+    queryKey: authQueryKey.regionKeyword(keyword),
     queryFn: () => getRegionByKeyword(keyword),
     enabled,
     staleTime: 1000 * 60 * 5,
@@ -52,7 +53,7 @@ export const useGetRegionByLatLng = ({
   enabled = false,
 }: LatLng & { enabled: boolean }) => {
   return useQuery({
-    queryKey: ["regions", lat, lng],
+    queryKey: authQueryKey.regionLatLng({ lat, lng }),
     queryFn: () => getRegionByLatLng({ lat, lng }),
     enabled,
     staleTime: 1000 * 60 * 5,

--- a/src/entities/auth/constants/index.ts
+++ b/src/entities/auth/constants/index.ts
@@ -14,3 +14,5 @@ export const REGION_END_POINT = {
   REGION_LIST: (keyword: string) =>
     `${API_BASE_URL}/addresses?keyword=${keyword}`,
 };
+
+export * from "./queryKey";

--- a/src/entities/auth/constants/queryKey.ts
+++ b/src/entities/auth/constants/queryKey.ts
@@ -1,0 +1,14 @@
+// TODO 타입 리팩토링 시 건들기
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export const authQueryKey = {
+  myInfo: () => ["myInfo"] as const,
+  regionAll: () => ["regions"] as const,
+  regionKeyword: (keyword: string) =>
+    [...authQueryKey.regionAll(), keyword] as const,
+  regionLatLng: ({ lat, lng }: LatLng) =>
+    [...authQueryKey.regionAll(), lat, lng] as const,
+} as const;

--- a/src/entities/auth/constants/queryKey.ts
+++ b/src/entities/auth/constants/queryKey.ts
@@ -8,7 +8,7 @@ export const authQueryKey = {
   myInfo: () => ["myInfo"] as const,
   regionAll: () => ["regions"] as const,
   regionKeyword: (keyword: string) =>
-    [...authQueryKey.regionAll(), keyword] as const,
-  regionLatLng: ({ lat, lng }: LatLng) =>
-    [...authQueryKey.regionAll(), lat, lng] as const,
+    [...authQueryKey.regionAll(), { keyword }] as const,
+  regionLatLng: (latLng: LatLng) =>
+    [...authQueryKey.regionAll(), { latLng }] as const,
 } as const;

--- a/src/entities/follow/api/getFollowerList.ts
+++ b/src/entities/follow/api/getFollowerList.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import type { Nickname, PetInfo, UserId } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { FOLLOW_END_POINT } from "../constants";
+import { FOLLOW_END_POINT, followQueryKey } from "../constants";
 
 // TODO 리팩토링 시 해당 타입 정의 위치 의논
 interface PageAbleInformation {
@@ -50,7 +50,7 @@ export const useGetFollowerList = ({ nickname }: GetFollowerListRequest) => {
   const token = useAuthStore((state) => state.token);
 
   return useInfiniteQuery({
-    queryKey: ["followerList", nickname],
+    queryKey: followQueryKey.follower(nickname),
     queryFn: token
       ? ({ pageParam = 0 }) => getFollowerList({ nickname, pageParam })
       : skipToken,

--- a/src/entities/follow/api/getFollowingList.ts
+++ b/src/entities/follow/api/getFollowingList.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import type { Nickname, PetInfo, UserId } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { FOLLOW_END_POINT } from "../constants";
+import { FOLLOW_END_POINT, followQueryKey } from "../constants";
 
 // TODO 리팩토링 시 해당 타입 정의 위치 의논
 interface PageAbleInformation {
@@ -50,7 +50,7 @@ export const useGetFollowingList = ({ nickname }: GetFollowingListRequest) => {
   const token = useAuthStore((state) => state.token);
 
   return useInfiniteQuery({
-    queryKey: ["followingList", nickname],
+    queryKey: followQueryKey.following(nickname),
     queryFn: token
       ? ({ pageParam = 0 }) => getFollowingList({ nickname, pageParam })
       : skipToken,

--- a/src/entities/follow/constants/index.ts
+++ b/src/entities/follow/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./endpoint";
+export * from "./queryKey";

--- a/src/entities/follow/constants/queryKey.ts
+++ b/src/entities/follow/constants/queryKey.ts
@@ -1,0 +1,4 @@
+export const followQueryKey = {
+  follower: (nickname: string) => ["follower", nickname] as const,
+  following: (nickname: string) => ["following", nickname] as const,
+} as const;

--- a/src/entities/follow/constants/queryKey.ts
+++ b/src/entities/follow/constants/queryKey.ts
@@ -1,4 +1,4 @@
 export const followQueryKey = {
-  follower: (nickname: string) => ["follower", nickname] as const,
-  following: (nickname: string) => ["following", nickname] as const,
+  follower: (nickname: string) => ["follower", { nickname }] as const,
+  following: (nickname: string) => ["following", { nickname }] as const,
 } as const;

--- a/src/entities/marking/api/getAddressFromLatLng.ts
+++ b/src/entities/marking/api/getAddressFromLatLng.ts
@@ -2,6 +2,7 @@ import { skipToken, useQuery } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { REVERSE_GEOCODING_END_POINT } from "../constants";
+import { markingQueryKey } from "../constants";
 
 interface GetAddressFromLatLngRequest {
   lat: number;
@@ -34,7 +35,7 @@ export const useGetAddressFromLatLng = ({
   const { isIdle } = useMapStore.getState();
 
   return useQuery({
-    queryKey: ["address", lat, lng],
+    queryKey: markingQueryKey.address({ lat: lat!, lng: lng! }),
     queryFn:
       isIdle && typeof lat === "number" && typeof lng === "number"
         ? () => getAddressFromLatLng({ lat, lng })

--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -3,7 +3,7 @@ import { useMapStore } from "@/features/map/store";
 import { useTiling } from "@/entities/map/lib";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKER_END_POINT, markingQueryKey } from "../constants";
+import { MARKER_END_POINT, markerQueryKey } from "../constants";
 
 interface Marker {
   markingId: number;
@@ -57,7 +57,7 @@ export const useGetBoundaryMarkerList = ({
   const getTiles = useTiling();
 
   return useQuery({
-    queryKey: markingQueryKey.boundaryMarker({
+    queryKey: markerQueryKey.boundaryMarker({
       southWestLat: southWestLat!,
       southWestLng: southWestLng!,
       northEastLat: northEastLat!,

--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -3,7 +3,7 @@ import { useMapStore } from "@/features/map/store";
 import { useTiling } from "@/entities/map/lib";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKER_END_POINT } from "../constants";
+import { MARKER_END_POINT, markingQueryKey } from "../constants";
 
 interface Marker {
   markingId: number;
@@ -57,14 +57,12 @@ export const useGetBoundaryMarkerList = ({
   const getTiles = useTiling();
 
   return useQuery({
-    queryKey: [
-      "marker",
-      "boundaryMarkerList",
-      southWestLat,
-      southWestLng,
-      northEastLat,
-      northEastLng,
-    ],
+    queryKey: markingQueryKey.boundaryMarker({
+      southWestLat: southWestLat!,
+      southWestLng: southWestLng!,
+      northEastLat: northEastLat!,
+      northEastLng: northEastLng!,
+    }),
 
     queryFn:
       isMapIdle &&

--- a/src/entities/marking/api/getDashboardMarkingThumbnail.ts
+++ b/src/entities/marking/api/getDashboardMarkingThumbnail.ts
@@ -1,7 +1,7 @@
 import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKING_THUMBNAIL_END_POINT, markingQueryKey } from "../constants";
+import { MARKING_THUMBNAIL_END_POINT, markerQueryKey } from "../constants";
 
 interface GetDashboardMarkingThumbnailRequest {
   nickname: string;
@@ -40,7 +40,7 @@ export const useGetDashboardMarkingThumbnail = (
   const token = useAuthStore((state) => state.token);
 
   return useInfiniteQuery({
-    queryKey: markingQueryKey.markerThumbnail(nickname),
+    queryKey: markerQueryKey.markerThumbnail(nickname),
     queryFn: token
       ? ({ pageParam = 0 }) =>
           apiClient.get<GetDashboardMarkingThumbnailResponse>(

--- a/src/entities/marking/api/getDashboardMarkingThumbnail.ts
+++ b/src/entities/marking/api/getDashboardMarkingThumbnail.ts
@@ -1,11 +1,10 @@
 import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
-import { Nickname } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKING_THUMBNAIL_END_POINT } from "../constants";
+import { MARKING_THUMBNAIL_END_POINT, markingQueryKey } from "../constants";
 
 interface GetDashboardMarkingThumbnailRequest {
-  nickname: Nickname;
+  nickname: string;
   pageParams: number;
 }
 
@@ -41,7 +40,7 @@ export const useGetDashboardMarkingThumbnail = (
   const token = useAuthStore((state) => state.token);
 
   return useInfiniteQuery({
-    queryKey: ["dashboardMarkingThumbnail", nickname],
+    queryKey: markingQueryKey.markerThumbnail(nickname),
     queryFn: token
       ? ({ pageParam = 0 }) =>
           apiClient.get<GetDashboardMarkingThumbnailResponse>(

--- a/src/entities/marking/api/getMarkingDetail.ts
+++ b/src/entities/marking/api/getMarkingDetail.ts
@@ -1,7 +1,7 @@
 import { skipToken, useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKING_END_POINT } from "../constants";
+import { MARKING_END_POINT, markingQueryKey } from "../constants";
 import type { Marking } from "./getMarkingList";
 
 export interface GetMarkingDetailRequest {
@@ -12,7 +12,7 @@ export const useGetMarkingDetail = ({ markingId }: GetMarkingDetailRequest) => {
   const { token } = useAuthStore.getState();
 
   return useQuery({
-    queryKey: ["markingList", markingId],
+    queryKey: markingQueryKey.detail(markingId as number),
     queryFn:
       token && markingId !== undefined
         ? () =>

--- a/src/entities/marking/api/getMarkingList.ts
+++ b/src/entities/marking/api/getMarkingList.ts
@@ -2,7 +2,11 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKING_END_POINT, type MarkingVisibilityKey } from "../constants";
+import {
+  MARKING_END_POINT,
+  markingQueryKey,
+  type MarkingVisibilityKey,
+} from "../constants";
 
 interface Address {
   id: number;
@@ -144,14 +148,17 @@ export const useGetMarkingList = ({
   const { isIdle: isMapIdle } = useMapStore.getState();
 
   return useInfiniteQuery({
-    queryKey: [
-      "markingList",
-      southWestLat,
-      southWestLng,
-      northEastLat,
-      northEastLng,
-      sortType,
-    ],
+    queryKey: markingQueryKey.boundaryMarkingList(
+      {
+        southWestLat: southWestLat!,
+        southWestLng: southWestLng!,
+        northEastLat: northEastLat!,
+        northEastLng: northEastLng!,
+      },
+      { lat: lat!, lng: lng! },
+      sortType!,
+      searchType,
+    ),
 
     queryFn:
       isMapIdle &&

--- a/src/entities/marking/api/getMyActivityMarkerList.ts
+++ b/src/entities/marking/api/getMyActivityMarkerList.ts
@@ -3,7 +3,7 @@ import { skipToken, useQuery } from "@tanstack/react-query";
 import { useTiling } from "@/entities/map/lib";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKER_END_POINT } from "../constants";
+import { MARKER_END_POINT, markingQueryKey } from "../constants";
 
 interface Marker {
   markingId: number;
@@ -26,7 +26,7 @@ export const useGetMyActivityMarkerList = (
   const token = useAuthStore((state) => state.token);
 
   return useQuery({
-    queryKey: ["marker", "myActivity", activity],
+    queryKey: markingQueryKey.myActivityMarker(activity),
     queryFn: token
       ? () =>
           apiClient.get<GetMyActivityMarkerListResponse>(

--- a/src/entities/marking/api/getMyActivityMarkerList.ts
+++ b/src/entities/marking/api/getMyActivityMarkerList.ts
@@ -3,7 +3,7 @@ import { skipToken, useQuery } from "@tanstack/react-query";
 import { useTiling } from "@/entities/map/lib";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKER_END_POINT, markingQueryKey } from "../constants";
+import { MARKER_END_POINT, markerQueryKey } from "../constants";
 
 interface Marker {
   markingId: number;
@@ -26,7 +26,7 @@ export const useGetMyActivityMarkerList = (
   const token = useAuthStore((state) => state.token);
 
   return useQuery({
-    queryKey: markingQueryKey.myActivityMarker(activity),
+    queryKey: markerQueryKey.myActivityMarker(activity),
     queryFn: token
       ? () =>
           apiClient.get<GetMyActivityMarkerListResponse>(

--- a/src/entities/marking/api/getMyLikedMarkingList.ts
+++ b/src/entities/marking/api/getMyLikedMarkingList.ts
@@ -1,7 +1,7 @@
 import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKING_END_POINT } from "../constants";
+import { MARKING_END_POINT, markingQueryKey } from "../constants";
 import type { Marking } from "./getMarkingList";
 
 export interface GetMyLikedMarkingListRequest {
@@ -30,7 +30,7 @@ export const useGetMyLikedMarkingList = ({ enabled }: { enabled: boolean }) => {
   const { token } = useAuthStore.getState();
 
   return useInfiniteQuery({
-    queryKey: ["markingList", "myLikedMarkingList"],
+    queryKey: markingQueryKey.myActivityMarkingList("LIKED"),
     queryFn:
       token && enabled
         ? ({ pageParam = 0 }) =>

--- a/src/entities/marking/api/getMyMakerList.ts
+++ b/src/entities/marking/api/getMyMakerList.ts
@@ -2,7 +2,7 @@ import { skipToken, useQuery } from "@tanstack/react-query";
 import { useTiling } from "@/entities/map/lib";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKER_END_POINT, markingQueryKey } from "../constants";
+import { MARKER_END_POINT, markerQueryKey } from "../constants";
 
 interface Marker {
   markingId: number;
@@ -18,7 +18,7 @@ export const useGetMyMakerList = () => {
   const getTiles = useTiling();
 
   return useQuery({
-    queryKey: markingQueryKey.myMarker(),
+    queryKey: markerQueryKey.myMarker(),
     queryFn: token
       ? () => {
           return apiClient.get<GetMyMarkerListResponse>(MARKER_END_POINT.MY, {

--- a/src/entities/marking/api/getMyMakerList.ts
+++ b/src/entities/marking/api/getMyMakerList.ts
@@ -2,7 +2,7 @@ import { skipToken, useQuery } from "@tanstack/react-query";
 import { useTiling } from "@/entities/map/lib";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKER_END_POINT } from "../constants";
+import { MARKER_END_POINT, markingQueryKey } from "../constants";
 
 interface Marker {
   markingId: number;
@@ -18,7 +18,7 @@ export const useGetMyMakerList = () => {
   const getTiles = useTiling();
 
   return useQuery({
-    queryKey: ["marker", "myMarkerList"],
+    queryKey: markingQueryKey.myMarker(),
     queryFn: token
       ? () => {
           return apiClient.get<GetMyMarkerListResponse>(MARKER_END_POINT.MY, {

--- a/src/entities/marking/api/getMySavedMarkerList.ts
+++ b/src/entities/marking/api/getMySavedMarkerList.ts
@@ -1,7 +1,7 @@
 import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKING_END_POINT } from "../constants";
+import { MARKING_END_POINT, markingQueryKey } from "../constants";
 import type { Marking } from "./getMarkingList";
 
 export interface GetMySavedMarkingListRequest {
@@ -30,7 +30,7 @@ export const useGetMySavedMarkingList = ({ enabled }: { enabled: boolean }) => {
   const { token } = useAuthStore.getState();
 
   return useInfiniteQuery({
-    queryKey: ["markingList", "mySavedMarkingList"],
+    queryKey: markingQueryKey.myActivityMarkingList("SAVED"),
     queryFn:
       token && enabled
         ? ({ pageParam = 0 }) =>

--- a/src/entities/marking/api/getTemporaryMarkingList.ts
+++ b/src/entities/marking/api/getTemporaryMarkingList.ts
@@ -2,7 +2,11 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { Nickname, UserId } from "@/entities/profile/api";
 import { apiClient, formatDateToYearMonthDay } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MY_MARKING_END_POINT, type MarkingVisibilityKey } from "../constants";
+import {
+  markingQueryKey,
+  MY_MARKING_END_POINT,
+  type MarkingVisibilityKey,
+} from "../constants";
 
 export interface TempMarkingFileInfo {
   id: number;
@@ -59,7 +63,7 @@ export interface GetTemporaryMarkingListResponse {
 export const useGetTemporaryMarkingList = () => {
   const token = useAuthStore((state) => state.token);
   return useInfiniteQuery({
-    queryKey: ["markingList", "temporaryMarkingList"],
+    queryKey: markingQueryKey.myTemporaryMarkingList(),
     queryFn: token
       ? ({ pageParam }) =>
           apiClient.get<GetTemporaryMarkingListResponse>(

--- a/src/entities/marking/api/getUserMarkingList.ts
+++ b/src/entities/marking/api/getUserMarkingList.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { MARKING_END_POINT } from "../constants";
+import { MARKING_END_POINT, markingQueryKey } from "../constants";
 import type { Marking, SortType } from "./getMarkingList";
 
 export interface GetUserMarkingListRequest {
@@ -87,15 +87,17 @@ export const useGetUserMarkingList = ({
   const { isIdle: isMapIdle } = useMapStore.getState();
 
   return useInfiniteQuery({
-    queryKey: [
-      "markingList",
+    queryKey: markingQueryKey.userMarkingList(
       nickname,
-      southWestLat,
-      southWestLng,
-      northEastLat,
-      northEastLng,
-      sortType,
-    ],
+      {
+        southWestLat: southWestLat!,
+        southWestLng: southWestLng!,
+        northEastLat: northEastLat!,
+        northEastLng: northEastLng!,
+      },
+      { lat: lat!, lng: lng! },
+      sortType!,
+    ),
 
     queryFn:
       token &&

--- a/src/entities/marking/api/index.ts
+++ b/src/entities/marking/api/index.ts
@@ -9,3 +9,4 @@ export * from "./getMyLikedMarkingList";
 export * from "./getMySavedMarkerList";
 export * from "./getMarkingDetail";
 export * from "./getMyActivityMarkerList";
+export * from "./getDashboardMarkingThumbnail";

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -9,6 +9,7 @@ import type {
   GetAllMarkingsOfUserRequest,
 } from "../api";
 
+export * from "./queryKey";
 export const REVERSE_GEOCODING_END_POINT = ({
   lat,
   lng,

--- a/src/entities/marking/constants/index.ts
+++ b/src/entities/marking/constants/index.ts
@@ -89,6 +89,11 @@ export const MY_MARKING_END_POINT = {
     `${API_BASE_URL}/markings/temps?offset=${offset}`,
 };
 
+export const MARKING_THUMBNAIL_END_POINT = {
+  DASHBOARD: (nickname: string, pageParams: number) =>
+    `${API_BASE_URL}/markings/marks/${nickname}?offset=${pageParams}`,
+};
+
 export const MARKING_VISIBILITY_MAP = {
   PUBLIC: "전체 공개",
   PRIVATE: "나만 보기",

--- a/src/entities/marking/constants/queryKey.ts
+++ b/src/entities/marking/constants/queryKey.ts
@@ -17,21 +17,9 @@ type Activity = "LIKED" | "SAVED";
 
 export const markingQueryKey = {
   address: (latLng: LatLng) => ["address", { latLng }] as const,
-
-  markerAll: () => ["marker"] as const,
   markingListAll: () => ["marking"] as const,
-
-  boundaryMarker: (bounds: Bounds) =>
-    [...markingQueryKey.markerAll(), { bounds }] as const,
-  myActivityMarker: (activity: Activity) =>
-    [...markingQueryKey.markerAll(), { activity }] as const,
-  myMarker: () => [...markingQueryKey.markerAll(), "myMarker"] as const,
-  markerThumbnail: (nickname: string) =>
-    [...markingQueryKey.markerAll(), "dashboard", { nickname }] as const,
-
   detail: (markingId: number) =>
     [...markingQueryKey.markingListAll(), { markingId }] as const,
-
   boundaryMarkingList: (
     bounds: Bounds,
     latLng: LatLng,
@@ -63,3 +51,15 @@ export const markingQueryKey = {
       { sortType },
     ] as const,
 } as const;
+
+export const markerQueryKey = {
+  markerAll: () => ["marker"] as const,
+
+  boundaryMarker: (bounds: Bounds) =>
+    [...markerQueryKey.markerAll(), { bounds }] as const,
+  myActivityMarker: (activity: Activity) =>
+    [...markerQueryKey.markerAll(), { activity }] as const,
+  myMarker: () => [...markerQueryKey.markerAll(), "myMarker"] as const,
+  markerThumbnail: (nickname: string) =>
+    [...markerQueryKey.markerAll(), "dashboard", { nickname }] as const,
+};

--- a/src/entities/marking/constants/queryKey.ts
+++ b/src/entities/marking/constants/queryKey.ts
@@ -26,6 +26,8 @@ export const markingQueryKey = {
   myActivityMarker: (activity: Activity) =>
     [...markingQueryKey.markerAll(), { activity }] as const,
   myMarker: () => [...markingQueryKey.markerAll(), "myMarker"] as const,
+  markerThumbnail: (nickname: string) =>
+    [...markingQueryKey.markerAll(), "dashboard", { nickname }] as const,
 
   detail: (markingId: number) =>
     [...markingQueryKey.markingListAll(), { markingId }] as const,

--- a/src/entities/marking/constants/queryKey.ts
+++ b/src/entities/marking/constants/queryKey.ts
@@ -16,7 +16,7 @@ type SearchType = "NEARBY" | "LOCATION";
 type Activity = "LIKED" | "SAVED";
 
 export const markingQueryKey = {
-  address: (latLng: LatLng) => ["address", latLng] as const,
+  address: (latLng: LatLng) => ["address", { latLng }] as const,
 
   markerAll: () => ["marker"] as const,
   markingListAll: () => ["marking"] as const,

--- a/src/entities/marking/constants/queryKey.ts
+++ b/src/entities/marking/constants/queryKey.ts
@@ -1,0 +1,63 @@
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+interface Bounds {
+  southWestLat: number;
+  southWestLng: number;
+  northEastLat: number;
+  northEastLng: number;
+}
+
+type SortType = "RECENT" | "DISTANCE" | "POPULARITY";
+type SearchType = "NEARBY" | "LOCATION";
+
+type Activity = "LIKED" | "SAVED";
+
+export const markingQueryKey = {
+  address: (latLng: LatLng) => ["address", latLng] as const,
+
+  markerAll: () => ["marker"] as const,
+  markingListAll: () => ["marking"] as const,
+
+  boundaryMarker: (bounds: Bounds) =>
+    [...markingQueryKey.markerAll(), { bounds }] as const,
+  myActivityMarker: (activity: Activity) =>
+    [...markingQueryKey.markerAll(), { activity }] as const,
+  myMarker: () => [...markingQueryKey.markerAll(), "myMarker"] as const,
+
+  detail: (markingId: number) =>
+    [...markingQueryKey.markingListAll(), { markingId }] as const,
+
+  boundaryMarkingList: (
+    bounds: Bounds,
+    latLng: LatLng,
+    sortType: SortType,
+    searchType: SearchType,
+  ) =>
+    [
+      ...markingQueryKey.markingListAll(),
+      { bounds },
+      { latLng },
+      { sortType },
+      { searchType },
+    ] as const,
+  myActivityMarkingList: (activity: Activity) =>
+    [...markingQueryKey.markingListAll(), { activity }] as const,
+  myTemporaryMarkingList: () =>
+    [...markingQueryKey.markingListAll(), "myTemporaryMarker"] as const,
+  userMarkingList: (
+    nickname: string,
+    bounds: Bounds,
+    latLng: LatLng,
+    sortType: SortType,
+  ) =>
+    [
+      ...markingQueryKey.markingListAll(),
+      { nickname },
+      { bounds },
+      { latLng },
+      { sortType },
+    ] as const,
+} as const;

--- a/src/entities/marking/constants/queryKey.ts
+++ b/src/entities/marking/constants/queryKey.ts
@@ -17,7 +17,7 @@ type Activity = "LIKED" | "SAVED";
 
 export const markingQueryKey = {
   address: (latLng: LatLng) => ["address", { latLng }] as const,
-  markingListAll: () => ["marking"] as const,
+  markingListAll: () => ["markingList"] as const,
   detail: (markingId: number) =>
     [...markingQueryKey.markingListAll(), { markingId }] as const,
   boundaryMarkingList: (
@@ -36,7 +36,7 @@ export const markingQueryKey = {
   myActivityMarkingList: (activity: Activity) =>
     [...markingQueryKey.markingListAll(), { activity }] as const,
   myTemporaryMarkingList: () =>
-    [...markingQueryKey.markingListAll(), "myTemporaryMarker"] as const,
+    [...markingQueryKey.markingListAll(), "temporary"] as const,
   userMarkingList: (
     nickname: string,
     bounds: Bounds,

--- a/src/entities/profile/api/getProfile.ts
+++ b/src/entities/profile/api/getProfile.ts
@@ -1,7 +1,7 @@
 import { skipToken, useQuery } from "@tanstack/react-query";
 import { apiClient, HttpError } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { PROFILE_END_POINT } from "../constants";
+import { PROFILE_END_POINT, profileQueryKey } from "../constants";
 
 // 유저 정보
 export type Nickname = string;
@@ -67,7 +67,7 @@ export const useGetProfile = ({ nickname }: { nickname: Nickname | null }) => {
   const token = useAuthStore((state) => state.token);
 
   return useQuery<GetProfileResponse, HttpError>({
-    queryKey: ["profile", nickname],
+    queryKey: profileQueryKey.profile(nickname!),
     queryFn: nickname && token ? () => getProfile({ nickname }) : skipToken,
     gcTime: 0,
   });
@@ -80,7 +80,7 @@ export const useGetMyProfile = <TResult = GetProfileResponse>(
   const nickname = useAuthStore((state) => state.nickname);
 
   return useQuery({
-    queryKey: ["profile", nickname],
+    queryKey: profileQueryKey.profile(nickname!),
     queryFn: nickname && token ? () => getProfile({ nickname }) : skipToken,
     gcTime: 0,
     select,

--- a/src/entities/profile/constants/index.ts
+++ b/src/entities/profile/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./endpoint";
+export * from "./queryKey";

--- a/src/entities/profile/constants/queryKey.ts
+++ b/src/entities/profile/constants/queryKey.ts
@@ -1,0 +1,7 @@
+export const profileQueryKey = {
+  profileAll: () => ["profile"],
+  profile: (nickname: string) => [
+    ...profileQueryKey.profileAll(),
+    { nickname },
+  ],
+};

--- a/src/features/auth/api/putChangeNickname.ts
+++ b/src/features/auth/api/putChangeNickname.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { authQueryKey } from "@/entities/auth/constants";
 import { apiClient } from "@/shared/lib";
 import { AuthStore, useAuthStore } from "@/shared/store/auth";
 import { CHANGE_USER_INFO_END_POINT } from "../constants";
@@ -25,7 +26,7 @@ export const usePutChangeNickname = () => {
       setNickname(variables.nickname);
 
       queryClient.invalidateQueries({
-        queryKey: ["myInfo"],
+        queryKey: authQueryKey.myInfo(),
       });
     },
   });

--- a/src/features/marking/api/deleteLikeMarking.ts
+++ b/src/features/marking/api/deleteLikeMarking.ts
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-query";
 import { useMapMode } from "@/features/map/hooks";
 import type { GetMyLikedMarkingListResponse } from "@/entities/marking/api";
+import { markingQueryKey } from "@/entities/marking/constants";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -27,7 +28,7 @@ export const useDeleteLikeMarking = () => {
     onSuccess: (_, { markingId }) => {
       if (mode === "MY_ACTIVITY") {
         queryClient.setQueryData<InfiniteData<GetMyLikedMarkingListResponse>>(
-          ["myLikedMarkingList"],
+          markingQueryKey.myActivityMarkingList("LIKED"),
           (oldData) => {
             if (!oldData) return oldData;
 
@@ -47,7 +48,7 @@ export const useDeleteLikeMarking = () => {
         );
 
         queryClient.invalidateQueries({
-          queryKey: ["myLikedMarkingList"],
+          queryKey: markingQueryKey.myActivityMarkingList("LIKED"),
         });
       }
     },

--- a/src/features/marking/api/deleteSavedMarking.ts
+++ b/src/features/marking/api/deleteSavedMarking.ts
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-query";
 import { useMapMode } from "@/features/map/hooks";
 import { GetMySavedMarkingListResponse } from "@/entities/marking/api";
+import { markingQueryKey } from "@/entities/marking/constants";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -27,7 +28,7 @@ export const useDeleteSavedMarking = () => {
     onSuccess: (_, { markingId }) => {
       if (mode === "MY_ACTIVITY") {
         queryClient.setQueryData<InfiniteData<GetMySavedMarkingListResponse>>(
-          ["mySavedMarkingList"],
+          markingQueryKey.myActivityMarkingList("SAVED"),
           (oldData) => {
             if (!oldData) return oldData;
 
@@ -47,7 +48,7 @@ export const useDeleteSavedMarking = () => {
         );
 
         queryClient.invalidateQueries({
-          queryKey: ["mySavedMarkingList"],
+          queryKey: markingQueryKey.myActivityMarkingList("SAVED"),
         });
       }
     },

--- a/src/features/marking/api/deleteTemporaryMarking.ts
+++ b/src/features/marking/api/deleteTemporaryMarking.ts
@@ -7,6 +7,7 @@ import type {
   GetTemporaryMarkingListResponse,
   TempMarkingInfo,
 } from "@/entities/marking/api";
+import { markingQueryKey } from "@/entities/marking/constants";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -27,7 +28,7 @@ export const useDeleteTemporaryMarking = () => {
     mutationKey: ["deleteTemporaryMarking"],
     onSuccess: (_data, { id }) => {
       queryClient.setQueryData<InfiniteData<GetTemporaryMarkingListResponse>>(
-        ["temporaryMarkingList"],
+        markingQueryKey.myTemporaryMarkingList(),
         (data) => {
           if (!data) {
             return data;
@@ -47,7 +48,7 @@ export const useDeleteTemporaryMarking = () => {
         },
       );
       queryClient.invalidateQueries({
-        queryKey: ["temporaryMarkingList"],
+        queryKey: markingQueryKey.myTemporaryMarkingList(),
       });
     },
   });

--- a/src/features/setting/api/postChangeRegion.ts
+++ b/src/features/setting/api/postChangeRegion.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { Region } from "@/entities/auth/api";
+import { authQueryKey } from "@/entities/auth/constants";
 import { apiClient } from "@/shared/lib";
 import { SETTING_END_POINT } from "../constants";
 
@@ -22,7 +23,7 @@ export const usePostChangeRegion = () => {
     mutationKey: ["postChangeRegion"],
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["myInfo"],
+        queryKey: authQueryKey.myInfo(),
       });
     },
     onError: (error) => {

--- a/src/features/setting/api/putChangeAge.tsx
+++ b/src/features/setting/api/putChangeAge.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { MyInfo } from "@/entities/auth/api";
+import { authQueryKey } from "@/entities/auth/constants";
 import { apiClient } from "@/shared/lib";
 import { SETTING_END_POINT } from "../constants";
 
@@ -29,7 +30,7 @@ export const usePutChangeAge = () => {
       ].reverse()[0];
 
       if (cachedMutation?.state.status === "pending") {
-        queryClient.invalidateQueries({ queryKey: ["myInfo"] });
+        queryClient.invalidateQueries({ queryKey: authQueryKey.myInfo() });
       }
     };
   }, [queryClient]);
@@ -40,25 +41,30 @@ export const usePutChangeAge = () => {
 
     /* 낙관적 업데이트 시행 */
     onMutate: async ({ age }) => {
-      await queryClient.cancelQueries({ queryKey: ["myInfo"] });
-      const prevQueryData = queryClient.getQueryData<MyInfo>(["myInfo"]);
+      await queryClient.cancelQueries({ queryKey: authQueryKey.myInfo() });
+      const prevQueryData = queryClient.getQueryData<MyInfo>(
+        authQueryKey.myInfo(),
+      );
 
-      queryClient.setQueryData(["myInfo"], (prevQueryData?: MyInfo) => {
-        if (!prevQueryData) return prevQueryData;
+      queryClient.setQueryData(
+        authQueryKey.myInfo(),
+        (prevQueryData?: MyInfo) => {
+          if (!prevQueryData) return prevQueryData;
 
-        return {
-          ...prevQueryData,
-          age,
-        };
-      });
+          return {
+            ...prevQueryData,
+            age,
+          };
+        },
+      );
 
       return prevQueryData;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["myInfo"] });
+      queryClient.invalidateQueries({ queryKey: authQueryKey.myInfo() });
     },
     onError: (_error, _variable, context) => {
-      queryClient.setQueryData(["myInfo"], context);
+      queryClient.setQueryData(authQueryKey.myInfo(), context);
     },
   });
 };

--- a/src/features/setting/api/putChangeGender.ts
+++ b/src/features/setting/api/putChangeGender.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { MyInfo } from "@/entities/auth/api";
+import { authQueryKey } from "@/entities/auth/constants";
 import { apiClient } from "@/shared/lib";
 import { SETTING_END_POINT } from "../constants";
 
@@ -29,7 +30,7 @@ export const usePutChangeGender = () => {
       ].reverse()[0];
 
       if (cachedMutation?.state.status === "pending") {
-        queryClient.invalidateQueries({ queryKey: ["myInfo"] });
+        queryClient.invalidateQueries({ queryKey: authQueryKey.myInfo() });
       }
     };
   }, [queryClient]);
@@ -40,24 +41,29 @@ export const usePutChangeGender = () => {
 
     /* 낙관적 업데이트 시행 */
     onMutate: async ({ gender }) => {
-      await queryClient.cancelQueries({ queryKey: ["myInfo"] });
-      const prevQueryData = queryClient.getQueryData<MyInfo>(["myInfo"]);
+      await queryClient.cancelQueries({ queryKey: authQueryKey.myInfo() });
+      const prevQueryData = queryClient.getQueryData<MyInfo>(
+        authQueryKey.myInfo(),
+      );
 
-      queryClient.setQueryData(["myInfo"], (prevQueryData?: MyInfo) => {
-        if (!prevQueryData) return prevQueryData;
-        return {
-          ...prevQueryData,
-          gender,
-        };
-      });
+      queryClient.setQueryData(
+        authQueryKey.myInfo(),
+        (prevQueryData?: MyInfo) => {
+          if (!prevQueryData) return prevQueryData;
+          return {
+            ...prevQueryData,
+            gender,
+          };
+        },
+      );
 
       return prevQueryData;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["myInfo"] });
+      queryClient.invalidateQueries({ queryKey: authQueryKey.myInfo() });
     },
     onError: (_error, _variable, context) => {
-      queryClient.setQueryData(["myInfo"], context);
+      queryClient.setQueryData(authQueryKey.myInfo(), context);
     },
   });
 };

--- a/src/features/setting/api/putChangePetInfo.ts
+++ b/src/features/setting/api/putChangePetInfo.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PetInfo } from "@/entities/profile/api";
+import { profileQueryKey } from "@/entities/profile/constants";
 import { apiClient } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { SETTING_END_POINT } from "../constants";
@@ -34,13 +35,14 @@ const putChangePetInfo = async ({
 
 export const usePutChangePetInfo = () => {
   const queryClient = useQueryClient();
+  const nickname = useAuthStore((state) => state.nickname);
 
   return useMutation<unknown, Error, PutChangePetInfoRequest>({
     mutationFn: putChangePetInfo,
     mutationKey: ["putChangePetInfo"],
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["profile", useAuthStore.getState().nickname],
+        queryKey: profileQueryKey.profile(nickname!),
       });
     },
     onError: (error) => {

--- a/src/features/setting/api/putSetPassword.tsx
+++ b/src/features/setting/api/putSetPassword.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
+import { authQueryKey } from "@/entities/auth/constants";
 import { apiClient, useSnackBar } from "@/shared/lib";
 import { SETTING_END_POINT } from "../constants";
 import { usePasswordSetFormStore } from "../store";
@@ -27,7 +28,7 @@ export const usePutSetPassword = () => {
     mutationKey: ["putSetPassword"],
     onSuccess: () => {
       /* isPasswordSet 값의 mutation 이 일어났기 때문에 새로운 데이터를 패치 해옵니다. */
-      queryClient.invalidateQueries({ queryKey: ["myInfo"] });
+      queryClient.invalidateQueries({ queryKey: authQueryKey.myInfo() });
       resetPasswordSetForm();
       handleOpenSnackbar("비밀번호가 설정 되었습니다.");
     },

--- a/src/widgets/marking/api/index.ts
+++ b/src/widgets/marking/api/index.ts
@@ -1,1 +1,0 @@
-export * from "./getDashboardMarkingThumbnail";

--- a/src/widgets/marking/constants/index.ts
+++ b/src/widgets/marking/constants/index.ts
@@ -1,7 +1,0 @@
-import type { Nickname } from "@/entities/profile/api";
-import { API_BASE_URL } from "@/shared/constants";
-
-export const MARKING_THUMBNAIL_END_POINT = {
-  DASHBOARD: (nickname: Nickname, pageParams: number) =>
-    `${API_BASE_URL}/markings/marks/${nickname}?offset=${pageParams}`,
-};

--- a/src/widgets/marking/ui/markingThumbnailGrid.tsx
+++ b/src/widgets/marking/ui/markingThumbnailGrid.tsx
@@ -1,8 +1,8 @@
 import { Link } from "react-router-dom";
+import { useGetDashboardMarkingThumbnail } from "@/entities/marking/api";
 import { Nickname } from "@/entities/profile/api";
 import { API_BASE_URL } from "@/shared/constants";
 import { useInfiniteScroll, useNicknameParams } from "@/shared/lib";
-import { useGetDashboardMarkingThumbnail } from "../api";
 
 interface MarkingThumbnailGridProps {
   nickname: Nickname;


### PR DESCRIPTION
# 관련 이슈 번호
close #469 
# 설명

 추후 리액트 쿼리를 최적화 하기 위해서 

쿼리키들을 일관된 패턴으로 관리하고 다른 뮤테이션들에서도 조회하기 쉽도록 쿼리키를 리팩토링 합니다.

https://highjoon-dev.vercel.app/blogs/8-effective-react-query-keys

사용하는 패턴은 위 게시글에 중점을 두고 진행합니다

사용하는 쿼리키들의 규칙은 다음과 같습니다.

# React Query에서 팩토리 패턴을 사용한 Query Key 관리 모범 사례

React Query에서 Query Key 관리를 위한 팩토리 패턴을 사용하면 일관성과 확장성, 가독성이 향상됩니다. 아래는 이 접근 방식을 사용할 때 유용한 규칙과 예시입니다.

1. 각 쿼리키들을 생성하는 팩토리 객체는 `${슬라이스명}queryKey` 라는 네이밍을 가집니다.
2. . 재사용 되는 쿼리키를 사용하는 쿼리키들은 재사용 쿼리키를 반환하는 메소드를 호출하여 생성 합니다.
```tsx
// 예시 
user : ()=>['user'],
userInfo : ()=>[...queryKey.user() , 'info']
```
3. 쿼리키 팩토리는 해당 슬라이스의 루트 쿼리키를  `all` 이라는 메소드명을 가집니다.
4. 루트 쿼리키는 두 가지 이상이 될 수 있습니다. 예를 들어 다음과 같이 사용 가능합니다.
```tsx
markerAll  : ()=> [...queryKey.all() , 'marker'], 
markingAll : ()=>[...queryKey.all() , 'marking']
```
5. 중복되는 쿼리키 네이밍을 지양합니다. 예시 : `['user' , 'userList'] X , ['user' , 'list'] O` 

# 쿼리키를 열거하기 보단 객체 형태로 사용 

리액트 쿼리에서 쿼리키는 어차피 `JSON.stringfy` 를 통해 직렬화 됩니다.

이에 의미를 가지는 쿼리키들을 객체 형태로 저장합니다.

![385135325-07cfc373-148d-4a22-a09b-735206098059](https://github.com/user-attachments/assets/4cd35eaa-6111-4927-b290-cb3469402ce2)

> 첫 번쨰 쿼리는 쿼리키를 객체 형태로 저장 , 마지막 쿼리는 아직 적용이 되지 않은 모습

객체 형태로 저장하게 되면 가지게 되는 이점은 다음과 같습니다.

1. 쿼리키의 의미를 살리기 때문에 devTools 에서 의미를 찾기 쉬움 
2. 쿼리키에서 해당 아이템의 순서와 상관 없이 사용 가능 

예를 들어 쿼리키를 `southWestLng , .... ` 이렇게 배열에 열거하면 사용처에서 해당 쿼리키의 순서에 맞춰 인수를 집어 넣어야 하지만 

객체 형태로 하게 되면 인수의 순서와 상관 없이 `{south ... , }`  이런식으로 넣어주면 됩니다.

# TODO  

이번 피알에선 단순히 기존에 존재하는 값들만 리팩토링 하였습니다.

보니까 마커가 추가되었을 때 마커들을 invalidate 시키는등의 행위가 없는 mutation 들이 존재 합니다.

이런 값들은 추후 수정해야 합니다.


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
