### PR TITLE
[Feat] 셋팅 페이지에서 내 활동 라우팅 , 알림 클릭 시 출시 예정 스낵바 나타나도록 기능 추가 

### DIFF
--- a/src/pages/setting/page.tsx
+++ b/src/pages/setting/page.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { useSettingPermission } from "@/features/setting/hooks";
 import { Report, LogoutButton } from "@/features/setting/ui";
 import { ROUTER_PATH } from "@/shared/constants";
+import { useSnackBar } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { DividerLine } from "@/shared/ui/divider";
 import { ArrowRightIcon } from "@/shared/ui/icon";
@@ -71,14 +72,21 @@ const MyActivity = () => (
 );
 
 // 알림
-const Notification = () => (
-  <Link to="." className="setting-item">
-    <p>알림</p>
-    <span className="text-grey-500">
-      <ArrowRightIcon />
-    </span>
-  </Link>
-);
+const Notification = () => {
+  const handleOpenSnackbar = useSnackBar();
+
+  return (
+    <button
+      onClick={() => handleOpenSnackbar("아직 출시 되지 않은 기능입니다")}
+      className="setting-item"
+    >
+      <p>알림</p>
+      <span className="text-grey-500">
+        <ArrowRightIcon />
+      </span>
+    </button>
+  );
+};
 
 // 이용 약관
 const TermsOfService = () => (

--- a/src/pages/setting/page.tsx
+++ b/src/pages/setting/page.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { useSettingPermission } from "@/features/setting/hooks";
 import { Report, LogoutButton } from "@/features/setting/ui";
 import { ROUTER_PATH } from "@/shared/constants";
+import { useAuthStore } from "@/shared/store";
 import { DividerLine } from "@/shared/ui/divider";
 import { ArrowRightIcon } from "@/shared/ui/icon";
 import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
@@ -58,7 +59,10 @@ const EditMyInfo = () => (
 
 // 내 활동 내역을 보는 컴포넌트
 const MyActivity = () => (
-  <Link to="." className="setting-item">
+  <Link
+    to={`/@${useAuthStore.getState().nickname}/${ROUTER_PATH.USER_MARKING}`}
+    className="setting-item"
+  >
     <p>내 활동</p>
     <span className="text-grey-500">
       <ArrowRightIcon />


### PR DESCRIPTION
# 관련 이슈 번호
close #496 

# 설명
 
셋팅 페이지에서 내 활동 클릭 시 `/@{nickname}/markings` 로 라우팅 되도록 기능을 추가했습니다.

알림 버튼 클릭 시 출시 예정이라는 스낵바가 나타나도록 기능을 추가했습니다 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
