### PR TITLE
[Feat] 현 위치 재검색 선언적으로 수정 & 바운더리 값이 변경 되었을 때에만 나타나도록 수정

### DIFF
--- a/src/features/map/hooks/useMapQueryParams.ts
+++ b/src/features/map/hooks/useMapQueryParams.ts
@@ -1,7 +1,6 @@
 import { useSearchParams } from "react-router-dom";
 import type { SortType } from "@/entities/marking/api";
 import { sortTypeMap } from "../constants";
-import { useMapStore } from "../store";
 import type { Bounds } from "./useGetMapCurrentBounds";
 
 export interface Filter {
@@ -31,10 +30,6 @@ const getNumberParam = (
 
 export const useMapQueryParams = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-
-  const setIsLastSearchedLocation = useMapStore(
-    (state) => state.setIsLastSearchedLocation,
-  );
 
   const bounds: Bounds = {
     northEastLat: getNumberParam("boundsNELat", searchParams),
@@ -69,9 +64,6 @@ export const useMapQueryParams = () => {
       newSearchParams.set("sortType", sortType);
     }
 
-    setTimeout(() => {
-      setIsLastSearchedLocation(true);
-    }, 0);
     setSearchParams(newSearchParams);
   };
 

--- a/src/features/map/store/map.ts
+++ b/src/features/map/store/map.ts
@@ -30,9 +30,7 @@ interface MapState {
   userInfo: UserInfo;
   mode: Mode;
   isCenterOnMyLocation: boolean;
-  isLastSearchedLocation: boolean;
   mapInfo: MapInfo;
-  searchedBoundary: MapInfo["bounds"];
 }
 
 interface MapActions {
@@ -40,9 +38,7 @@ interface MapActions {
   setUserInfo: (userInfo: UserInfo) => void;
   setMode: (mode: Mode) => void;
   setIsCenterOnMyLocation: (isCenterOnMyLocation: boolean) => void;
-  setIsLastSearchedLocation: (isLastSearchedLocation: boolean) => void;
   setMapInfo: (mapInfo: MapInfo) => void;
-  setSearchedBoundary: (searchedBoundary: MapInfo["bounds"]) => void;
 }
 
 const mapStoreInitialState: MapState = {
@@ -53,13 +49,11 @@ const mapStoreInitialState: MapState = {
   },
   mode: "view",
   isCenterOnMyLocation: false,
-  isLastSearchedLocation: true,
   mapInfo: {
     center: MAP_INITIAL_CENTER,
     zoom: MAP_INITIAL_ZOOM,
     bounds: MAP_INITIAL_BOUNDS,
   },
-  searchedBoundary: MAP_INITIAL_BOUNDS,
 };
 
 export const useMapStore = create<MapState & MapActions>((set) => ({
@@ -68,9 +62,7 @@ export const useMapStore = create<MapState & MapActions>((set) => ({
   setMode: (mode) => set({ mode }),
   setIsCenterOnMyLocation: (isCenterOnMyLocation) =>
     set({ isCenterOnMyLocation }),
-  setIsLastSearchedLocation: (isLastSearchedLocation) =>
-    set({ isLastSearchedLocation }),
+
   setIsIdle: (isIdle) => set({ isIdle }),
   setMapInfo: (mapInfo) => set({ mapInfo }),
-  setSearchedBoundary: (searchedBoundary) => set({ searchedBoundary }),
 }));

--- a/src/features/map/store/map.ts
+++ b/src/features/map/store/map.ts
@@ -32,6 +32,7 @@ interface MapState {
   isCenterOnMyLocation: boolean;
   isLastSearchedLocation: boolean;
   mapInfo: MapInfo;
+  searchedBoundary: MapInfo["bounds"];
 }
 
 interface MapActions {
@@ -41,6 +42,7 @@ interface MapActions {
   setIsCenterOnMyLocation: (isCenterOnMyLocation: boolean) => void;
   setIsLastSearchedLocation: (isLastSearchedLocation: boolean) => void;
   setMapInfo: (mapInfo: MapInfo) => void;
+  setSearchedBoundary: (searchedBoundary: MapInfo["bounds"]) => void;
 }
 
 const mapStoreInitialState: MapState = {
@@ -57,6 +59,7 @@ const mapStoreInitialState: MapState = {
     zoom: MAP_INITIAL_ZOOM,
     bounds: MAP_INITIAL_BOUNDS,
   },
+  searchedBoundary: MAP_INITIAL_BOUNDS,
 };
 
 export const useMapStore = create<MapState & MapActions>((set) => ({
@@ -69,4 +72,5 @@ export const useMapStore = create<MapState & MapActions>((set) => ({
     set({ isLastSearchedLocation }),
   setIsIdle: (isIdle) => set({ isIdle }),
   setMapInfo: (mapInfo) => set({ mapInfo }),
+  setSearchedBoundary: (searchedBoundary) => set({ searchedBoundary }),
 }));

--- a/src/features/map/ui/mapControlButton.tsx
+++ b/src/features/map/ui/mapControlButton.tsx
@@ -55,21 +55,13 @@ export const MyLocationButton = () => {
   const isCenteredOnMyLocation = useMapStore(
     (state) => state.isCenterOnMyLocation,
   );
-  const setIsMapCenteredOnMyLocation = useMapStore(
-    (state) => state.setIsCenterOnMyLocation,
-  );
-
   const { loading, setCurrentLocation } = useCurrentLocation();
 
   const handleClick = () => {
     setCurrentLocation({
       onSuccess: ({ coords }) => {
         const { latitude: lat, longitude: lng } = coords;
-
         map.setCenter({ lat, lng });
-        setTimeout(() => {
-          setIsMapCenteredOnMyLocation(true);
-        }, 0);
       },
     });
   };

--- a/src/features/map/ui/markingResearchButton.tsx
+++ b/src/features/map/ui/markingResearchButton.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { ResetIcon } from "@/shared/ui/icon";
 import { useGetMapCurrentBounds, useMapQueryParams } from "../hooks";
 import { useMapStore } from "../store";
@@ -13,13 +13,22 @@ export const MarkingResearchButton = () => {
   const setIsLastSearchedLocation = useMapStore(
     (state) => state.setIsLastSearchedLocation,
   );
+  const setSearchedBoundary = useMapStore((state) => state.setSearchedBoundary);
 
   const { boundsParams, setMapQueryParams, sortTypeParam } =
     useMapQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
 
   useEffect(() => {
+    const { northEastLat, northEastLng, southWestLat, southWestLng } =
+      boundsParams;
     setIsLastSearchedLocation(true);
+    setSearchedBoundary({
+      east: northEastLng!,
+      north: northEastLat!,
+      south: southWestLat!,
+      west: southWestLng!,
+    });
   }, [JSON.stringify(boundsParams)]);
 
   if (pathname !== "/map" || isLastSearchedLocation) return null;

--- a/src/features/map/ui/markingResearchButton.tsx
+++ b/src/features/map/ui/markingResearchButton.tsx
@@ -1,18 +1,23 @@
-import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { ResetIcon } from "@/shared/ui/icon";
 import { useGetMapCurrentBounds, useMapQueryParams } from "../hooks";
+import { useMapStore } from "../store";
 
 export const MarkingResearchButton = () => {
   const { pathname } = useLocation();
-
-  const { boundsParams, setMapQueryParams, sortTypeParam } =
+  const { bounds } = useMapStore((state) => state.mapInfo);
+  const { boundsParams, setMapQueryParams, sortTypeParam, hasBoundsParams } =
     useMapQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
 
-  useEffect(() => {}, [JSON.stringify(boundsParams)]);
+  const isBoundInBoundsParams =
+    hasBoundsParams &&
+    bounds.east <= boundsParams.northEastLng! &&
+    bounds.west >= boundsParams.southWestLng! &&
+    bounds.north <= boundsParams.northEastLat! &&
+    bounds.south >= boundsParams.southWestLat!;
 
-  if (pathname !== "/map") return null;
+  if (pathname !== "/map" || isBoundInBoundsParams) return null;
 
   return (
     <div className="absolute top-4 left-1/2 transform -translate-x-1/2 translate-y-1/2">

--- a/src/features/map/ui/markingResearchButton.tsx
+++ b/src/features/map/ui/markingResearchButton.tsx
@@ -2,36 +2,17 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { ResetIcon } from "@/shared/ui/icon";
 import { useGetMapCurrentBounds, useMapQueryParams } from "../hooks";
-import { useMapStore } from "../store";
 
 export const MarkingResearchButton = () => {
   const { pathname } = useLocation();
-
-  const isLastSearchedLocation = useMapStore(
-    (state) => state.isLastSearchedLocation,
-  );
-  const setIsLastSearchedLocation = useMapStore(
-    (state) => state.setIsLastSearchedLocation,
-  );
-  const setSearchedBoundary = useMapStore((state) => state.setSearchedBoundary);
 
   const { boundsParams, setMapQueryParams, sortTypeParam } =
     useMapQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
 
-  useEffect(() => {
-    const { northEastLat, northEastLng, southWestLat, southWestLng } =
-      boundsParams;
-    setIsLastSearchedLocation(true);
-    setSearchedBoundary({
-      east: northEastLng!,
-      north: northEastLat!,
-      south: southWestLat!,
-      west: southWestLng!,
-    });
-  }, [JSON.stringify(boundsParams)]);
+  useEffect(() => {}, [JSON.stringify(boundsParams)]);
 
-  if (pathname !== "/map" || isLastSearchedLocation) return null;
+  if (pathname !== "/map") return null;
 
   return (
     <div className="absolute top-4 left-1/2 transform -translate-x-1/2 translate-y-1/2">

--- a/src/features/map/ui/markingResearchButton.tsx
+++ b/src/features/map/ui/markingResearchButton.tsx
@@ -13,19 +13,21 @@ export const MarkingResearchButton = () => {
   if (isLastSearchedLocation) return null;
 
   return (
-    <button
-      className="flex text-tangerine-500 gap-2 pl-2 pr-3 h-8 items-center rounded-2xl bg-grey-0 shadow-custom-1"
-      onClick={() => {
-        setMapQueryParams({
-          bounds: getMapBounds(),
-          sortType: sortTypeParam!,
-        });
-      }}
-    >
-      <ResetIcon width={20} height={20} />
-      <span className="text-grey-500 btn-3 text-center">
-        현 지도에서 재검색
-      </span>
-    </button>
+    <div className="absolute top-4 left-1/2 transform -translate-x-1/2 translate-y-1/2">
+      <button
+        className="flex text-tangerine-500 gap-2 pl-2 pr-3 h-8 items-center rounded-2xl bg-grey-0 shadow-custom-1"
+        onClick={() => {
+          setMapQueryParams({
+            bounds: getMapBounds(),
+            sortType: sortTypeParam!,
+          });
+        }}
+      >
+        <ResetIcon width={20} height={20} />
+        <span className="text-grey-500 btn-3 text-center">
+          현 지도에서 재검색
+        </span>
+      </button>
+    </div>
   );
 };

--- a/src/features/map/ui/markingResearchButton.tsx
+++ b/src/features/map/ui/markingResearchButton.tsx
@@ -1,4 +1,5 @@
-import { useLocation } from "react-router-dom";
+import { useEffect } from "react";
+import { useLocation, useSearchParams } from "react-router-dom";
 import { ResetIcon } from "@/shared/ui/icon";
 import { useGetMapCurrentBounds, useMapQueryParams } from "../hooks";
 import { useMapStore } from "../store";
@@ -9,9 +10,17 @@ export const MarkingResearchButton = () => {
   const isLastSearchedLocation = useMapStore(
     (state) => state.isLastSearchedLocation,
   );
+  const setIsLastSearchedLocation = useMapStore(
+    (state) => state.setIsLastSearchedLocation,
+  );
 
-  const { setMapQueryParams, sortTypeParam } = useMapQueryParams();
+  const { boundsParams, setMapQueryParams, sortTypeParam } =
+    useMapQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
+
+  useEffect(() => {
+    setIsLastSearchedLocation(true);
+  }, [JSON.stringify(boundsParams)]);
 
   if (pathname !== "/map" || isLastSearchedLocation) return null;
 

--- a/src/features/map/ui/markingResearchButton.tsx
+++ b/src/features/map/ui/markingResearchButton.tsx
@@ -1,8 +1,11 @@
+import { useLocation } from "react-router-dom";
 import { ResetIcon } from "@/shared/ui/icon";
 import { useGetMapCurrentBounds, useMapQueryParams } from "../hooks";
 import { useMapStore } from "../store";
 
 export const MarkingResearchButton = () => {
+  const { pathname } = useLocation();
+
   const isLastSearchedLocation = useMapStore(
     (state) => state.isLastSearchedLocation,
   );
@@ -10,7 +13,7 @@ export const MarkingResearchButton = () => {
   const { setMapQueryParams, sortTypeParam } = useMapQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
 
-  if (isLastSearchedLocation) return null;
+  if (pathname !== "/map" || isLastSearchedLocation) return null;
 
   return (
     <div className="absolute top-4 left-1/2 transform -translate-x-1/2 translate-y-1/2">

--- a/src/features/map/ui/markingResearchButton.tsx
+++ b/src/features/map/ui/markingResearchButton.tsx
@@ -10,14 +10,14 @@ export const MarkingResearchButton = () => {
     useMapQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
 
-  const isBoundInBoundsParams =
+  const isMapInsideBoundsParams =
     hasBoundsParams &&
     bounds.east <= boundsParams.northEastLng! &&
     bounds.west >= boundsParams.southWestLng! &&
     bounds.north <= boundsParams.northEastLat! &&
     bounds.south >= boundsParams.southWestLat!;
 
-  if (pathname !== "/map" || isBoundInBoundsParams) return null;
+  if (pathname !== "/map" || isMapInsideBoundsParams) return null;
 
   return (
     <div className="absolute top-4 left-1/2 transform -translate-x-1/2 translate-y-1/2">

--- a/src/widgets/map/ui/googleMaps.tsx
+++ b/src/widgets/map/ui/googleMaps.tsx
@@ -15,13 +15,10 @@ interface GoogleMapProps {
  */
 export const GoogleMaps = ({ children }: GoogleMapProps) => {
   const isTilesLoadedRef = useRef<boolean>(false);
-  const setIsIdle = useMapStore((state) => state.setIsIdle);
 
+  const setIsIdle = useMapStore((state) => state.setIsIdle);
   const setIsMapCenteredOnMyLocation = useMapStore(
     (state) => state.setIsCenterOnMyLocation,
-  );
-  const setIsLastSearchedLocation = useMapStore(
-    (state) => state.setIsLastSearchedLocation,
   );
   const setMapInfo = useMapStore((state) => state.setMapInfo);
 
@@ -50,15 +47,6 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
       zoom: zoom,
       bounds,
     });
-
-    const { east, north, south, west } =
-      useMapStore.getState().searchedBoundary;
-    setIsLastSearchedLocation(
-      bounds.north <= north &&
-        bounds.south >= south &&
-        bounds.west >= west &&
-        bounds.east <= east,
-    );
   };
 
   // 해당 useEffect는 Google Maps API를 사용할 때, 기본적으로 제공되는 outline을 제거하기 위한 코드입니다.

--- a/src/widgets/map/ui/googleMaps.tsx
+++ b/src/widgets/map/ui/googleMaps.tsx
@@ -27,29 +27,38 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
 
   const handleMapChange = () => {
     if (!isTilesLoadedRef.current) return;
-    setIsLastSearchedLocation(false);
+
     setIsMapCenteredOnMyLocation(false);
   };
 
   const handleMapIdle = ({ map }: MapEvent) => {
     const center = map.getCenter();
     const zoom = map.getZoom();
-    const bounds = map.getBounds();
+    const northEast = map.getBounds().getNorthEast();
+    const southWest = map.getBounds().getSouthWest();
 
-    const northEast = bounds.getNorthEast();
-    const southWest = bounds.getSouthWest();
+    const bounds = {
+      east: northEast.lng(),
+      north: northEast.lat(),
+      west: southWest.lng(),
+      south: southWest.lat(),
+    };
 
     setIsIdle(true);
     setMapInfo({
       center: { lat: center.lat(), lng: center.lng() },
       zoom: zoom,
-      bounds: {
-        east: northEast.lng(),
-        north: northEast.lat(),
-        west: southWest.lng(),
-        south: southWest.lat(),
-      },
+      bounds,
     });
+
+    const { east, north, south, west } =
+      useMapStore.getState().searchedBoundary;
+    setIsLastSearchedLocation(
+      bounds.north <= north &&
+        bounds.south >= south &&
+        bounds.west >= west &&
+        bounds.east <= east,
+    );
   };
 
   // 해당 useEffect는 Google Maps API를 사용할 때, 기본적으로 제공되는 outline을 제거하기 위한 코드입니다.

--- a/src/widgets/map/ui/googleMaps.tsx
+++ b/src/widgets/map/ui/googleMaps.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useRef } from "react";
-import { Map, MapEvent } from "@vis.gl/react-google-maps";
+import {
+  Map,
+  MapCameraChangedEvent,
+  MapEvent,
+} from "@vis.gl/react-google-maps";
 import { MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM } from "@/features/map/constants";
 import { useMapStore } from "@/features/map/store/map";
 import { mapOptions } from "../constants";
@@ -22,10 +26,13 @@ export const GoogleMaps = ({ children }: GoogleMapProps) => {
   );
   const setMapInfo = useMapStore((state) => state.setMapInfo);
 
-  const handleMapChange = () => {
+  const handleMapChange = ({ detail }: MapCameraChangedEvent) => {
     if (!isTilesLoadedRef.current) return;
-
-    setIsMapCenteredOnMyLocation(false);
+    const { center } = detail;
+    const { currentLocation } = useMapStore.getState().userInfo;
+    setIsMapCenteredOnMyLocation(
+      center.lat === currentLocation.lat && center.lng === currentLocation.lng,
+    );
   };
 
   const handleMapIdle = ({ map }: MapEvent) => {

--- a/src/widgets/map/ui/mapControlWidget.tsx
+++ b/src/widgets/map/ui/mapControlWidget.tsx
@@ -21,9 +21,7 @@ export const MapControlWidget = () => {
     return (
       <>
         {/* Map 최하단에 렌더링 될 컨트롤 버튼들 */}
-        <div className="absolute top-4 left-1/2 transform -translate-x-1/2 translate-y-1/2">
-          <MarkingResearchButton />
-        </div>
+        <MarkingResearchButton />
         <div className="absolute bottom-[6.875rem] left-4">
           <MyLocationButton />
         </div>

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -39,10 +39,10 @@ export const MapInitializer = () => {
 
         if (!hasBoundsParams) {
           map.setCenter(currentLocationOfUser);
-
-          setTimeout(() => {
-            setIsCenteredOnMyLocation(true);
-          }, 0);
+          // 현재 위치를 기준으로 중앙에 위치하도록 설정합니다.
+          // 원래 setIsCenteredOnMyLocation 의 경우 GoogleMap 컴포넌트 내부의 handleCameraChange 에서 처리하도록 되어 있습니다.
+          // 하지만, 초기화 단계에서는 handleCameraChange 가 호출되지 않아서, 초기화 단계에서 처리합니다.
+          setIsCenteredOnMyLocation(true);
 
           setMapQueryParams({
             bounds: getMapBounds(),


### PR DESCRIPTION
# 관련 이슈 번호
close #474 
# 설명

## markingResearchButton 기능 수정 
```tsx
export const MarkingResearchButton = () => {
  const { pathname } = useLocation();
  ...
  useEffect(() => {
    const { northEastLat, northEastLng, southWestLat, southWestLng } =
      boundsParams;
    setIsLastSearchedLocation(true);
    setSearchedBoundary({
      east: northEastLng!,
      north: northEastLat!,
      south: southWestLat!,
      west: southWestLng!,
    });
  }, [JSON.stringify(boundsParams)]);
// /map 이란 패스에서만 나타나도록 기능 수정
 if (pathname !== "/map" || isLastSearchedLocation) return null;
```

이전 `setTimeout` 으로 상태를 명령적으로 변경시키던 양상을 `useEffect` 를 이용해 선언적으로 변경했습니다.

그리고 mapStore 에서 `searchedBoundary` 라는 상태를 추가해줬습니다.

해당 상태는 다음처럼 사용 됩니다.

## 지도에서 현위치 재검색이 나타나는 조건 
```tsx
Map 컴포넌트의 일부 
  const handleMapIdle = ({ map }: MapEvent) => {
    const center = map.getCenter();
    const zoom = map.getZoom();
    const northEast = map.getBounds().getNorthEast();
    const southWest = map.getBounds().getSouthWest();

    const bounds = {
      east: northEast.lng(),
      north: northEast.lat(),
      west: southWest.lng(),
      south: southWest.lat(),
    };
  ...

    const { east, north, south, west } =
      useMapStore.getState().searchedBoundary;

    setIsLastSearchedLocation(
      bounds.north <= north &&
        bounds.south >= south &&
        bounds.west >= west &&
        bounds.east <= east,
    );
  };
```

지도의 이동이 모두 일어났을 때 현재의 지도 바운더리가 이전 마커를 불러왔던 바운더리 내부에 존재하는지를 확인하고 
`isLastSearchedLocation` 상태를 변경 합니다.




# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
