### PR TITLE
[Feat] 유효하지 않은 토큰으로 요청했을 때 재발급 받고 요청 재시도

### DIFF
--- a/src/app/DevTools.tsx
+++ b/src/app/DevTools.tsx
@@ -165,6 +165,44 @@ export const DevTools = () => {
           colorType="primary"
           variant="filled"
           size="small"
+          onClick={() => {
+            useAuthStore.setState({
+              role: "ROLE_USER",
+              token: "invalidAccessToken",
+              nickname,
+            });
+            document.cookie =
+              "Authorization-refresh=freshRefreshToken; path=/; max-age=3600";
+          }}
+        >
+          <p className="flex flex-col">
+            <span>ROLE_USER</span>
+            <span>invalid AT & valid RT</span>
+          </p>
+        </Button>
+        <Button
+          colorType="primary"
+          variant="filled"
+          size="small"
+          onClick={() => {
+            useAuthStore.setState({
+              role: "ROLE_USER",
+              token: "invalidAccessToken",
+              nickname,
+            });
+            document.cookie =
+              "Authorization-refresh=invalidRefreshToken; path=/; max-age=3600";
+          }}
+        >
+          <p className="flex flex-col">
+            <span>ROLE_USER</span>
+            <span>invalid AT & invalid RT</span>
+          </p>
+        </Button>
+        <Button
+          colorType="primary"
+          variant="filled"
+          size="small"
           onClick={setSocialUser}
         >
           <p className="flex flex-col">

--- a/src/app/ReactQueryProvider/errorHandlers.ts
+++ b/src/app/ReactQueryProvider/errorHandlers.ts
@@ -1,60 +1,98 @@
-import { NavigateFunction } from "react-router-dom";
-import type { QueryClient } from "@tanstack/react-query";
+import { useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import type {
+  Mutation,
+  Query,
+  QueryClient,
+  QueryKey,
+} from "@tanstack/react-query";
 import { ROUTER_PATH } from "@/shared/constants";
-import { AuthStore, useAuthStore } from "@/shared/store";
+import { HttpError } from "@/shared/lib";
+import { useAuthStore } from "@/shared/store";
 import { getAccessTokenByRefreshToken } from "../api";
-import { ERROR_MESSAGE } from "./constants";
 
-export const getValidAuthorization = async ({
-  queryClient,
-  callbackFunctions,
-}: {
-  queryClient: QueryClient;
-  callbackFunctions: {
-    resetAuthStore: AuthStore["reset"];
-    navigate: NavigateFunction;
-  };
-}) => {
-  const { resetAuthStore, navigate } = callbackFunctions;
+interface FailedRequest {
+  query?: Query<unknown, unknown, unknown, QueryKey>;
+  mutation?: Mutation<unknown, unknown, unknown, unknown>;
+  variables?: unknown;
+}
 
-  // 해당 try-catch 문은 access token 을 refresh token 을 이용해 재발급 받는 로직입니다.
-  try {
-    const { authorization, role, nickname } =
-      await getAccessTokenByRefreshToken();
+export const useRefreshToken = () => {
+  const navigate = useNavigate();
+  const resetAuthStore = useAuthStore((state) => state.reset);
 
-    useAuthStore.setState({
-      token: authorization,
-      role,
-      nickname,
-    });
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === ERROR_MESSAGE.REFRESH_TOKEN_INVALIDATED
-    ) {
-      /**
-       * refresh 토큰이 유효하지 않다면 다음과 같은 일들을 처리 합니다.
-       * 1. AuthStore 의 token, role, nickname 을 초기화 합니다.
-       * 2. 캐싱 된 쿼리를 모두 초기화 합니다.
-       */
-      resetAuthStore();
-      queryClient.clear();
+  // access token 갱신 중인지 여부
+  const isRefreshing = useRef<boolean>(false);
+  // 실패한 query나 mutation을 저장하는 queue
+  const failedQueue = useRef<FailedRequest[]>([]);
 
-      // 스토리북 환경의 경우엔 이하 코드를 실행 시키지 않습니다.
-      // 스토리북은 react-router-dom을 사용하지 않기 때문입니다.
-      if (
-        (
-          window as Window &
-            typeof globalThis & { __STORYBOOK_ADDONS_CHANNEL__?: unknown }
-        ).__STORYBOOK_ADDONS_CHANNEL__
-      ) {
-        return;
+  // access token 갱신 요청
+  const updateAccessToken = async (queryClient: QueryClient) => {
+    try {
+      const {
+        authorization: newToken,
+        role,
+        nickname,
+      } = await getAccessTokenByRefreshToken();
+
+      useAuthStore.setState({
+        token: newToken,
+        role,
+        nickname,
+      });
+    } catch (error) {
+      if (error instanceof HttpError && error.code === 401) {
+        resetAuthStore();
+        queryClient.clear();
+
+        if (
+          (
+            window as Window &
+              typeof globalThis & { __STORYBOOK_ADDONS_CHANNEL__?: unknown }
+          ).__STORYBOOK_ADDONS_CHANNEL__
+        ) {
+          return;
+        }
+
+        navigate(ROUTER_PATH.LOGIN);
       }
+    }
+  };
 
-      navigate(ROUTER_PATH.LOGIN);
+  // 실패한 요청 재시도
+  const retryRequest = () => {
+    failedQueue.current.forEach(({ query, mutation, variables }) => {
+      if (mutation) {
+        mutation.execute(variables);
+      }
+      if (query) {
+        query.fetch();
+      }
+    });
+
+    isRefreshing.current = false;
+    failedQueue.current = [];
+  };
+
+  // 토큰 갱신 후 요청 재시도
+  const refreshTokenAndRetry = async (
+    queryClient: QueryClient,
+    query?: Query<unknown, unknown, unknown, QueryKey>,
+    mutation?: Mutation<unknown, unknown, unknown, unknown>,
+    variables?: unknown,
+  ) => {
+    if (!isRefreshing.current) {
+      isRefreshing.current = true;
+      failedQueue.current.push({ query, mutation, variables });
+
+      await updateAccessToken(queryClient);
+
+      retryRequest();
       return;
     }
 
-    throw error;
-  }
+    failedQueue.current.push({ query, mutation, variables });
+  };
+
+  return { refreshTokenAndRetry };
 };

--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -1,17 +1,12 @@
 import { useRef } from "react";
-import { useNavigate } from "react-router-dom";
 import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
-import { HttpError, useSnackBar } from "@/shared/lib";
-import { useAuthStore } from "@/shared/store";
+import { HttpError } from "@/shared/lib";
 import { useOverlayStore } from "@/shared/store/overlay";
-import { ERROR_MESSAGE } from "./constants";
-import { getValidAuthorization } from "./errorHandlers";
+import { useRefreshToken } from "./errorHandlers";
 
 export const useCreateQueryClient = () => {
-  const resetAuthStore = useAuthStore((state) => state.reset);
-  const navigate = useNavigate();
   const resetOverlays = useOverlayStore((state) => state.resetOverlays);
-  const handleOpenSnackbar = useSnackBar();
+  const { refreshTokenAndRetry } = useRefreshToken();
 
   const queryClient = useRef(
     new QueryClient({
@@ -36,24 +31,9 @@ export const useCreateQueryClient = () => {
 
       queryCache: new QueryCache({
         onError: async (error, query) => {
-          if (error instanceof HttpError && error.code === 500) {
-            handleOpenSnackbar(ERROR_MESSAGE.INTERNAL_SERVER_ERROR);
-          }
-
-          switch (error.message) {
-            case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
-              await getValidAuthorization({
-                queryClient,
-                callbackFunctions: { resetAuthStore, navigate },
-              });
-              queryClient.invalidateQueries({
-                queryKey: query.queryKey,
-              });
-              break;
-            }
-            default:
-              handleOpenSnackbar(error.message);
-              return;
+          if (error instanceof HttpError && error.code === 401) {
+            refreshTokenAndRetry(queryClient, query);
+            return;
           }
         },
       }),
@@ -70,48 +50,10 @@ export const useCreateQueryClient = () => {
             resetOverlays();
           }
         },
-        onError: async (error, variables, context, mutation) => {
-          if (error instanceof HttpError && error.code === 500) {
-            handleOpenSnackbar(ERROR_MESSAGE.INTERNAL_SERVER_ERROR);
-          }
-
-          switch (error.message) {
-            case ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED: {
-              await getValidAuthorization({
-                queryClient,
-                callbackFunctions: { resetAuthStore, navigate },
-              });
-              const { options, state } = mutation;
-              /**
-               * 이전에 시도 했던 mutationFn 을 업데이트 된 액세스 토큰을 이용해 다시 시도합니다.
-               * options.mutationFn 으로 재시도 하는 mutation의 경우엔 onSuccess, onError를 자동으로 호출하지 않습니다.
-               * 이에 try,catch 문을 이용해 onSuccess, onError 를 수동으로 호출합니다.
-               */
-              try {
-                const { token } = useAuthStore.getState();
-                const updatedVariables = { ...(variables as object), token };
-                await options.mutationFn?.(updatedVariables);
-                // mutation이 성공하면 mutationCached에 존재하는 로직과 동일하게 모든 오버레이 닫기
-                if (useOverlayStore.getState().overlays.length > 0) {
-                  resetOverlays();
-                }
-                // 기존 mutation 의 onSuccess 호출
-                options.onSuccess?.(state.data, updatedVariables, context);
-              } catch (error) {
-                options.onError?.(error, variables, context);
-              }
-              break;
-            }
-            default:
-              /**
-               * 만약 발생 한 에러가 전역으로 핸들링 할 에러가 아니라면
-               * 아무런 행위도 하지 않습니다.
-               * 2024/10/15 에서 throw error 문이 제거 되었습니다.
-               * throw error 가 있을 경우 에러가 mutation.onError 에게 에러가 전달 되지 않고
-               * 실행 스택이 중단 되어 mutation.onError 가 호출 되지 않았습니다.
-               */
-              handleOpenSnackbar(error.message);
-              return;
+        onError: async (error, variables, _context, mutation) => {
+          if (error instanceof HttpError && error.code === 401) {
+            refreshTokenAndRetry(queryClient, undefined, mutation, variables);
+            return;
           }
         },
       }),

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -622,6 +622,18 @@ const getValidAuthorizationHandler = [
   http.get(APP_END_POINT.REFRESH_ACCESS_TOKEN, ({ cookies }) => {
     const refreshToken = cookies["Authorization-refresh"];
 
+    if (!refreshToken) {
+      return HttpResponse.json(
+        {
+          code: 400,
+          message: "RefreshToken이 존재하지 않습니다.",
+        },
+        {
+          status: 400,
+        },
+      );
+    }
+
     if (refreshToken !== "freshRefreshToken") {
       return HttpResponse.json(
         {
@@ -1222,6 +1234,19 @@ const markingListDB: Record<string, Marking[]> = {};
 const getMarkingListHandler = [
   http.get(`${API_BASE_URL}/markings/bounds`, async ({ request }) => {
     const url = new URL(request.url);
+    const token = request.headers.get("Authorization");
+
+    if (token === "invalidAccessToken") {
+      return HttpResponse.json(
+        {
+          code: 401,
+          message: ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED,
+        },
+        {
+          status: 401,
+        },
+      );
+    }
 
     const lat = Number(url.searchParams.get("lat"));
     const lng = Number(url.searchParams.get("lng"));
@@ -1297,6 +1322,20 @@ const getMarkingListHandler = [
 const getBoundaryMarkerListHandler = [
   http.get(`${API_BASE_URL}/markings/marks`, async ({ request }) => {
     const url = new URL(request.url);
+    const token = request.headers.get("Authorization");
+
+    if (token === "invalidAccessToken") {
+      return HttpResponse.json(
+        {
+          code: 401,
+          message: ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED,
+        },
+        {
+          status: 401,
+        },
+      );
+    }
+
     const southBottomLat = Number(url.searchParams.get("southBottomLat"));
     const northTopLat = Number(url.searchParams.get("northTopLat"));
     const southLeftLng = Number(url.searchParams.get("southLeftLng"));

--- a/src/pages/[nickname]/myProfilePage.tsx
+++ b/src/pages/[nickname]/myProfilePage.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import { Link } from "react-router-dom";
 import { MarkingThumbnailGrid } from "@/widgets/marking/ui";
 import {
@@ -17,18 +15,10 @@ import { NotFoundUser } from "./notFoundUser";
 
 export const MyProfilePage = () => {
   const { nicknameParams } = useNicknameParams();
-  const token = useAuthStore((state) => state.token);
-  const navigate = useNavigate();
   // TODO 404 와 같은 양식의 디자인 사용하는건 어떤지 디자이너와 상의
   const { data, isLoading, isError, error } = useGetProfile({
     nickname: nicknameParams,
   });
-
-  useEffect(() => {
-    if (!token) {
-      navigate(ROUTER_PATH.LOGIN);
-    }
-  }, [token, navigate]);
 
   if (isError && error.code === 404) {
     return <NotFoundUser />;

--- a/src/pages/[nickname]/otherProfilePage.tsx
+++ b/src/pages/[nickname]/otherProfilePage.tsx
@@ -1,31 +1,19 @@
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import { MarkingThumbnailGrid } from "@/widgets/marking/ui";
 import { ProfileOverView } from "@/widgets/profile/ui";
 import { useGetProfile } from "@/entities/profile/api";
 import { useGetMyFollowingIdsMap } from "@/entities/profile/api";
-import { ROUTER_PATH } from "@/shared/constants";
 import { useNicknameParams } from "@/shared/lib";
-import { useAuthStore } from "@/shared/store";
 import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
 import { NotFoundUser } from "./notFoundUser";
 
 export const OtherProfilePage = () => {
   const { nicknameParams } = useNicknameParams();
-  const token = useAuthStore((state) => state.token);
-  const navigate = useNavigate();
   // TODO 404 와 같은 양식의 디자인 사용하는건 어떤지 디자이너와 상의
   const { data, isLoading, isError, error } = useGetProfile({
     nickname: nicknameParams,
   });
   const { data: myFollowingIdsMap, isLoading: isMyFollowingIdsMapLoading } =
     useGetMyFollowingIdsMap();
-
-  useEffect(() => {
-    if (!token) {
-      navigate(ROUTER_PATH.LOGIN);
-    }
-  }, [token, navigate]);
 
   if (isError && error.code === 404) {
     return <NotFoundUser />;

--- a/src/pages/[nickname]/page.tsx
+++ b/src/pages/[nickname]/page.tsx
@@ -1,4 +1,8 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { ROUTER_PATH } from "@/shared/constants";
 import { useNicknameParams } from "@/shared/lib";
+import { useAuthStore } from "@/shared/store";
 import { MyProfilePage } from "./myProfilePage";
 import { OtherProfilePage } from "./otherProfilePage";
 
@@ -7,7 +11,15 @@ import { OtherProfilePage } from "./otherProfilePage";
  * @:nickname: 해당 닉네임을 가진 사용자의 프로필 페이지, 만약 AuthStore에 저장된 닉네임과 같다면 마이페이지처럼 이용 가능 합니다.
  */
 export const ProfilePage = () => {
+  const token = useAuthStore((state) => state.token);
+  const navigate = useNavigate();
   const { isMyPage } = useNicknameParams();
+
+  useEffect(() => {
+    if (!token) {
+      navigate(ROUTER_PATH.LOGIN);
+    }
+  }, [token, navigate]);
 
   if (isMyPage) {
     return <MyProfilePage />;


### PR DESCRIPTION
# 관련 이슈 번호

#470 

# 설명

queryCache나 mutationCache의 onError에서 401 에러가 발생할 때마다 access token 재발급 요청을 보냈습니다.
그러면 401 에러 응답이 발생한 쿼리가 4개가 있다면 4번이나 재발급 요청을 보내게 됩니다.
재발급 요청을 1번만 보내고 나서 실패한 요청들을 재시도하면 되는데 말이죠.

그래서 useRefreshToken 커스텀 훅을 만들었습니다.

아래 사진은 useRefreshToken의 refreshTokenAndRetry 함수 작동 순서입니다.

![image](https://github.com/user-attachments/assets/db3e9027-1d2f-463c-8da8-600a420e499d)

dev tools에 `invalid AT & valid RT`이랑 `invalid AT & invalid RT` 버튼을 추가하여 테스트해봤습니다.

유효하지 않은 토큰으로 요청을 보냈을 때, auth로 재발급 1번 받고 나서 다시 요청을 시도하는 모습을 볼 수 있었습니다.


<img width="1102" alt="스크린샷 2024-11-18 오후 4 44 11" src="https://github.com/user-attachments/assets/4a8af045-a640-4e48-912e-1dc6533cadca">
<img width="1102" alt="스크린샷 2024-11-18 오후 4 44 20" src="https://github.com/user-attachments/assets/fe4872dc-ce89-4ddd-8fe1-95d15da7f9b2">


