### PR TITLE
[Hotfix] fullPageModal 의 overlayWrapper 너비 수정

### DIFF
--- a/src/app/OverlayPortal.tsx
+++ b/src/app/OverlayPortal.tsx
@@ -21,14 +21,11 @@ const OverlayWrapper = ({ overlayInfo }: { overlayInfo: OverlayInfo }) => {
   // 만약 disabledInteraction 이 false인 경우 (Overlay와 함께 인터렉션을 할 경우)에는
   // OverlayController 영역을 최소화 합니다.
   const overlayAreaClass = disableInteraction
-    ? "h-screen w-screen bg-translucent-gray"
+    ? "h-screen w-[37.5rem] mx-auto bg-translucent-gray"
     : "w-screen h-fit";
 
   return (
-    <div
-      onClick={handleWrapperClick}
-      className={`absolute ${overlayAreaClass}`}
-    >
+    <div onClick={handleWrapperClick} className={`${overlayAreaClass}`}>
       {component}
     </div>
   );


### PR DESCRIPTION
# 관련 이슈 번호
close #472 
# 설명

![image](https://github.com/user-attachments/assets/17f396a5-1705-4c49-8e28-540d44843a02)

피시 화면에서 풀페이지 모달의 `OverlayWrapper` 컴포넌트가 뷰포트 전체 영역을 채우는 문제가 있습니다.

풀페이지 모달의 `OverlayWrapper` 의 너비를 서비스의 너비영역만큼으로 수정합니다.

![image](https://github.com/user-attachments/assets/a6acd6a0-3e26-4e34-ae86-6c37d8598e97)


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
