### PR TITLE
[Hotfix] 로그인 하지 않은 유저에게서 이 장소 마킹이 나타나지 않던 문제 해결

### DIFF
--- a/src/entities/profile/api/getProfile.ts
+++ b/src/entities/profile/api/getProfile.ts
@@ -89,7 +89,7 @@ export const useGetMyProfile = <TResult = GetProfileResponse>(
 
 export const useGetMyFollowingIdsMap = () => {
   return useGetMyProfile((data) => {
-    const followingsIds = data?.followingsIds || [];
+    const followingsIds = data.followingsIds || [];
     return followingsIds.reduce(
       (map, id) => {
         map[id] = true;
@@ -102,7 +102,7 @@ export const useGetMyFollowingIdsMap = () => {
 
 export const useGetMyBookmarkIdsMap = () => {
   return useGetMyProfile((data) => {
-    const bookmarks = data?.bookmarks || [];
+    const bookmarks = data.bookmarks || [];
 
     return bookmarks.reduce(
       (map, id) => {
@@ -116,7 +116,7 @@ export const useGetMyBookmarkIdsMap = () => {
 
 export const useGetMyLikedIdsMap = () => {
   return useGetMyProfile((data) => {
-    const likes = data?.likes || [];
+    const likes = data.likes || [];
 
     return likes.reduce(
       (map, id) => {

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -30,7 +30,7 @@ export const PlaceMarkingList = () => {
   const { setPlaceQueryParams } = usePlaceQueryParams();
 
   const {
-    data: markingList = [],
+    data: markingList,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -13,6 +13,7 @@ import {
 import { ROUTER_PATH } from "@/shared/constants";
 import { useInfiniteScroll } from "@/shared/lib";
 import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { mapOptions } from "../constants";
 import { MarkingList } from "./markingList";
 
 export const PlaceMarkingList = () => {
@@ -25,6 +26,8 @@ export const PlaceMarkingList = () => {
   const { data: myFollowingMap = {} } = useGetMyFollowingIdsMap();
   const { data: myBookmarkedMap = {} } = useGetMyBookmarkIdsMap();
   const { data: myLikedMap = {} } = useGetMyLikedIdsMap();
+
+  const { setPlaceQueryParams } = usePlaceQueryParams();
 
   const {
     data: markingList = [],
@@ -72,12 +75,16 @@ export const PlaceMarkingList = () => {
         {markingList?.map((marking) => (
           <MarkingItem
             key={marking.markingId}
-            onRegionClick={() => {
-              map.setCenter({
+            onRegionClick={async () => {
+              await map.setCenter({
                 lat: marking.lat,
                 lng: marking.lng,
               });
-              map.setZoom(19);
+              await map.setZoom(mapOptions.maxZoom);
+              setPlaceQueryParams({
+                lat: marking.lat,
+                lng: marking.lng,
+              });
             }}
             onDelete={() => {
               queryClient.invalidateQueries({

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -22,12 +22,12 @@ export const PlaceMarkingList = () => {
     useMapQueryParams();
   const { boundsAdjacentPlace } = usePlaceQueryParams();
 
-  const { data: myFollowingMap } = useGetMyFollowingIdsMap();
-  const { data: myBookmarkedMap } = useGetMyBookmarkIdsMap();
-  const { data: myLikedMap } = useGetMyLikedIdsMap();
+  const { data: myFollowingMap = {} } = useGetMyFollowingIdsMap();
+  const { data: myBookmarkedMap = {} } = useGetMyBookmarkIdsMap();
+  const { data: myLikedMap = {} } = useGetMyLikedIdsMap();
 
   const {
-    data: markingList,
+    data: markingList = [],
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -44,11 +44,6 @@ export const PlaceMarkingList = () => {
   });
 
   const map = useMap();
-
-  // TODO 로딩 상태 구현 하기
-  if (!markingList || !myFollowingMap || !myBookmarkedMap || !myLikedMap) {
-    return null;
-  }
 
   return (
     <>

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -221,23 +221,6 @@ const MarkingItemBookmarkToggle = () => {
   const { mutate: deleteSaveMarking, isPending: isDeleteSaveMarkingPending } =
     useDeleteSavedMarking();
 
-  const token = useAuthStore((state) => state.token);
-  const handleOpenSnackbar = useSnackBar();
-
-  if (!token) {
-    return (
-      <button
-        className="text-grey-500"
-        aria-label={`${markingId} 번 마킹 저장하기`}
-        onClick={() =>
-          handleOpenSnackbar("로그인 후 이용해 주세요", { type: "map" })
-        }
-      >
-        <BookmarkIcon />
-      </button>
-    );
-  }
-
   const isPending = isPostSaveMarkingPending || isDeleteSaveMarkingPending;
 
   const handleClickSaveButton = () => {

--- a/src/widgets/marking/ui/markingItem.tsx
+++ b/src/widgets/marking/ui/markingItem.tsx
@@ -13,7 +13,9 @@ import { useMarkingFormModal } from "@/features/marking/lib";
 import { EditMarkingFormModal } from "@/features/marking/ui";
 import { API_BASE_URL } from "@/shared/constants";
 import { formatDateToYearMonthDay, useDropdown } from "@/shared/lib";
+import { useSnackBar } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
+import { Button } from "@/shared/ui/button";
 import { DividerLine } from "@/shared/ui/divider";
 import { MoreIcon, MyLocationIcon } from "@/shared/ui/icon";
 import { FilledLikeIcon, LikeIcon } from "@/shared/ui/icon";
@@ -42,6 +44,25 @@ const MarkingItemPropsProvider = ({
 
 export const MarkingItem = (props: MarkingItemProps) => {
   const { nickName, isOwner = false, isFollowing } = props;
+  const token = useAuthStore((state) => state.token);
+
+  const renderFollowingToggle = () => {
+    if (!token) {
+      return <UnAuthorizedFollowingButton />;
+    }
+
+    if (isOwner) {
+      return null;
+    }
+
+    return (
+      <FollowingToggle
+        nickname={nickName}
+        size="xSmall"
+        isFollowing={!!isFollowing}
+      />
+    );
+  };
 
   return (
     <MarkingItemPropsProvider props={props}>
@@ -50,7 +71,6 @@ export const MarkingItem = (props: MarkingItemProps) => {
           <MarkingItemRegion />
           {isOwner && <MarkingManageButton />}
         </div>
-
         <header className="flex items-center justify-between">
           <div className="flex justify-between items-center gap-1 ">
             <MarkingItemProfileImage />
@@ -58,19 +78,17 @@ export const MarkingItem = (props: MarkingItemProps) => {
             <DividerLine axis="col" />
             <MarkingItemPetName />
           </div>
-          {!isOwner && typeof isFollowing === "boolean" && (
-            <FollowingToggle
-              nickname={nickName}
-              size="xSmall"
-              isFollowing={isFollowing}
-            />
-          )}
+          {renderFollowingToggle()}
         </header>
         <main className="flex flex-col gap-2">
           <MarkingItemImages />
           <div className="flex justify-between">
-            <MarkingItemLikeToggle />
-            <MarkingItemBookmarkToggle />
+            {token ? <MarkingItemLikeToggle /> : <UnauthorizedLikeButton />}
+            {token ? (
+              <MarkingItemBookmarkToggle />
+            ) : (
+              <UnAuthorizedBookmarkButton />
+            )}
           </div>
         </main>
         <footer className="flex flex-col gap-2">
@@ -79,6 +97,24 @@ export const MarkingItem = (props: MarkingItemProps) => {
         </footer>
       </li>
     </MarkingItemPropsProvider>
+  );
+};
+
+const UnAuthorizedFollowingButton = () => {
+  const handleOpenSnackbar = useSnackBar();
+
+  return (
+    <Button
+      variant="filled"
+      colorType="primary"
+      fullWidth={false}
+      size="xSmall"
+      onClick={() =>
+        handleOpenSnackbar("로그인 후 이용해 주세요", { type: "map" })
+      }
+    >
+      팔로우
+    </Button>
   );
 };
 
@@ -151,6 +187,26 @@ const MarkingItemLikeToggle = () => {
   );
 };
 
+const UnauthorizedLikeButton = () => {
+  const { markingId, countData } = useMarkingItemProps();
+  const { likedCount } = countData;
+  const handleOpenSnackbar = useSnackBar();
+
+  return (
+    <div className="flex gap-2 items-center text-grey-500">
+      <button
+        aria-label={`${markingId} 번 마킹 좋아요 추가`}
+        onClick={() =>
+          handleOpenSnackbar("로그인 후 이용해 주세요", { type: "map" })
+        }
+      >
+        <LikeIcon />
+      </button>
+      <span className="title-3">{likedCount > 0 && countData.likedCount}</span>
+    </div>
+  );
+};
+
 const MarkingItemBookmarkToggle = () => {
   const { isBookmarked, markingId, countData } = useMarkingItemProps();
   const [_isBookmarked, _setIsBookmarked] = useState<boolean>(
@@ -164,6 +220,24 @@ const MarkingItemBookmarkToggle = () => {
     usePostSaveMarking();
   const { mutate: deleteSaveMarking, isPending: isDeleteSaveMarkingPending } =
     useDeleteSavedMarking();
+
+  const token = useAuthStore((state) => state.token);
+  const handleOpenSnackbar = useSnackBar();
+
+  if (!token) {
+    return (
+      <button
+        className="text-grey-500"
+        aria-label={`${markingId} 번 마킹 저장하기`}
+        onClick={() =>
+          handleOpenSnackbar("로그인 후 이용해 주세요", { type: "map" })
+        }
+      >
+        <BookmarkIcon />
+      </button>
+    );
+  }
+
   const isPending = isPostSaveMarkingPending || isDeleteSaveMarkingPending;
 
   const handleClickSaveButton = () => {
@@ -217,6 +291,27 @@ const MarkingItemBookmarkToggle = () => {
         </button>
       )}
       <span className="title-3">{_savedCount > 0 && _savedCount}</span>
+    </div>
+  );
+};
+
+const UnAuthorizedBookmarkButton = () => {
+  const { markingId, countData } = useMarkingItemProps();
+  const { savedCount } = countData;
+  const handleOpenSnackbar = useSnackBar();
+
+  return (
+    <div className="flex gap-2 items-center text-grey-500">
+      <button
+        className="text-grey-500"
+        aria-label={`${markingId} 번 마킹 저장하기`}
+        onClick={() =>
+          handleOpenSnackbar("로그인 후 이용해 주세요", { type: "map" })
+        }
+      >
+        <BookmarkIcon />
+      </button>
+      <span className="title-3">{savedCount > 0 && savedCount}</span>
     </div>
   );
 };


### PR DESCRIPTION
# 관련 이슈 번호
close #492 
# 설명

오 마이 갓 범인은 저였습니다.

```tsx
export const PlaceMarkingList = () => {
  ...

  const { data: myFollowingMap } = useGetMyFollowingIdsMap();
  const { data: myBookmarkedMap } = useGetMyBookmarkIdsMap();
  const { data: myLikedMap } = useGetMyLikedIdsMap();

...

  // TODO 로딩 상태 구현 하기
  if (!markingList || !myFollowingMap || !myBookmarkedMap || !myLikedMap) {
    return null;
  }
```

api 요청은 문제 없이 갔는데 로그인 하지 않은 유저는 `my ... Map` 이 매번 `undefined` 이기 때문에 데이터가 렌더링 되지 않았던 것입니다 .

```tsx
...
  const { data: myFollowingMap = {} } = useGetMyFollowingIdsMap();
  const { data: myBookmarkedMap = {} } = useGetMyBookmarkIdsMap();
  const { data: myLikedMap = {} } = useGetMyLikedIdsMap();

  const { setPlaceQueryParams } = usePlaceQueryParams();

  const {
    data: markingList = [],
...
```

다음과 같이 쿼리의 반환 값들의 기본 값을 지정해준 후  `return null` 시키던 부분을 제거했습니다 .

그렇게 하니 문제 없이 잘 나오더군요 

# 비회원을 위한 `Unauthorized...Button` 생성

토큰이 없는 유저를 위한 분기 처리를 `어쩌구Toggle` 내부에서 할까 하다가 

비회원용 컴포넌트를 만들어서 `MarkingItem` 내부에서 `token` 여부로 삼항연산자로 렌더링 하는편이 낫겠더군요 

그래서 비회원의 경우 좋아요, 북마크 , 팔로잉 모두 안한 유저의 모습을 가진 `UnAutorized ... Button` 으로 렌더링 하고 

버튼 클릭 시 로그인 후 이용하라는 스낵바가 나타납니다. 

아 추가로  onRegionClick 시 placeQueryParams 변경하도록 로직 추가했습니다. 



# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
