### PR TITLE
[Feat] 맵 이니셜라이저 버그 수정 & 이 장소 마킹 라우팅 및 API 요청

### DIFF
--- a/src/entities/map/lib/tiling.ts
+++ b/src/entities/map/lib/tiling.ts
@@ -117,7 +117,10 @@ const calculateTileIndex = (
   return [lngIndex, latIndex];
 };
 
-const filterInnerBoundary = ({ lat, lng }: LatLng, bounds: MapBounds) => {
+export const filterInnerBoundary = (
+  { lat, lng }: LatLng,
+  bounds: MapBounds,
+) => {
   return (
     lat < bounds.north &&
     lat > bounds.south &&

--- a/src/entities/map/ui/customMarker.tsx
+++ b/src/entities/map/ui/customMarker.tsx
@@ -1,10 +1,12 @@
+import { useNavigate } from "react-router-dom";
 import {
   AdvancedMarker,
   AdvancedMarkerProps,
   useMap,
 } from "@vis.gl/react-google-maps";
 import { mapOptions } from "@/widgets/map/constants";
-import { API_BASE_URL } from "@/shared/constants";
+import { usePlaceQueryParams } from "@/features/map/hooks";
+import { API_BASE_URL, ROUTER_PATH } from "@/shared/constants";
 import { Badge } from "@/shared/ui/badge";
 import { PinShadowIcon } from "@/shared/ui/icon";
 import { Tile } from "../lib";
@@ -81,15 +83,28 @@ interface MarkingPinProps {
 export const MarkingPins = ({ tiles }: MarkingPinProps) => {
   const map = useMap();
   const zoom = map.getZoom();
+  const navigate = useNavigate();
+
+  const { placeParams, setPlaceQueryParams } = usePlaceQueryParams();
+
+  const isMarkerInBottomSheet = (position: Tile["position"]) => {
+    return placeParams.lat === position.lat && placeParams.lng === position.lng;
+  };
 
   const handleClickSingleMarker = (position: Tile["position"]) => {
     map.setCenter(position);
     map.setZoom(mapOptions.maxZoom);
+    navigate(ROUTER_PATH.PLACE);
+    setPlaceQueryParams(position);
   };
 
-  const handleClickMultipleMarker = (position: Tile["position"]) => {
+  const handleClickMultipleMarker = async (position: Tile["position"]) => {
     map.setCenter(position);
     map.setZoom(zoom + 1);
+    if (mapOptions.maxZoom === zoom) {
+      navigate(ROUTER_PATH.PLACE);
+      setPlaceQueryParams(position);
+    }
   };
 
   return tiles.map(({ markingId, markerCount, position, previewImage }) => {
@@ -105,6 +120,7 @@ export const MarkingPins = ({ tiles }: MarkingPinProps) => {
           imageUrl={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
           alt={`marking-${markingId} 마커를 나타내는 핀`}
           onClick={() => handleClickSingleMarker(position)}
+          className={`${isMarkerInBottomSheet(position) ? "scale-[2]" : ""}`}
         />
       );
     }
@@ -116,6 +132,7 @@ export const MarkingPins = ({ tiles }: MarkingPinProps) => {
         imageUrl={`${API_BASE_URL}/markings/image/preview/${markingId}/${previewImage}`}
         alt={`${markerCount}개의 마커를 담은 멀티핀`}
         onClick={() => handleClickMultipleMarker(position)}
+        className={`${isMarkerInBottomSheet(position) ? "scale-[2]" : ""}`}
       >
         {markerCount}
       </MultiplePin>

--- a/src/entities/marking/api/getBoundaryMarkerList.ts
+++ b/src/entities/marking/api/getBoundaryMarkerList.ts
@@ -88,7 +88,6 @@ export const useGetBoundaryMarkerList = ({
         northEastLng: northEastLng!,
       });
     },
-
-    gcTime: 0,
+    staleTime: 1000 * 60 * 1,
   });
 };

--- a/src/features/map/hooks/index.ts
+++ b/src/features/map/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useCurrentLocation";
 export * from "./useGetMapCurrentBounds";
 export * from "./useMapQueryParams";
 export * from "./useMapMode";
+export * from "./usePlaceQueryParams";

--- a/src/features/map/hooks/useMapQueryParams.ts
+++ b/src/features/map/hooks/useMapQueryParams.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import type { SortType } from "@/entities/marking/api";
 import { sortTypeMap } from "../constants";
@@ -31,12 +32,21 @@ export const getNumberParam = (
 export const useMapQueryParams = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const bounds: Bounds = {
-    northEastLat: getNumberParam("boundsNELat", searchParams),
-    northEastLng: getNumberParam("boundsNELng", searchParams),
-    southWestLat: getNumberParam("boundsSWLat", searchParams),
-    southWestLng: getNumberParam("boundsSWLng", searchParams),
-  };
+  const northEastLat = getNumberParam("boundsNELat", searchParams);
+  const northEastLng = getNumberParam("boundsNELng", searchParams);
+  const southWestLat = getNumberParam("boundsSWLat", searchParams);
+  const southWestLng = getNumberParam("boundsSWLng", searchParams);
+
+  const bounds: Bounds = useMemo(
+    () => ({
+      northEastLat,
+      northEastLng,
+      southWestLat,
+      southWestLng,
+    }),
+    [northEastLat, northEastLng, southWestLat, southWestLng],
+  );
+
   const hasBoundsParams = Object.values(bounds).every(
     (value) => value !== null,
   );

--- a/src/features/map/hooks/useMapQueryParams.ts
+++ b/src/features/map/hooks/useMapQueryParams.ts
@@ -8,7 +8,7 @@ export interface Filter {
   bounds?: Bounds;
 }
 
-const getNumberParam = (
+export const getNumberParam = (
   key: string,
   searchParams: URLSearchParams,
 ): number | null => {

--- a/src/features/map/hooks/usePlaceQueryParams.ts
+++ b/src/features/map/hooks/usePlaceQueryParams.ts
@@ -51,7 +51,7 @@ export const usePlaceQueryParams = () => {
       lat: (northEastLat + southWestLat) / 2,
       lng: (northEastLng + southWestLng) / 2,
     });
-  }, [pathname, JSON.stringify(boundsParams)]);
+  }, [pathname, boundsParams]);
 
   return {
     placeParams: { lat, lng },

--- a/src/features/map/hooks/usePlaceQueryParams.ts
+++ b/src/features/map/hooks/usePlaceQueryParams.ts
@@ -7,7 +7,7 @@ import { getNumberParam, useMapQueryParams } from "./useMapQueryParams";
 export const usePlaceQueryParams = () => {
   const { pathname } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { boundsParams, hasBoundsParams } = useMapQueryParams();
+  const { boundsParams } = useMapQueryParams();
 
   const setPlaceQueryParams = ({ lat, lng }: { lat: number; lng: number }) => {
     setSearchParams((prevSearchParams) => {
@@ -35,7 +35,13 @@ export const usePlaceQueryParams = () => {
   };
 
   useEffect(() => {
-    if (pathname !== ROUTER_PATH.PLACE || !hasBoundsParams) {
+    const { northEastLat, northEastLng, southWestLat, southWestLng } =
+      boundsParams;
+
+    if (
+      !(northEastLat && northEastLng && southWestLat && southWestLng) ||
+      pathname !== ROUTER_PATH.PLACE
+    ) {
       return;
     }
 
@@ -46,21 +52,12 @@ export const usePlaceQueryParams = () => {
     if (lat && lng && filterInnerBoundary({ lat, lng }, boundsParams)) {
       return;
     }
-
-    // 만약 유효하지 않은 lat , lng 값을 가지고 있는 경우엔 boundsParams 의 중심으로 lat , lng 값을 지정합니다.
-    const { northEastLat, northEastLng, southWestLat, southWestLng } =
-      boundsParams;
-
-    // hasBoundsParams 가 true 이면 해당 값들은 항상 true 입니다.
-    // 타입 단언을 사용하여 값이 존재한다는 것을 명시적으로 표현합니다.
-
-    if (northEastLat && northEastLng && southWestLat && southWestLng) {
-      setPlaceQueryParams({
-        lat: northEastLat - (northEastLat - southWestLat) / 2,
-        lng: northEastLng - (northEastLng - southWestLng) / 2,
-      });
-    }
-  }, [pathname, JSON.stringify(boundsParams), hasBoundsParams]);
+    // lat , lng 가 유효하지 않은 경우 boundsParams 의 중심값을 사용합니다.
+    setPlaceQueryParams({
+      lat: northEastLat - (northEastLat - southWestLat) / 2,
+      lng: northEastLng - (northEastLng - southWestLng) / 2,
+    });
+  }, [pathname, JSON.stringify(boundsParams)]);
 
   return { placeParams, setPlaceQueryParams, latLng100meterBounds };
 };

--- a/src/features/map/hooks/usePlaceQueryParams.ts
+++ b/src/features/map/hooks/usePlaceQueryParams.ts
@@ -18,15 +18,27 @@ export const usePlaceQueryParams = () => {
     });
   };
 
+  const lat = getNumberParam("lat", searchParams);
+  const lng = getNumberParam("lng", searchParams);
   const placeParams = {
-    lat: getNumberParam("lat", searchParams),
-    lng: getNumberParam("lng", searchParams),
+    lat,
+    lng,
+  };
+
+  // lat , lng 로부터 반경 100m의 경계값을 계산합니다.
+  // 100m 는 0.0009이기에 중심으로부터 0.00045씩 떨어진 값을 사용합니다.
+  const latLng100meterBounds = {
+    northEastLat: lat && lat + 0.00045,
+    northEastLng: lng && lng + 0.00045,
+    southWestLat: lat && lat - 0.00045,
+    southWestLng: lng && lng - 0.00045,
   };
 
   useEffect(() => {
     if (pathname !== ROUTER_PATH.PLACE || !hasBoundsParams) {
       return;
     }
+
     // searchParameter 에 lat, lng 가 있고, 현재 검색된 boundsParams 내부에 존재하는
     // 유효한 경계값이라면, 해당 값을 사용합니다.
     const lat = getNumberParam("lat", searchParams);
@@ -48,7 +60,7 @@ export const usePlaceQueryParams = () => {
         lng: northEastLng - (northEastLng - southWestLng) / 2,
       });
     }
-  }, [pathname, boundsParams, hasBoundsParams]);
+  }, [pathname, JSON.stringify(boundsParams), hasBoundsParams]);
 
-  return { placeParams, setPlaceQueryParams };
+  return { placeParams, setPlaceQueryParams, latLng100meterBounds };
 };

