### PR TITLE
[Feat] 마킹 아이템 더 보기 버튼 장착

### DIFF
--- a/src/mocks/data/markingList.ts
+++ b/src/mocks/data/markingList.ts
@@ -14,7 +14,10 @@ export const getMockMarkingList = ({
   const markingList: Marking[] = Array.from({ length: 1000 }, (_, index) => ({
     markingId: index + 1,
     region: "**시 **구 **동",
-    content: `Marking content ${index + 1}`,
+    content: Array.from(
+      { length: Math.random() * 30 },
+      (_, index) => `content ${index + 1}`,
+    ).join(" "),
     previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
     isVisible: "PUBLIC",
     regDt: new Date().toISOString(),

--- a/src/mocks/data/markingList.ts
+++ b/src/mocks/data/markingList.ts
@@ -16,7 +16,7 @@ export const getMockMarkingList = ({
     region: "**시 **구 **동",
     content:
       index % 2
-        ? `${`content ${index + 1}`.repeat(Math.random() * 30)} \n\n ${`content ${index + 1}`.repeat(Math.random() * 30)}`
+        ? `${`content ${index + 1}`.repeat(Math.random() * 30)} \n ${`content ${index + 1}`.repeat(Math.random() * 30)}`
         : `content ${index + 1} `.repeat(Math.random() * 30),
     previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
     isVisible: "PUBLIC",

--- a/src/mocks/data/markingList.ts
+++ b/src/mocks/data/markingList.ts
@@ -16,8 +16,10 @@ export const getMockMarkingList = ({
     region: "**시 **구 **동",
     content:
       index % 2
-        ? `${`content ${index + 1}`.repeat(Math.random() * 30)} \n ${`content ${index + 1}`.repeat(Math.random() * 30)}`
-        : `content ${index + 1} `.repeat(Math.random() * 30),
+        ? `${`content ${index + 1}`.repeat(Math.random() * 10)} \n ${`content ${index + 1}`.repeat(Math.random() * 10)}`.repeat(
+            Math.random() * 10,
+          )
+        : `content ${index + 1} `.repeat(Math.random() * 10),
     previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
     isVisible: "PUBLIC",
     regDt: new Date().toISOString(),

--- a/src/mocks/data/markingList.ts
+++ b/src/mocks/data/markingList.ts
@@ -14,7 +14,10 @@ export const getMockMarkingList = ({
   const markingList: Marking[] = Array.from({ length: 1000 }, (_, index) => ({
     markingId: index + 1,
     region: "**시 **구 **동",
-    content: `content ${index + 1} `.repeat(Math.random() * 30),
+    content:
+      index % 2
+        ? `${`content ${index + 1}`.repeat(Math.random() * 30)} \n\n ${`content ${index + 1}`.repeat(Math.random() * 30)}`
+        : `content ${index + 1} `.repeat(Math.random() * 30),
     previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
     isVisible: "PUBLIC",
     regDt: new Date().toISOString(),

--- a/src/mocks/data/markingList.ts
+++ b/src/mocks/data/markingList.ts
@@ -14,10 +14,7 @@ export const getMockMarkingList = ({
   const markingList: Marking[] = Array.from({ length: 1000 }, (_, index) => ({
     markingId: index + 1,
     region: "**시 **구 **동",
-    content: Array.from(
-      { length: Math.random() * 30 },
-      (_, index) => `content ${index + 1}`,
-    ).join(" "),
+    content: `content ${index + 1} `.repeat(Math.random() * 30),
     previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
     isVisible: "PUBLIC",
     regDt: new Date().toISOString(),

--- a/src/mocks/data/tempMarkingList.ts
+++ b/src/mocks/data/tempMarkingList.ts
@@ -26,7 +26,7 @@ export const temporaryMarkingList: GetTemporaryMarkingListResponse["markings"] =
     {
       length: 100,
     },
-    (_, i) => {
+    (_, index) => {
       const regionInfo = randomRegions[Math.ceil(Math.random() * 10) % 3];
       const randomDate = new Date();
       randomDate.setHours(randomDate.getHours() - hours++ * 5);
@@ -35,11 +35,9 @@ export const temporaryMarkingList: GetTemporaryMarkingListResponse["markings"] =
         markingId: tempMarkingId++,
         region: regionInfo.region,
         content:
-          Math.random() > 0.5
-            ? `임시저장 마킹${i}`.repeat(
-                Math.random() > 0.3 ? Math.ceil(Math.random() * 30) : 0,
-              )
-            : null,
+          index % 2
+            ? `${`content ${index + 1}`.repeat(Math.random() * 30)} \n\n ${`content ${index + 1}`.repeat(Math.random() * 30)}`
+            : `content ${index + 1} `.repeat(Math.random() * 30),
         isVisible:
           Math.random() > 0.3
             ? "PUBLIC"

--- a/src/mocks/data/tempMarkingList.ts
+++ b/src/mocks/data/tempMarkingList.ts
@@ -37,7 +37,7 @@ export const temporaryMarkingList: GetTemporaryMarkingListResponse["markings"] =
         content:
           Math.random() > 0.5
             ? `임시저장 마킹${i}`.repeat(
-                Math.random() > 0.3 ? Math.ceil(Math.random() * 10) : 0,
+                Math.random() > 0.3 ? Math.ceil(Math.random() * 30) : 0,
               )
             : null,
         isVisible:

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -391,16 +391,12 @@ const MarkingItemContent = () => {
     if (isMultiLine) {
       return isSummary ? (
         <>
-          <p className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap">
-            {multiLineContent[0]}
-          </p>
-          <p
-            className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap"
-            ref={multiLineSummaryRef}
-          >
+          <span>{multiLineContent[0]}</span>
+          <br />
+          <span ref={multiLineSummaryRef}>
             {multiLineContent[1]}
             {!isMultiLineSummaryEllipsis && "..."}
-          </p>
+          </span>
         </>
       ) : (
         multiLineContent.map((line, index) => (
@@ -427,7 +423,7 @@ const MarkingItemContent = () => {
 
   return (
     <p
-      className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2 text-ellipsis overflow-hidden" : ""}`}
+      className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2" : ""}`}
       ref={contentRef}
       onClick={() => setIsSummary((prev) => !prev)}
     >

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { FollowingToggle } from "@/features/follow/ui";
 import { useDeleteMarking } from "@/features/marking/api";
 import {
@@ -15,9 +15,15 @@ import { API_BASE_URL } from "@/shared/constants";
 import { formatDateToYearMonthDay, useDropdown } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { DividerLine } from "@/shared/ui/divider";
-import { MoreIcon, MyLocationIcon } from "@/shared/ui/icon";
-import { FilledLikeIcon, LikeIcon } from "@/shared/ui/icon";
-import { BookmarkIcon, FilledBookmarkIcon } from "@/shared/ui/icon";
+import {
+  FilledLikeIcon,
+  LikeIcon,
+  BookmarkIcon,
+  FilledBookmarkIcon,
+  DropDownIcon,
+  MoreIcon,
+  MyLocationIcon,
+} from "@/shared/ui/icon";
 import { ImgSlider } from "@/shared/ui/imgSlider";
 import { List } from "@/shared/ui/list";
 import {
@@ -370,8 +376,56 @@ const MarkingItemPetName = () => {
 };
 
 const MarkingItemContent = () => {
-  const { content } = useMarkingItemProps();
-  return <p className="text-grey-700 body-2 text-overflow">{content}</p>;
+  const { content, markingId } = useMarkingItemProps();
+  const [isSummary, setIsSummary] = useState<boolean>(true);
+  const [isEllipsis, setIsEllipsis] = useState<boolean>(false);
+  const contentRef = useRef<HTMLParagraphElement>(null);
+
+  // 줄바꿈이 적용된 배열
+  const multiLineContent = content.split("\n");
+  const isMultiLine = multiLineContent.length > 1;
+
+  const renderMarkingContent = () => {
+    if (isMultiLine) {
+      return isSummary
+        ? multiLineContent[0]
+        : multiLineContent.map((line, index) => (
+            <p className="min-h-4" key={index}>
+              {line}
+            </p>
+          ));
+    }
+    return content;
+  };
+
+  useEffect(() => {
+    const $p = contentRef.current!;
+    setIsEllipsis($p.scrollWidth > $p.clientWidth);
+  }, []);
+
+  return (
+    <div className="flex gap-4 text-grey-700">
+      <p
+        className={`body-2  ${isSummary ? "text-ellipsis overflow-hidden text-nowrap" : ""}`}
+        ref={contentRef}
+      >
+        {renderMarkingContent()}
+      </p>
+      {(isMultiLine || isEllipsis) && (
+        <button
+          className="w-4 h-4 "
+          onClick={() => setIsSummary((prev) => !prev)}
+          aria-label={
+            isSummary
+              ? `${markingId} 번 마킹 내용 더 보기`
+              : `${markingId} 번 마킹 내용 접기`
+          }
+        >
+          <DropDownIcon />
+        </button>
+      )}
+    </div>
+  );
 };
 
 const MarkingItemDate = () => {

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -376,10 +376,13 @@ const MarkingItemPetName = () => {
 };
 
 const MarkingItemContent = () => {
-  const { content, markingId } = useMarkingItemProps();
+  const { content } = useMarkingItemProps();
   const [isSummary, setIsSummary] = useState<boolean>(true);
-  const [isEllipsis, setIsEllipsis] = useState<boolean>(false);
+  const [isMultiLineSummaryEllipsis, setIsMultiLineSummaryEllipsis] =
+    useState<boolean>(false);
+
   const contentRef = useRef<HTMLParagraphElement>(null);
+  const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
 
   // 줄바꿈이 적용된 배열
   const multiLineContent = content.split("\n");
@@ -387,44 +390,42 @@ const MarkingItemContent = () => {
 
   const renderMarkingContent = () => {
     if (isMultiLine) {
-      return isSummary
-        ? multiLineContent[0]
-        : multiLineContent.map((line, index) => (
-            <p className="min-h-4" key={index}>
-              {line}
-            </p>
-          ));
+      return isSummary ? (
+        <p
+          className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap"
+          ref={multiLineSummaryRef}
+        >
+          {multiLineContent[0]}
+          {!isMultiLineSummaryEllipsis && "..."}
+        </p>
+      ) : (
+        multiLineContent.map((line, index) => (
+          <p className="min-h-4" key={index}>
+            {line}
+          </p>
+        ))
+      );
     }
     return content;
   };
 
   useEffect(() => {
-    const $p = contentRef.current!;
-    setIsEllipsis($p.scrollWidth > $p.clientWidth);
-  }, []);
+    if (multiLineSummaryRef.current === null) {
+      return;
+    }
+
+    const $p = multiLineSummaryRef.current!;
+    setIsMultiLineSummaryEllipsis($p.scrollWidth > $p.clientWidth);
+  }, [multiLineContent]);
 
   return (
-      <p
+    <p
       className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2 text-ellipsis overflow-hidden" : ""}`}
-        ref={contentRef}
+      ref={contentRef}
       onClick={() => setIsSummary((prev) => !prev)}
-      >
-        {renderMarkingContent()}
-      </p>
-      {(isMultiLine || isEllipsis) && (
-        <button
-          className="w-4 h-4 "
-          onClick={() => setIsSummary((prev) => !prev)}
-          aria-label={
-            isSummary
-              ? `${markingId} 번 마킹 내용 더 보기`
-              : `${markingId} 번 마킹 내용 접기`
-          }
-        >
-          <DropDownIcon />
-        </button>
-      )}
-    </div>
+    >
+      {renderMarkingContent()}
+    </p>
   );
 };
 

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -377,8 +377,6 @@ const MarkingItemPetName = () => {
 const MarkingItemContent = () => {
   const { content } = useMarkingItemProps();
   const [isSummary, setIsSummary] = useState<boolean>(true);
-  const [isMultiLineSummaryEllipsis, setIsMultiLineSummaryEllipsis] =
-    useState<boolean>(false);
 
   const contentRef = useRef<HTMLParagraphElement>(null);
   const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
@@ -390,12 +388,15 @@ const MarkingItemContent = () => {
   const renderMarkingContent = () => {
     if (isMultiLine) {
       return isSummary ? (
-        <p
-          className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap"
-          ref={multiLineSummaryRef}
-        >
-          {multiLineContent[0]}
-          {!isMultiLineSummaryEllipsis && "..."}
+        <p className="body-2" ref={multiLineSummaryRef}>
+          {multiLineContent.slice(0, 2).map((line, index) => (
+            <p
+              className="min-h-4 text-ellipsis overflow-hidden text-nowrap"
+              key={index}
+            >
+              {line}
+            </p>
+          ))}
         </p>
       ) : (
         multiLineContent.map((line, index) => (
@@ -407,15 +408,6 @@ const MarkingItemContent = () => {
     }
     return content;
   };
-
-  useEffect(() => {
-    if (multiLineSummaryRef.current === null) {
-      return;
-    }
-
-    const $p = multiLineSummaryRef.current;
-    setIsMultiLineSummaryEllipsis($p.scrollWidth > $p.clientWidth);
-  }, []);
 
   return (
     <p

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -377,7 +377,7 @@ const MarkingItemPetName = () => {
 const MarkingItemContent = () => {
   const { content } = useMarkingItemProps();
   const [isSummary, setIsSummary] = useState<boolean>(true);
-  const [isMultiLineEllipsis, setIsMultiLineEllipsis] =
+  const [isMultiLineSummaryEllipsis, setIsMultiLineSummaryEllipsis] =
     useState<boolean>(false);
 
   const contentRef = useRef<HTMLParagraphElement>(null);
@@ -399,7 +399,7 @@ const MarkingItemContent = () => {
             ref={multiLineSummaryRef}
           >
             {multiLineContent[1]}
-            {!isMultiLineEllipsis && "..."}
+            {!isMultiLineSummaryEllipsis && "..."}
           </p>
         </>
       ) : (
@@ -419,7 +419,7 @@ const MarkingItemContent = () => {
     const $multiLineSummaryText = multiLineSummaryRef.current;
 
     if ($multiLineSummaryText) {
-      setIsMultiLineEllipsis(
+      setIsMultiLineSummaryEllipsis(
         $multiLineSummaryText.scrollWidth > $multiLineSummaryText.clientWidth,
       );
     }

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -382,20 +382,18 @@ const MarkingItemContent = () => {
 
   const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
 
-  // 줄바꿈이 적용된 배열
-  const multiLineContent = content.split("\n");
-  const isMultiLine = multiLineContent.length > 1;
-
   const renderMarkingContent = () => {
-    if (isMultiLine) {
+    const multiLineContent = content.split("\n");
+
+    if (multiLineContent.length > 1) {
       return isSummary ? (
-        <div>
+        <>
           <p>{multiLineContent[0]}</p>
           <p ref={multiLineSummaryRef}>
             {multiLineContent[1]}
             {!isMultiLineSummaryEllipsis && "..."}
           </p>
-        </div>
+        </>
       ) : (
         multiLineContent.map((line, index) => (
           <p className="min-h-4" key={index}>

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -389,14 +389,13 @@ const MarkingItemContent = () => {
   const renderMarkingContent = () => {
     if (isMultiLine) {
       return isSummary ? (
-        <>
-          <span>{multiLineContent[0]}</span>
-          <br />
-          <span ref={multiLineSummaryRef}>
+        <div>
+          <p>{multiLineContent[0]}</p>
+          <p ref={multiLineSummaryRef}>
             {multiLineContent[1]}
             {!isMultiLineSummaryEllipsis && "..."}
-          </span>
-        </>
+          </p>
+        </div>
       ) : (
         multiLineContent.map((line, index) => (
           <p className="min-h-4" key={index}>
@@ -421,12 +420,12 @@ const MarkingItemContent = () => {
   }, []);
 
   return (
-    <p
+    <div
       className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2" : ""}`}
       onClick={() => setIsSummary((prev) => !prev)}
     >
       {renderMarkingContent()}
-    </p>
+    </div>
   );
 };
 

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { FollowingToggle } from "@/features/follow/ui";
 import { useDeleteMarking } from "@/features/marking/api";
 import {
@@ -377,6 +377,8 @@ const MarkingItemPetName = () => {
 const MarkingItemContent = () => {
   const { content } = useMarkingItemProps();
   const [isSummary, setIsSummary] = useState<boolean>(true);
+  const [isMultiLineEllipsis, setIsMultiLineEllipsis] =
+    useState<boolean>(false);
 
   const contentRef = useRef<HTMLParagraphElement>(null);
   const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
@@ -388,16 +390,18 @@ const MarkingItemContent = () => {
   const renderMarkingContent = () => {
     if (isMultiLine) {
       return isSummary ? (
-        <p className="body-2" ref={multiLineSummaryRef}>
-          {multiLineContent.slice(0, 2).map((line, index) => (
-            <p
-              className="min-h-4 text-ellipsis overflow-hidden text-nowrap"
-              key={index}
-            >
-              {line.trim() === "" ? "..." : line}
-            </p>
-          ))}
-        </p>
+        <>
+          <p className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap">
+            {multiLineContent[0]}
+          </p>
+          <p
+            className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap"
+            ref={multiLineSummaryRef}
+          >
+            {multiLineContent[1]}
+            {!isMultiLineEllipsis && "..."}
+          </p>
+        </>
       ) : (
         multiLineContent.map((line, index) => (
           <p className="min-h-4" key={index}>
@@ -408,6 +412,18 @@ const MarkingItemContent = () => {
     }
     return content;
   };
+
+  // 멀티 라인의 두 번째 줄에는 필수적으로 ... 를 붙혀 하위에 렌더링 되지 않은 줄이 있음을 표현 해줍니다.
+  // 이를 위해 멀티라인의 두 번쨰 줄이 ellipsis 되었는지 확인하고 , 그렇지 않다면 인위적으로 ...을 붙혀주기 위해 상태를 변경합니다.
+  useEffect(() => {
+    const $multiLineSummaryText = multiLineSummaryRef.current;
+
+    if ($multiLineSummaryText) {
+      setIsMultiLineEllipsis(
+        $multiLineSummaryText.scrollWidth > $multiLineSummaryText.clientWidth,
+      );
+    }
+  }, []);
 
   return (
     <p

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -20,7 +20,6 @@ import {
   LikeIcon,
   BookmarkIcon,
   FilledBookmarkIcon,
-  DropDownIcon,
   MoreIcon,
   MyLocationIcon,
 } from "@/shared/ui/icon";

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -384,14 +384,15 @@ const MarkingItemContent = () => {
 
   const renderMarkingContent = () => {
     const multiLineContent = content.split("\n");
+    const multiLineLength = multiLineContent.length;
 
-    if (multiLineContent.length > 1) {
+    if (multiLineLength > 1) {
       return isSummary ? (
         <>
           <p>{multiLineContent[0]}</p>
           <p ref={multiLineSummaryRef}>
             {multiLineContent[1]}
-            {!isMultiLineSummaryEllipsis && "..."}
+            {!isMultiLineSummaryEllipsis && multiLineLength > 2 && "..."}
           </p>
         </>
       ) : (

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -404,7 +404,7 @@ const MarkingItemContent = () => {
   }, []);
 
   return (
-    <div className="flex gap-4 text-grey-700">
+    <div className="flex gap-4 justify-between text-grey-700">
       <p
         className={`body-2  ${isSummary ? "text-ellipsis overflow-hidden text-nowrap" : ""}`}
         ref={contentRef}

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -413,9 +413,9 @@ const MarkingItemContent = () => {
       return;
     }
 
-    const $p = multiLineSummaryRef.current!;
+    const $p = multiLineSummaryRef.current;
     setIsMultiLineSummaryEllipsis($p.scrollWidth > $p.clientWidth);
-  }, [multiLineContent]);
+  }, []);
 
   return (
     <p

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -394,7 +394,7 @@ const MarkingItemContent = () => {
               className="min-h-4 text-ellipsis overflow-hidden text-nowrap"
               key={index}
             >
-              {line}
+              {line.trim() === "" ? "..." : line}
             </p>
           ))}
         </p>

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -404,10 +404,10 @@ const MarkingItemContent = () => {
   }, []);
 
   return (
-    <div className="flex gap-4 justify-between text-grey-700">
       <p
-        className={`body-2  ${isSummary ? "text-ellipsis overflow-hidden text-nowrap" : ""}`}
+      className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2 text-ellipsis overflow-hidden" : ""}`}
         ref={contentRef}
+      onClick={() => setIsSummary((prev) => !prev)}
       >
         {renderMarkingContent()}
       </p>

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -380,7 +380,6 @@ const MarkingItemContent = () => {
   const [isMultiLineSummaryEllipsis, setIsMultiLineSummaryEllipsis] =
     useState<boolean>(false);
 
-  const contentRef = useRef<HTMLParagraphElement>(null);
   const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
 
   // 줄바꿈이 적용된 배열
@@ -424,7 +423,6 @@ const MarkingItemContent = () => {
   return (
     <p
       className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2" : ""}`}
-      ref={contentRef}
       onClick={() => setIsSummary((prev) => !prev)}
     >
       {renderMarkingContent()}

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
 import { FollowingToggle } from "@/features/follow/ui";
 import { useDeleteMarking } from "@/features/marking/api";
 import {

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -8,7 +8,6 @@ import { API_BASE_URL } from "@/shared/constants";
 import { Button } from "@/shared/ui/button";
 import { InfoChip } from "@/shared/ui/chip/InfoChip";
 import { MyLocationIcon } from "@/shared/ui/icon";
-import { DropDownIcon } from "@/shared/ui/icon";
 import { ImgSlider } from "@/shared/ui/imgSlider";
 
 export const TemporaryMarkingItem = ({
@@ -62,7 +61,6 @@ export const TemporaryMarkingItem = ({
 
 const TempMarkingContent = ({
   content,
-  markingId,
 }: {
   content: NonNullable<TempMarkingInfo["content"]>;
   markingId: TempMarkingInfo["markingId"];

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -94,7 +94,7 @@ const TempMarkingContent = ({
   }, []);
 
   return (
-    <div className="flex gap-4 text-grey-700">
+    <div className="flex gap-4 justify-between text-grey-700">
       <p
         className={`body-2  ${isSummary ? "text-ellipsis overflow-hidden text-nowrap" : ""}`}
         ref={contentRef}

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -71,20 +71,19 @@ const TempMarkingContent = ({
 
   const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
 
-  // 줄바꿈이 적용된 배열
-  const multiLineContent = content.split("\n");
-  const isMultiLine = multiLineContent.length > 1;
-
   const renderMarkingContent = () => {
-    if (isMultiLine) {
+    // 줄바꿈이 적용된 배열
+    const multiLineContent = content.split("\n");
+
+    if (multiLineContent.length > 1) {
       return isSummary ? (
-        <div>
+        <>
           <p>{multiLineContent[0]}</p>
           <p ref={multiLineSummaryRef}>
             {multiLineContent[1]}
             {!isMultiLineSummaryEllipsis && "..."}
           </p>
-        </div>
+        </>
       ) : (
         multiLineContent.map((line, index) => (
           <p className="min-h-4" key={index}>

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -68,8 +68,11 @@ const TempMarkingContent = ({
   markingId: TempMarkingInfo["markingId"];
 }) => {
   const [isSummary, setIsSummary] = useState<boolean>(true);
-  const [isEllipsis, setIsEllipsis] = useState<boolean>(false);
+  const [isMultiLineSummaryEllipsis, setIsMultiLineSummaryEllipsis] =
+    useState<boolean>(false);
+
   const contentRef = useRef<HTMLParagraphElement>(null);
+  const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
 
   // 줄바꿈이 적용된 배열
   const multiLineContent = content.split("\n");
@@ -77,44 +80,41 @@ const TempMarkingContent = ({
 
   const renderMarkingContent = () => {
     if (isMultiLine) {
-      return isSummary
-        ? multiLineContent[0]
-        : multiLineContent.map((line, index) => (
-            <p className="min-h-4" key={index}>
-              {line}
-            </p>
-          ));
+      return isSummary ? (
+        <p
+          className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap"
+          ref={multiLineSummaryRef}
+        >
+          {multiLineContent[0]}
+          {!isMultiLineSummaryEllipsis && "..."}
+        </p>
+      ) : (
+        multiLineContent.map((line, index) => (
+          <p className="min-h-4" key={index}>
+            {line}
+          </p>
+        ))
+      );
     }
     return content;
   };
 
   useEffect(() => {
-    const $p = contentRef.current!;
-    setIsEllipsis($p.scrollWidth > $p.clientWidth);
-  }, []);
+    if (multiLineSummaryRef.current === null) {
+      return;
+    }
 
+    const $p = multiLineSummaryRef.current!;
+    setIsMultiLineSummaryEllipsis($p.scrollWidth > $p.clientWidth);
+  }, [multiLineContent]);
   return (
-    <div className="flex gap-4 justify-between text-grey-700">
-      <p
-        className={`body-2  ${isSummary ? "text-ellipsis overflow-hidden text-nowrap" : ""}`}
-        ref={contentRef}
-      >
-        {renderMarkingContent()}
-      </p>
-      {(isMultiLine || isEllipsis) && (
-        <button
-          className="w-4 h-4 "
-          onClick={() => setIsSummary((prev) => !prev)}
-          aria-label={
-            isSummary
-              ? `${markingId} 번 마킹 내용 더 보기`
-              : `${markingId} 번 마킹 내용 접기`
-          }
-        >
-          <DropDownIcon />
-        </button>
-      )}
-    </div>
+    <p
+      className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2 text-ellipsis overflow-hidden" : ""}`}
+      ref={contentRef}
+      onClick={() => setIsSummary((prev) => !prev)}
+    >
+      {renderMarkingContent()}
+    </p>
   );
 };
 

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -78,14 +78,13 @@ const TempMarkingContent = ({
   const renderMarkingContent = () => {
     if (isMultiLine) {
       return isSummary ? (
-        <>
-          <span>{multiLineContent[0]}</span>
-          <br />
-          <span ref={multiLineSummaryRef}>
+        <div>
+          <p>{multiLineContent[0]}</p>
+          <p ref={multiLineSummaryRef}>
             {multiLineContent[1]}
             {!isMultiLineSummaryEllipsis && "..."}
-          </span>
-        </>
+          </p>
+        </div>
       ) : (
         multiLineContent.map((line, index) => (
           <p className="min-h-4" key={index}>
@@ -110,12 +109,12 @@ const TempMarkingContent = ({
   }, []);
 
   return (
-    <p
+    <div
       className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2" : ""}`}
       onClick={() => setIsSummary((prev) => !prev)}
     >
       {renderMarkingContent()}
-    </p>
+    </div>
   );
 };
 

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -69,7 +69,6 @@ const TempMarkingContent = ({
   const [isMultiLineSummaryEllipsis, setIsMultiLineSummaryEllipsis] =
     useState<boolean>(false);
 
-  const contentRef = useRef<HTMLParagraphElement>(null);
   const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
 
   // 줄바꿈이 적용된 배열
@@ -113,7 +112,6 @@ const TempMarkingContent = ({
   return (
     <p
       className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2" : ""}`}
-      ref={contentRef}
       onClick={() => setIsSummary((prev) => !prev)}
     >
       {renderMarkingContent()}

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -79,13 +79,18 @@ const TempMarkingContent = ({
   const renderMarkingContent = () => {
     if (isMultiLine) {
       return isSummary ? (
-        <p
-          className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap"
-          ref={multiLineSummaryRef}
-        >
-          {multiLineContent[0]}
-          {!isMultiLineSummaryEllipsis && "..."}
-        </p>
+        <>
+          <p className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap">
+            {multiLineContent[0]}
+          </p>
+          <p
+            className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap"
+            ref={multiLineSummaryRef}
+          >
+            {multiLineContent[1]}
+            {!isMultiLineSummaryEllipsis && "..."}
+          </p>
+        </>
       ) : (
         multiLineContent.map((line, index) => (
           <p className="min-h-4" key={index}>
@@ -97,14 +102,18 @@ const TempMarkingContent = ({
     return content;
   };
 
+  // 멀티 라인의 두 번째 줄에는 필수적으로 ... 를 붙혀 하위에 렌더링 되지 않은 줄이 있음을 표현 해줍니다.
+  // 이를 위해 멀티라인의 두 번쨰 줄이 ellipsis 되었는지 확인하고 , 그렇지 않다면 인위적으로 ...을 붙혀주기 위해 상태를 변경합니다.
   useEffect(() => {
-    if (multiLineSummaryRef.current === null) {
-      return;
-    }
+    const $multiLineSummaryText = multiLineSummaryRef.current;
 
-    const $p = multiLineSummaryRef.current!;
-    setIsMultiLineSummaryEllipsis($p.scrollWidth > $p.clientWidth);
-  }, [multiLineContent]);
+    if ($multiLineSummaryText) {
+      setIsMultiLineSummaryEllipsis(
+        $multiLineSummaryText.scrollWidth > $multiLineSummaryText.clientWidth,
+      );
+    }
+  }, []);
+
   return (
     <p
       className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2 text-ellipsis overflow-hidden" : ""}`}

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -80,16 +80,12 @@ const TempMarkingContent = ({
     if (isMultiLine) {
       return isSummary ? (
         <>
-          <p className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap">
-            {multiLineContent[0]}
-          </p>
-          <p
-            className="body-2 min-h-4 text-ellipsis overflow-hidden text-nowrap"
-            ref={multiLineSummaryRef}
-          >
+          <span>{multiLineContent[0]}</span>
+          <br />
+          <span ref={multiLineSummaryRef}>
             {multiLineContent[1]}
             {!isMultiLineSummaryEllipsis && "..."}
-          </p>
+          </span>
         </>
       ) : (
         multiLineContent.map((line, index) => (
@@ -116,7 +112,7 @@ const TempMarkingContent = ({
 
   return (
     <p
-      className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2 text-ellipsis overflow-hidden" : ""}`}
+      className={`body-2  text-grey-700 ${isSummary ? "line-clamp-2" : ""}`}
       ref={contentRef}
       onClick={() => setIsSummary((prev) => !prev)}
     >

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useRef } from "react";
 import { useMarkingFormModal } from "@/features/marking/lib";
 import { DeleteTemporaryMarkingButton } from "@/features/marking/ui";
 import { EditMarkingFormModal } from "@/features/marking/ui";
@@ -7,6 +8,7 @@ import { API_BASE_URL } from "@/shared/constants";
 import { Button } from "@/shared/ui/button";
 import { InfoChip } from "@/shared/ui/chip/InfoChip";
 import { MyLocationIcon } from "@/shared/ui/icon";
+import { DropDownIcon } from "@/shared/ui/icon";
 import { ImgSlider } from "@/shared/ui/imgSlider";
 
 export const TemporaryMarkingItem = ({
@@ -41,9 +43,9 @@ export const TemporaryMarkingItem = ({
           ))}
         </ImgSlider>
         {/* 내용 */}
-        <p className="body-2 text-grey-700 text-ellipsis line-clamp-2">
-          {content}
-        </p>
+        {content && (
+          <TempMarkingContent content={content} markingId={markingId} />
+        )}
       </main>
       <footer className="mt-4">
         <EditMarkingModalOpenButton
@@ -55,6 +57,64 @@ export const TemporaryMarkingItem = ({
         />
       </footer>
     </li>
+  );
+};
+
+const TempMarkingContent = ({
+  content,
+  markingId,
+}: {
+  content: NonNullable<TempMarkingInfo["content"]>;
+  markingId: TempMarkingInfo["markingId"];
+}) => {
+  const [isSummary, setIsSummary] = useState<boolean>(true);
+  const [isEllipsis, setIsEllipsis] = useState<boolean>(false);
+  const contentRef = useRef<HTMLParagraphElement>(null);
+
+  // 줄바꿈이 적용된 배열
+  const multiLineContent = content.split("\n");
+  const isMultiLine = multiLineContent.length > 1;
+
+  const renderMarkingContent = () => {
+    if (isMultiLine) {
+      return isSummary
+        ? multiLineContent[0]
+        : multiLineContent.map((line, index) => (
+            <p className="min-h-4" key={index}>
+              {line}
+            </p>
+          ));
+    }
+    return content;
+  };
+
+  useEffect(() => {
+    const $p = contentRef.current!;
+    setIsEllipsis($p.scrollWidth > $p.clientWidth);
+  }, []);
+
+  return (
+    <div className="flex gap-4 text-grey-700">
+      <p
+        className={`body-2  ${isSummary ? "text-ellipsis overflow-hidden text-nowrap" : ""}`}
+        ref={contentRef}
+      >
+        {renderMarkingContent()}
+      </p>
+      {(isMultiLine || isEllipsis) && (
+        <button
+          className="w-4 h-4 "
+          onClick={() => setIsSummary((prev) => !prev)}
+          aria-label={
+            isSummary
+              ? `${markingId} 번 마킹 내용 더 보기`
+              : `${markingId} 번 마킹 내용 접기`
+          }
+        >
+          <DropDownIcon />
+        </button>
+      )}
+    </div>
   );
 };
 

--- a/src/widgets/marking/ui/temporaryMarkingItem.tsx
+++ b/src/widgets/marking/ui/temporaryMarkingItem.tsx
@@ -72,16 +72,16 @@ const TempMarkingContent = ({
   const multiLineSummaryRef = useRef<HTMLParagraphElement>(null);
 
   const renderMarkingContent = () => {
-    // 줄바꿈이 적용된 배열
     const multiLineContent = content.split("\n");
+    const multiLineLength = multiLineContent.length;
 
-    if (multiLineContent.length > 1) {
+    if (multiLineLength > 1) {
       return isSummary ? (
         <>
           <p>{multiLineContent[0]}</p>
           <p ref={multiLineSummaryRef}>
             {multiLineContent[1]}
-            {!isMultiLineSummaryEllipsis && "..."}
+            {!isMultiLineSummaryEllipsis && multiLineLength > 2 && "..."}
           </p>
         </>
       ) : (


### PR DESCRIPTION
# 관련 이슈 번호
close #485 
# 설명

바텀 시트에 존재하는 마킹 아이템과 , 임시저장 게시글 보기에서 사용 되는 TempMarkingItem 에서 더 보기 버튼을 추가해줬습니다.

로직들은 이전에 사용한 ProfileOverview 에서 사용되었던 로직과 동일합니다 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