--- a/src/features/map/hooks/usePlaceQueryParams.ts
+++ b/src/features/map/hooks/usePlaceQueryParams.ts
@@ -48,8 +48,8 @@ export const usePlaceQueryParams = () => {
     }
     // lat , lng 가 유효하지 않은 경우 boundsParams 의 중심값을 사용합니다.
     setPlaceQueryParams({
-      lat: northEastLat - (northEastLat - southWestLat) / 2,
-      lng: northEastLng - (northEastLng - southWestLng) / 2,
+      lat: (northEastLat + southWestLat) / 2,
+      lng: (northEastLng + southWestLng) / 2,
     });
   }, [pathname, JSON.stringify(boundsParams)]);
 

--- a/src/features/map/hooks/usePlaceQueryParams.ts
+++ b/src/features/map/hooks/usePlaceQueryParams.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useLocation, useSearchParams } from "react-router-dom";
+import { filterInnerBoundary } from "@/entities/map/lib";
+import { ROUTER_PATH } from "@/shared/constants";
+import { getNumberParam, useMapQueryParams } from "./useMapQueryParams";
+
+export const usePlaceQueryParams = () => {
+  const { pathname } = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { boundsParams, hasBoundsParams } = useMapQueryParams();
+
+  const setPlaceQueryParams = ({ lat, lng }: { lat: number; lng: number }) => {
+    setSearchParams((prevSearchParams) => {
+      const newSearchParams = new URLSearchParams(prevSearchParams);
+      newSearchParams.set("lat", lat.toString());
+      newSearchParams.set("lng", lng.toString());
+      return newSearchParams;
+    });
+  };
+
+  const placeParams = {
+    lat: getNumberParam("lat", searchParams),
+    lng: getNumberParam("lng", searchParams),
+  };
+
+  useEffect(() => {
+    if (pathname !== ROUTER_PATH.PLACE || !hasBoundsParams) {
+      return;
+    }
+    // searchParameter 에 lat, lng 가 있고, 현재 검색된 boundsParams 내부에 존재하는
+    // 유효한 경계값이라면, 해당 값을 사용합니다.
+    const lat = getNumberParam("lat", searchParams);
+    const lng = getNumberParam("lng", searchParams);
+    if (lat && lng && filterInnerBoundary({ lat, lng }, boundsParams)) {
+      return;
+    }
+
+    // 만약 유효하지 않은 lat , lng 값을 가지고 있는 경우엔 boundsParams 의 중심으로 lat , lng 값을 지정합니다.
+    const { northEastLat, northEastLng, southWestLat, southWestLng } =
+      boundsParams;
+
+    // hasBoundsParams 가 true 이면 해당 값들은 항상 true 입니다.
+    // 타입 단언을 사용하여 값이 존재한다는 것을 명시적으로 표현합니다.
+
+    if (northEastLat && northEastLng && southWestLat && southWestLng) {
+      setPlaceQueryParams({
+        lat: northEastLat - (northEastLat - southWestLat) / 2,
+        lng: northEastLng - (northEastLng - southWestLng) / 2,
+      });
+    }
+  }, [pathname, boundsParams, hasBoundsParams]);
+
+  return { placeParams, setPlaceQueryParams };
+};

--- a/src/features/map/hooks/usePlaceQueryParams.ts
+++ b/src/features/map/hooks/usePlaceQueryParams.ts
@@ -20,14 +20,10 @@ export const usePlaceQueryParams = () => {
 
   const lat = getNumberParam("lat", searchParams);
   const lng = getNumberParam("lng", searchParams);
-  const placeParams = {
-    lat,
-    lng,
-  };
 
   // lat , lng 로부터 반경 100m의 경계값을 계산합니다.
   // 100m 는 0.0009이기에 중심으로부터 0.00045씩 떨어진 값을 사용합니다.
-  const latLng100meterBounds = {
+  const boundsAdjacentPlace = {
     northEastLat: lat && lat + 0.00045,
     northEastLng: lng && lng + 0.00045,
     southWestLat: lat && lat - 0.00045,
@@ -47,8 +43,6 @@ export const usePlaceQueryParams = () => {
 
     // searchParameter 에 lat, lng 가 있고, 현재 검색된 boundsParams 내부에 존재하는
     // 유효한 경계값이라면, 해당 값을 사용합니다.
-    const lat = getNumberParam("lat", searchParams);
-    const lng = getNumberParam("lng", searchParams);
     if (lat && lng && filterInnerBoundary({ lat, lng }, boundsParams)) {
       return;
     }
@@ -59,5 +53,9 @@ export const usePlaceQueryParams = () => {
     });
   }, [pathname, JSON.stringify(boundsParams)]);
 
-  return { placeParams, setPlaceQueryParams, latLng100meterBounds };
+  return {
+    placeParams: { lat, lng },
+    setPlaceQueryParams,
+    boundsAdjacentPlace,
+  };
 };

--- a/src/features/map/ui/markingResearchButton.tsx
+++ b/src/features/map/ui/markingResearchButton.tsx
@@ -1,4 +1,5 @@
 import { useLocation } from "react-router-dom";
+import { ROUTER_PATH } from "@/shared/constants";
 import { ResetIcon } from "@/shared/ui/icon";
 import { useGetMapCurrentBounds, useMapQueryParams } from "../hooks";
 import { useMapStore } from "../store";
@@ -17,7 +18,10 @@ export const MarkingResearchButton = () => {
     bounds.north <= boundsParams.northEastLat! &&
     bounds.south >= boundsParams.southWestLat!;
 
-  if (pathname !== "/map" || isMapInsideBoundsParams) return null;
+  const isValidPath =
+    pathname === ROUTER_PATH.MAP || pathname === ROUTER_PATH.PLACE;
+
+  if (!isValidPath || isMapInsideBoundsParams) return null;
 
   return (
     <div className="absolute top-4 left-1/2 transform -translate-x-1/2 translate-y-1/2">

--- a/src/pages/map/page.tsx
+++ b/src/pages/map/page.tsx
@@ -1,4 +1,4 @@
-import { LocalMarkingList } from "@/widgets/map/ui";
+import { LocalMarkingListBottomSheet } from "@/widgets/map/ui";
 import { useMapQueryParams } from "@/features/map/hooks";
 import { MarkingPins } from "@/entities/map/ui";
 import { useGetBoundaryMarkerList } from "@/entities/marking/api";
@@ -12,7 +12,7 @@ export const MapPage = () => {
   return (
     <>
       {data && <MarkingPins tiles={data} />}
-      <LocalMarkingList />
+      <LocalMarkingListBottomSheet />
     </>
   );
 };

--- a/src/pages/map/place/page.tsx
+++ b/src/pages/map/place/page.tsx
@@ -1,5 +1,10 @@
+import { useEffect } from "react";
+import { useMap } from "@vis.gl/react-google-maps";
+import { mapOptions } from "@/widgets/map/constants";
 import { PlaceMarkingList } from "@/widgets/map/ui";
+import { MAP_INITIAL_ZOOM } from "@/features/map/constants";
 import { useMapQueryParams } from "@/features/map/hooks";
+import { useMapStore } from "@/features/map/store";
 import { MarkingPins } from "@/entities/map/ui";
 import { useGetBoundaryMarkerList } from "@/entities/marking/api";
 
@@ -8,6 +13,18 @@ export const PlaceMarkingPage = () => {
   const { data } = useGetBoundaryMarkerList({
     ...boundsParams,
   });
+  const map = useMap();
+  const isIdle = useMapStore((state) => state.isIdle);
+
+  // 이 장소 마킹으로 초기 진입한 경우에는 maxZoom 으로 변경합니다.
+  useEffect(() => {
+    if (!isIdle) return;
+
+    const { zoom } = useMapStore.getState().mapInfo;
+    if (zoom === MAP_INITIAL_ZOOM) {
+      map.setZoom(mapOptions.maxZoom);
+    }
+  }, [isIdle]);
 
   return (
     <>

--- a/src/pages/map/place/page.tsx
+++ b/src/pages/map/place/page.tsx
@@ -18,13 +18,13 @@ export const PlaceMarkingPage = () => {
 
   // 이 장소 마킹으로 초기 진입한 경우에는 maxZoom 으로 변경합니다.
   useEffect(() => {
-    if (!isIdle) return;
+    if (!map || !isIdle) return;
 
     const { zoom } = useMapStore.getState().mapInfo;
     if (zoom === MAP_INITIAL_ZOOM) {
       map.setZoom(mapOptions.maxZoom);
     }
-  }, [isIdle]);
+  }, [map, isIdle]);
 
   return (
     <>

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -57,7 +57,7 @@ const LocalMarkingList = () => {
             key={markingId}
             type="button"
             className="aspect-square"
-            onClick={async () => {
+            onClick={() => {
               navigate(ROUTER_PATH.PLACE);
               map.setCenter({ lat, lng });
               map.setZoom(mapOptions.maxZoom);

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -29,7 +29,8 @@ export const LocalMarkingListBottomSheet = () => {
 const LocalMarkingList = () => {
   const navigate = useNavigate();
   const map = useMap();
-  const { boundsParams, sortTypeParam } = useMapQueryParams();
+  const { boundsParams, sortTypeParam, setMapQueryParams } =
+    useMapQueryParams();
   const { setPlaceQueryParams } = usePlaceQueryParams();
 
   const {
@@ -62,6 +63,10 @@ const LocalMarkingList = () => {
               map.setCenter({ lat, lng });
               map.setZoom(mapOptions.maxZoom);
               setPlaceQueryParams({ lat, lng });
+              setMapQueryParams({
+                bounds: boundsParams,
+                sortType: "POPULARITY",
+              });
             }}
           >
             <img

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -64,7 +64,6 @@ const LocalMarkingList = () => {
               map.setZoom(mapOptions.maxZoom);
               setPlaceQueryParams({ lat, lng });
               setMapQueryParams({
-                bounds: boundsParams,
                 sortType: "POPULARITY",
               });
             }}

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -15,12 +15,26 @@ import { MyLocationIcon } from "@/shared/ui/icon";
 import { mapOptions } from "../constants";
 import { MarkingList } from "./markingList";
 
-export const LocalMarkingList = () => {
-  const map = useMap();
-  const getCurrentMapBounds = useGetMapCurrentBounds();
+export const LocalMarkingListBottomSheet = () => {
+  return (
+    <div className="px-4">
+      {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
+      <h1 className="title-1 text-grey-900 py-4">동네 마킹</h1>
+      <div className="flex justify-between items-center mb-4">
+        <LocalMarkingListBottomSheetHeader />
+        <LocationMarkingListFilter />
+      </div>
+      <LocalMarkingList />
+    </div>
+  );
+};
+
+const LocalMarkingList = () => {
   const navigate = useNavigate();
+  const map = useMap();
   const { boundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
+  const getCurrentMapBounds = useGetMapCurrentBounds();
 
   const {
     data: markingList,
@@ -39,44 +53,8 @@ export const LocalMarkingList = () => {
     }
   });
 
-  const { northEastLat, northEastLng, southWestLat, southWestLng } =
-    boundsParams;
-
-  const lat =
-    typeof northEastLat === "number" && typeof southWestLat === "number"
-      ? (northEastLat + southWestLat) / 2
-      : null;
-  const lng =
-    typeof northEastLng === "number" && typeof southWestLng === "number"
-      ? (northEastLng + southWestLng) / 2
-      : null;
-
-  const { data } = useGetAddressFromLatLng({
-    lat,
-    lng,
-  });
-
   return (
-    <div className="px-4">
-      {/* todo 버튼 활성화 여부에 따라 내용 바뀜 */}
-      <h1 className="title-1 text-grey-900 py-4">동네 마킹</h1>
-      <div className="flex justify-between items-center mb-4">
-        <div className="flex gap-1 text-tangerine-500 items-center">
-          <MyLocationIcon width={20} height={20} />
-          <span className="body-2 text-grey-500">{data?.region}</span>
-        </div>
-
-        <div className="flex">
-          <RangeFilter options={["CURRENT_LOCATION", "MAP_LOCATION"]} />
-          <SortTypeFilter
-            options={["POPULARITY", "RECENT", "DISTANCE"]}
-            selectedOption={sortTypeParam || "POPULARITY"}
-            onSelect={(sortType) => {
-              setMapQueryParams({ sortType });
-            }}
-          />
-        </div>
-      </div>
+    <>
       <MarkingList display="grid">
         {markingList?.map(({ markingId, previewImage, lat, lng }) => (
           <button
@@ -101,6 +79,51 @@ export const LocalMarkingList = () => {
         ))}
       </MarkingList>
       <div className="h-[.125rem]" ref={setNode} />
+    </>
+  );
+};
+
+const LocalMarkingListBottomSheetHeader = () => {
+  const { boundsParams } = useMapQueryParams();
+
+  const { northEastLat, northEastLng, southWestLat, southWestLng } =
+    boundsParams;
+
+  const lat =
+    typeof northEastLat === "number" && typeof southWestLat === "number"
+      ? (northEastLat + southWestLat) / 2
+      : null;
+  const lng =
+    typeof northEastLng === "number" && typeof southWestLng === "number"
+      ? (northEastLng + southWestLng) / 2
+      : null;
+
+  const { data } = useGetAddressFromLatLng({
+    lat,
+    lng,
+  });
+
+  return (
+    <div className="flex gap-1 text-tangerine-500 items-center">
+      <MyLocationIcon width={20} height={20} />
+      <span className="body-2 text-grey-500">{data?.region}</span>
+    </div>
+  );
+};
+
+const LocationMarkingListFilter = () => {
+  const { sortTypeParam, setMapQueryParams } = useMapQueryParams();
+
+  return (
+    <div className="flex">
+      <RangeFilter options={["CURRENT_LOCATION", "MAP_LOCATION"]} />
+      <SortTypeFilter
+        options={["POPULARITY", "RECENT", "DISTANCE"]}
+        selectedOption={sortTypeParam || "POPULARITY"}
+        onSelect={(sortType) => {
+          setMapQueryParams({ sortType });
+        }}
+      />
     </div>
   );
 };

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -1,5 +1,9 @@
 import { useNavigate } from "react-router-dom";
-import { useMapQueryParams } from "@/features/map/hooks";
+import { useMap } from "@vis.gl/react-google-maps";
+import {
+  useGetMapCurrentBounds,
+  useMapQueryParams,
+} from "@/features/map/hooks";
 import { RangeFilter, SortTypeFilter } from "@/features/marking/ui";
 import {
   useGetAddressFromLatLng,
@@ -8,9 +12,12 @@ import {
 import { API_BASE_URL, ROUTER_PATH } from "@/shared/constants";
 import { useInfiniteScroll } from "@/shared/lib";
 import { MyLocationIcon } from "@/shared/ui/icon";
+import { mapOptions } from "../constants";
 import { MarkingList } from "./markingList";
 
 export const LocalMarkingList = () => {
+  const map = useMap();
+  const getCurrentMapBounds = useGetMapCurrentBounds();
   const navigate = useNavigate();
   const { boundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
@@ -76,16 +83,12 @@ export const LocalMarkingList = () => {
             key={markingId}
             type="button"
             className="aspect-square"
-            onClick={() => {
-              // todo 클러스터링 데이터에 있는 bounds로 인수 전달
+            onClick={async () => {
               navigate(ROUTER_PATH.PLACE);
+              await map.setCenter({ lat, lng });
+              await map.setZoom(mapOptions.maxZoom);
               setMapQueryParams({
-                bounds: {
-                  southWestLat: lat - 0.00001,
-                  southWestLng: lng - 0.00001,
-                  northEastLat: lat + 0.00001,
-                  northEastLng: lng + 0.00001,
-                },
+                bounds: getCurrentMapBounds(),
                 sortType: "POPULARITY",
               });
             }}

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -1,9 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useMap } from "@vis.gl/react-google-maps";
-import {
-  useGetMapCurrentBounds,
-  useMapQueryParams,
-} from "@/features/map/hooks";
+import { useMapQueryParams, usePlaceQueryParams } from "@/features/map/hooks";
 import { RangeFilter, SortTypeFilter } from "@/features/marking/ui";
 import {
   useGetAddressFromLatLng,
@@ -32,9 +29,8 @@ export const LocalMarkingListBottomSheet = () => {
 const LocalMarkingList = () => {
   const navigate = useNavigate();
   const map = useMap();
-  const { boundsParams, sortTypeParam, setMapQueryParams } =
-    useMapQueryParams();
-  const getCurrentMapBounds = useGetMapCurrentBounds();
+  const { boundsParams, sortTypeParam } = useMapQueryParams();
+  const { setPlaceQueryParams } = usePlaceQueryParams();
 
   const {
     data: markingList,
@@ -63,12 +59,9 @@ const LocalMarkingList = () => {
             className="aspect-square"
             onClick={async () => {
               navigate(ROUTER_PATH.PLACE);
-              await map.setCenter({ lat, lng });
-              await map.setZoom(mapOptions.maxZoom);
-              setMapQueryParams({
-                bounds: getCurrentMapBounds(),
-                sortType: "POPULARITY",
-              });
+              map.setCenter({ lat, lng });
+              map.setZoom(mapOptions.maxZoom);
+              setPlaceQueryParams({ lat, lng });
             }}
           >
             <img

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MAP_INITIAL_BOUNDS } from "@/features/map/constants";
 import {
@@ -12,6 +13,7 @@ import { CurrentLocationLoading } from "@/entities/map/ui";
 import { useSnackBar } from "@/shared/lib";
 
 export const MapInitializer = () => {
+  const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const map = useMap();
   const mapMode = useMapMode();
 
@@ -52,6 +54,8 @@ export const MapInitializer = () => {
           bounds: getMapBounds(),
           sortType: sortTypeParam ?? defaultSortType,
         });
+
+        setIsInitialized(true);
       })();
       return;
     }
@@ -70,6 +74,7 @@ export const MapInitializer = () => {
           bounds: getMapBounds(),
           sortType: defaultSortType,
         });
+        setIsInitialized(true);
       },
       onError: async () => {
         await map.fitBounds(MAP_INITIAL_BOUNDS);
@@ -78,6 +83,7 @@ export const MapInitializer = () => {
           bounds: getMapBounds(),
           sortType: defaultSortType,
         });
+        setIsInitialized(true);
       },
     });
 
@@ -87,11 +93,11 @@ export const MapInitializer = () => {
   }, [map, isMapIdle]);
 
   useEffect(() => {
-    if (!hasBoundsParams) {
+    if (!isInitialized) {
       return;
     }
     handleOpen("스팟을 발견하고 마킹으로 추억을 남겨보세요", { type: "map" });
-  }, [hasBoundsParams]);
+  }, [isInitialized]);
 
   if (!map || loading || !isMapIdle) {
     return <CurrentLocationLoading />;

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -35,18 +35,14 @@ export const MapInitializer = () => {
 
     // map 인스턴스가 생기고 나서, 현재 위치를 가져옵니다.
     setCurrentLocation({
-      onSuccess: ({ coords }) => {
+      onSuccess: async ({ coords }) => {
         const { latitude, longitude } = coords;
-
         const currentLocationOfUser = { lat: latitude, lng: longitude };
 
         if (!hasBoundsParams) {
-          map.setCenter(currentLocationOfUser);
-          // 현재 위치를 기준으로 중앙에 위치하도록 설정합니다.
-          // 원래 setIsCenteredOnMyLocation 의 경우 GoogleMap 컴포넌트 내부의 handleCameraChange 에서 처리하도록 되어 있습니다.
-          // 하지만, 초기화 단계에서는 handleCameraChange 가 호출되지 않아서, 초기화 단계에서 처리합니다.
-          setIsCenteredOnMyLocation(true);
+          await map.setCenter(currentLocationOfUser);
 
+          setIsCenteredOnMyLocation(true);
           setMapQueryParams({
             bounds: getMapBounds(),
             sortType: defaultSortType,
@@ -64,20 +60,22 @@ export const MapInitializer = () => {
     });
 
     if (hasBoundsParams) {
-      const { northEastLat, northEastLng, southWestLat, southWestLng } =
-        boundsParams;
+      (async function () {
+        const { northEastLat, northEastLng, southWestLat, southWestLng } =
+          boundsParams;
 
-      map.fitBounds({
-        south: southWestLat,
-        west: southWestLng,
-        north: northEastLat,
-        east: northEastLng,
-      });
+        await map.fitBounds({
+          south: southWestLat,
+          west: southWestLng,
+          north: northEastLat,
+          east: northEastLng,
+        });
 
-      setMapQueryParams({
-        bounds: getMapBounds(),
-        sortType: sortTypeParam ?? defaultSortType,
-      });
+        setMapQueryParams({
+          bounds: getMapBounds(),
+          sortType: sortTypeParam ?? defaultSortType,
+        });
+      })();
     }
 
     return () => {

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { useState } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MAP_INITIAL_BOUNDS } from "@/features/map/constants";
 import {
@@ -13,7 +12,6 @@ import { CurrentLocationLoading } from "@/entities/map/ui";
 import { useSnackBar } from "@/shared/lib";
 
 export const MapInitializer = () => {
-  const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const map = useMap();
   const mapMode = useMapMode();
 
@@ -54,8 +52,6 @@ export const MapInitializer = () => {
           bounds: getMapBounds(),
           sortType: sortTypeParam ?? defaultSortType,
         });
-
-        setIsInitialized(true);
       })();
       return;
     }
@@ -74,7 +70,6 @@ export const MapInitializer = () => {
           bounds: getMapBounds(),
           sortType: defaultSortType,
         });
-        setIsInitialized(true);
       },
       onError: async () => {
         await map.fitBounds(MAP_INITIAL_BOUNDS);
@@ -83,7 +78,6 @@ export const MapInitializer = () => {
           bounds: getMapBounds(),
           sortType: defaultSortType,
         });
-        setIsInitialized(true);
       },
     });
 
@@ -93,11 +87,11 @@ export const MapInitializer = () => {
   }, [map, isMapIdle]);
 
   useEffect(() => {
-    if (!isInitialized) {
+    if (!hasBoundsParams) {
       return;
     }
     handleOpen("스팟을 발견하고 마킹으로 추억을 남겨보세요", { type: "map" });
-  }, [isInitialized]);
+  }, [hasBoundsParams]);
 
   if (!map || loading || !isMapIdle) {
     return <CurrentLocationLoading />;

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useMap } from "@vis.gl/react-google-maps";
+import { MAP_INITIAL_BOUNDS } from "@/features/map/constants";
 import {
   useCurrentLocation,
   useGetMapCurrentBounds,
@@ -33,32 +34,8 @@ export const MapInitializer = () => {
 
     const defaultSortType = mapMode === "MY_MARK" ? "RECENT" : "POPULARITY";
 
-    // map 인스턴스가 생기고 나서, 현재 위치를 가져옵니다.
-    setCurrentLocation({
-      onSuccess: async ({ coords }) => {
-        const { latitude, longitude } = coords;
-        const currentLocationOfUser = { lat: latitude, lng: longitude };
-
-        if (!hasBoundsParams) {
-          await map.setCenter(currentLocationOfUser);
-
-          setIsCenteredOnMyLocation(true);
-          setMapQueryParams({
-            bounds: getMapBounds(),
-            sortType: defaultSortType,
-          });
-        }
-      },
-      onError: () => {
-        if (!hasBoundsParams) {
-          setMapQueryParams({
-            bounds: getMapBounds(),
-            sortType: defaultSortType,
-          });
-        }
-      },
-    });
-
+    // boundsParams 가 존재할 경우 해당 boundsParams 로 맵을 이동 시킨 후 boundsParams 를 변경합니다.
+    // 기기마다 boundsParams가 다르게 나올 수 있기 때문에 비동기적으로 동기화 과정을 거칩니다.
     if (hasBoundsParams) {
       (async function () {
         const { northEastLat, northEastLng, southWestLat, southWestLng } =
@@ -76,7 +53,33 @@ export const MapInitializer = () => {
           sortType: sortTypeParam ?? defaultSortType,
         });
       })();
+      return;
     }
+
+    // 만약 boundsParams가 없다면 사용자의 현재 위치로 boundsParams 를 설정합니다.
+    // 사용자의 위치를 가져오는데 실패했다면 기본 boundsParams 를 설정합니다.
+    setCurrentLocation({
+      onSuccess: async ({ coords }) => {
+        const { latitude, longitude } = coords;
+        const currentLocationOfUser = { lat: latitude, lng: longitude };
+
+        await map.setCenter(currentLocationOfUser);
+
+        setIsCenteredOnMyLocation(true);
+        setMapQueryParams({
+          bounds: getMapBounds(),
+          sortType: defaultSortType,
+        });
+      },
+      onError: async () => {
+        await map.fitBounds(MAP_INITIAL_BOUNDS);
+
+        setMapQueryParams({
+          bounds: getMapBounds(),
+          sortType: defaultSortType,
+        });
+      },
+    });
 
     return () => {
       setIsMapIdle(false);

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -2,11 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MarkingItem } from "@/widgets/marking/ui";
-import {
-  useGetMapCurrentBounds,
-  useMapQueryParams,
-  usePlaceQueryParams,
-} from "@/features/map/hooks";
+import { useMapQueryParams, usePlaceQueryParams } from "@/features/map/hooks";
 import { SortTypeFilter } from "@/features/marking/ui";
 import { useGetMarkingList } from "@/entities/marking/api";
 import {
@@ -22,14 +18,13 @@ import { MarkingList } from "./markingList";
 export const PlaceMarkingList = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { boundsParams, sortTypeParam, setMapQueryParams } = useMapQueryParams();
+  const { boundsParams, sortTypeParam, setMapQueryParams } =
+    useMapQueryParams();
   const { boundsAdjacentPlace } = usePlaceQueryParams();
 
   const { data: myFollowingMap } = useGetMyFollowingIdsMap();
   const { data: myBookmarkedMap } = useGetMyBookmarkIdsMap();
   const { data: myLikedMap } = useGetMyLikedIdsMap();
-
-  const getMapBounds = useGetMapCurrentBounds();
 
   const {
     data: markingList,

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -22,7 +22,7 @@ import { MarkingList } from "./markingList";
 export const PlaceMarkingList = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { sortTypeParam, setMapQueryParams } = useMapQueryParams();
+  const { boundsParams, sortTypeParam, setMapQueryParams } = useMapQueryParams();
   const { boundsAdjacentPlace } = usePlaceQueryParams();
 
   const { data: myFollowingMap } = useGetMyFollowingIdsMap();
@@ -61,7 +61,7 @@ export const PlaceMarkingList = () => {
         onClick={() => {
           navigate(ROUTER_PATH.MAP);
           setMapQueryParams({
-            bounds: getMapBounds(),
+            bounds: boundsParams,
             sortType: "POPULARITY",
           });
         }}

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -23,7 +23,7 @@ export const PlaceMarkingList = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { sortTypeParam, setMapQueryParams } = useMapQueryParams();
-  const { latLng100meterBounds } = usePlaceQueryParams();
+  const { boundsAdjacentPlace } = usePlaceQueryParams();
 
   const { data: myFollowingMap } = useGetMyFollowingIdsMap();
   const { data: myBookmarkedMap } = useGetMyBookmarkIdsMap();
@@ -37,7 +37,7 @@ export const PlaceMarkingList = () => {
     hasNextPage,
     isFetchingNextPage,
   } = useGetMarkingList({
-    ...latLng100meterBounds,
+    ...boundsAdjacentPlace,
     sortType: sortTypeParam,
     searchType: "LOCATION",
   });

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -5,6 +5,7 @@ import { MarkingItem } from "@/widgets/marking/ui";
 import {
   useGetMapCurrentBounds,
   useMapQueryParams,
+  usePlaceQueryParams,
 } from "@/features/map/hooks";
 import { SortTypeFilter } from "@/features/marking/ui";
 import { useGetMarkingList } from "@/entities/marking/api";
@@ -21,11 +22,13 @@ import { MarkingList } from "./markingList";
 export const PlaceMarkingList = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { boundsParams, sortTypeParam, setMapQueryParams } =
-    useMapQueryParams();
+  const { sortTypeParam, setMapQueryParams } = useMapQueryParams();
+  const { latLng100meterBounds } = usePlaceQueryParams();
+
   const { data: myFollowingMap } = useGetMyFollowingIdsMap();
   const { data: myBookmarkedMap } = useGetMyBookmarkIdsMap();
   const { data: myLikedMap } = useGetMyLikedIdsMap();
+
   const getMapBounds = useGetMapCurrentBounds();
 
   const {
@@ -34,7 +37,7 @@ export const PlaceMarkingList = () => {
     hasNextPage,
     isFetchingNextPage,
   } = useGetMarkingList({
-    ...boundsParams,
+    ...latLng100meterBounds,
     sortType: sortTypeParam,
     searchType: "LOCATION",
   });


### PR DESCRIPTION
# 관련 이슈 번호
close #483 

# 설명

우선 핑계부터 대고 설명문을 적습니다.

1. `usePlaceQueryParams` 의 작업은 `useMapQueryParams` 와  거의 일치합니다. 의미론 상으론 place 나 map 이나 비슷하니 하나로 합치는게 맞아 보이기도 합니다. 다만 저는 이번 작업에선 기존 `useMapQueryParams` 를 건들지 않고 `usePlace..` 라는 훅을 하나 더 추가했습니다.

이유는 기존 작업물을 수정함으로서 예기치 못한 버그가 발생하는걸 원치 않았기 떄문입니다. 수정보단 확장이 낫다는 solid 법칙을 근거로 들거나 , 최근에 읽은 프로그래밍 규칙에 따라 필요한 함수는 그 때 그 떄 생성하는게 낫다라고 변명을 댈 수도 있겠지만 솔직히 말해선 기존 작업물을 건들면 어떤 버그가 생길지 몰라 하나의 함수를 더 추가했습니다 .. 이건 다른 작업 후 리팩토링 해야 합니다.

2. `usePlace..` 는 `features` 에 존재하는데 `entities` 에 존재하는 `MarkingPins` 에서 import 됩니다. 이렇게 한 이유는 우선 `usePlace .. ` 가 `useMapQuery ..` 와 같은 레이어에 위치해야 할 거 같았어요 ... 마킹 핀의 레이어 위치가 잘못된건지 해당 훅 위치가 잘못된건지는 나중에 fsd 구조에 맞춰 리팩토링 할 때 건들겠습니다 .. 

---

# 1. 비동기 처리를 통한 맵 이니셜라이저 작업 변경 

오전에 이야기했던 것 처럼 프로미스 체인을 통해 맵을 우선 이동 시키고 이동 된 위치에 맞춰 boundsParmas 를 변경했습니다. 

이 코드는 가끔씩 잘 작동 할 때도 있고 가끔씩은 안될 때가 있습니다 .  아까 산책 전엔 안되더니 또 다녀오니 잘 작동합니다... 안전한 코드는 아닌거 같습니다 ..

# 2. `usePlaceQueryParams` 

```tsx
export const usePlaceQueryParams = () => {
  const { pathname } = useLocation();
  const [searchParams, setSearchParams] = useSearchParams();
  const { boundsParams } = useMapQueryParams();

  const setPlaceQueryParams = ({ lat, lng }: { lat: number; lng: number }) => {
    setSearchParams((prevSearchParams) => {
      const newSearchParams = new URLSearchParams(prevSearchParams);
      newSearchParams.set("lat", lat.toString());
      newSearchParams.set("lng", lng.toString());
      return newSearchParams;
    });
  };

  const lat = getNumberParam("lat", searchParams);
  const lng = getNumberParam("lng", searchParams);
  const placeParams = {
    lat,
    lng,
  };

  // lat , lng 로부터 반경 100m의 경계값을 계산합니다.
  // 100m 는 0.0009이기에 중심으로부터 0.00045씩 떨어진 값을 사용합니다.
  const latLng100meterBounds = {
    northEastLat: lat && lat + 0.00045,
    northEastLng: lng && lng + 0.00045,
    southWestLat: lat && lat - 0.00045,
    southWestLng: lng && lng - 0.00045,
  };
... 
 
 useEffect(() => {
    const { northEastLat, northEastLng, southWestLat, southWestLng } =
      boundsParams;

    if (
      !(northEastLat && northEastLng && southWestLat && southWestLng) ||
      pathname !== ROUTER_PATH.PLACE
    ) {
      return;
    }

    // searchParameter 에 lat, lng 가 있고, 현재 검색된 boundsParams 내부에 존재하는
    // 유효한 경계값이라면, 해당 값을 사용합니다.
    const lat = getNumberParam("lat", searchParams);
    const lng = getNumberParam("lng", searchParams);
    if (lat && lng && filterInnerBoundary({ lat, lng }, boundsParams)) {
      return;
    }
    // lat , lng 가 유효하지 않은 경우 boundsParams 의 중심값을 사용합니다.
    setPlaceQueryParams({
      lat: northEastLat - (northEastLat - southWestLat) / 2,
      lng: northEastLng - (northEastLng - southWestLng) / 2,
    });
  }, [pathname, JSON.stringify(boundsParams)]);
``` 

해당 훅은 말 그대로  `ROUTER_PATH.PLACE` 에서 lat , lng 라는 서치파라미터 값을 설정하거나 조회하기 위해 사용 됩니다.

`lat , lng ` 값이 변경 될 때 마다 `ROUTER_PATH.PLACE` 에서 `latLng100meter..` 이 바운더리를 통해 바텀시트에 데이터를 불러옵니다 .

이펙트문은 place 에 초기진입 했을 때 maxZoom 상태로 업데이트 시키기 위해 존재합니다

maxZoom 으로 업데이트 해야 하는 이유는 maxZoom 으로 이동해야지만 이 장소 마킹의 바텀시트가 업데이트 되도록 로직을 만들어놨기 때문입니다 .



# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
