### PR TITLE
[Feat] 유저 활동에서 마킹 아이템 Region 클릭 시 맵 링크로 넘어오도록 기능 추가

### DIFF
--- a/src/entities/map/lib/tiling.ts
+++ b/src/entities/map/lib/tiling.ts
@@ -117,7 +117,7 @@ const calculateTileIndex = (
   return [lngIndex, latIndex];
 };
 
-export const filterInnerBoundary = (
+ const filterInnerBoundary = (
   { lat, lng }: LatLng,
   bounds: MapBounds,
 ) => {

--- a/src/features/map/hooks/usePlaceQueryParams.ts
+++ b/src/features/map/hooks/usePlaceQueryParams.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import { useLocation, useSearchParams } from "react-router-dom";
-import { filterInnerBoundary } from "@/entities/map/lib";
 import { ROUTER_PATH } from "@/shared/constants";
 import { getNumberParam, useMapQueryParams } from "./useMapQueryParams";
 
@@ -34,6 +33,7 @@ export const usePlaceQueryParams = () => {
     const { northEastLat, northEastLng, southWestLat, southWestLng } =
       boundsParams;
 
+    // 이 장소 마킹이 아니거나 boundsParams 가 유효하지 않은 경우 lat , lng 값을 재조정 하지 않습니다.
     if (
       !(northEastLat && northEastLng && southWestLat && southWestLng) ||
       pathname !== ROUTER_PATH.PLACE
@@ -41,11 +41,18 @@ export const usePlaceQueryParams = () => {
       return;
     }
 
-    // searchParameter 에 lat, lng 가 있고, 현재 검색된 boundsParams 내부에 존재하는
-    // 유효한 경계값이라면, 해당 값을 사용합니다.
-    if (lat && lng && filterInnerBoundary({ lat, lng }, boundsParams)) {
+    // 만약 lat , lng 서치파라미터 값을 포함한 경우 경우 boundsParams 의 경계값을 벗어나지 않는지 확인합니다.
+    if (
+      lat &&
+      lng &&
+      lat > southWestLat &&
+      lat < northEastLat &&
+      lng > southWestLng &&
+      lng < northEastLng
+    ) {
       return;
     }
+
     // lat , lng 가 유효하지 않은 경우 boundsParams 의 중심값을 사용합니다.
     setPlaceQueryParams({
       lat: (northEastLat + southWestLat) / 2,

--- a/src/features/map/hooks/usePlaceQueryParams.ts
+++ b/src/features/map/hooks/usePlaceQueryParams.ts
@@ -1,12 +1,10 @@
-import { useEffect } from "react";
-import { useLocation, useSearchParams } from "react-router-dom";
-import { ROUTER_PATH } from "@/shared/constants";
-import { getNumberParam, useMapQueryParams } from "./useMapQueryParams";
+import { useSearchParams } from "react-router-dom";
+import { getNumberParam } from "./useMapQueryParams";
 
 export const usePlaceQueryParams = () => {
-  const { pathname } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { boundsParams } = useMapQueryParams();
+  const lat = getNumberParam("lat", searchParams);
+  const lng = getNumberParam("lng", searchParams);
 
   const setPlaceQueryParams = ({ lat, lng }: { lat: number; lng: number }) => {
     setSearchParams((prevSearchParams) => {
@@ -17,9 +15,6 @@ export const usePlaceQueryParams = () => {
     });
   };
 
-  const lat = getNumberParam("lat", searchParams);
-  const lng = getNumberParam("lng", searchParams);
-
   // lat , lng 로부터 반경 100m의 경계값을 계산합니다.
   // 100m 는 0.0009이기에 중심으로부터 0.00045씩 떨어진 값을 사용합니다.
   const boundsAdjacentPlace = {
@@ -28,37 +23,6 @@ export const usePlaceQueryParams = () => {
     southWestLat: lat && lat - 0.00045,
     southWestLng: lng && lng - 0.00045,
   };
-
-  useEffect(() => {
-    const { northEastLat, northEastLng, southWestLat, southWestLng } =
-      boundsParams;
-
-    // 이 장소 마킹이 아니거나 boundsParams 가 유효하지 않은 경우 lat , lng 값을 재조정 하지 않습니다.
-    if (
-      !(northEastLat && northEastLng && southWestLat && southWestLng) ||
-      pathname !== ROUTER_PATH.PLACE
-    ) {
-      return;
-    }
-
-    // 만약 lat , lng 서치파라미터 값을 포함한 경우 경우 boundsParams 의 경계값을 벗어나지 않는지 확인합니다.
-    if (
-      lat &&
-      lng &&
-      lat > southWestLat &&
-      lat < northEastLat &&
-      lng > southWestLng &&
-      lng < northEastLng
-    ) {
-      return;
-    }
-
-    // lat , lng 가 유효하지 않은 경우 boundsParams 의 중심값을 사용합니다.
-    setPlaceQueryParams({
-      lat: (northEastLat + southWestLat) / 2,
-      lng: (northEastLng + southWestLng) / 2,
-    });
-  }, [pathname, boundsParams]);
 
   return {
     placeParams: { lat, lng },

--- a/src/mocks/data/markingList.ts
+++ b/src/mocks/data/markingList.ts
@@ -11,52 +11,77 @@ export const getMockMarkingList = ({
   southLeftLng: number;
   northRightLng: number;
 }) => {
-  const markingList: Marking[] = Array.from({ length: 1000 }, (_, index) => ({
-    markingId: index + 1,
+  const markingList: Marking[] = Array.from({ length: 1000 }, (_, index) =>
+    createMockMarking(index + 1, {
+      southBottomLat,
+      northTopLat,
+      southLeftLng,
+      northRightLng,
+    }),
+  );
+
+  return markingList;
+};
+
+export const createMockMarking = (
+  id: number,
+  {
+    southBottomLat,
+    northTopLat,
+    southLeftLng,
+    northRightLng,
+  }: {
+    southBottomLat: number;
+    northTopLat: number;
+    southLeftLng: number;
+    northRightLng: number;
+  },
+  nickname?: string,
+) => {
+  return {
+    markingId: id,
     region: "**시 **구 **동",
     content:
-      index % 2
-        ? `${`content ${index + 1}`.repeat(Math.random() * 10)} \n ${`content ${index + 1}`.repeat(Math.random() * 10)}`.repeat(
+      id % 2
+        ? `${`content ${id}`.repeat(Math.random() * 10)} \n ${`content ${id}`.repeat(
             Math.random() * 10,
-          )
-        : `content ${index + 1} `.repeat(Math.random() * 10),
+          )}`.repeat(Math.random() * 10)
+        : `content ${id} `.repeat(Math.random() * 10),
     previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
-    isVisible: "PUBLIC",
+    isVisible: "PUBLIC" as "PUBLIC" | "PRIVATE" | "FOLLOW_ONLY",
     regDt: new Date().toISOString(),
-    userId: index + 1,
-    nickName: `User${index + 1}`,
-    isOwner: index === 0 ? true : false,
+    userId: id,
+    nickName: nickname ?? `User${id}`,
+    isOwner: id === 0 ? true : false,
     isTempSaved: false,
     lat: southBottomLat + Math.random() * (northTopLat - southBottomLat),
     lng: southLeftLng + Math.random() * (northRightLng - southLeftLng),
     address: {
-      id: index + 1,
+      id: id,
       province: "**시",
       cityCounty: "**구",
       district: null,
-      subDistrict: `district ${index + 1}`,
+      subDistrict: `district ${id}`,
     },
     countData: {
       likedCount: Math.floor(Math.random() * 100),
       savedCount: Math.floor(Math.random() * 100),
     },
     pet: {
-      petId: index + 1,
-      name: `Pet${index + 1}`,
-      description: `Pet description ${index + 1}`,
-      profile: `profile_url_${index + 1}`,
-      breed: `Breed${index + 1}`,
+      petId: id,
+      name: `Pet${id}`,
+      description: `Pet description ${id}`,
+      profile: `profile_url_${id}`,
+      breed: `Breed${id}`,
       personalities: ["personality1", "personality2"],
     },
     images: [
       {
-        id: index + 1,
-        imageUrl: `image_url_${index + 1}`,
+        id: id,
+        imageUrl: `image_url_${id}`,
         lank: 1,
         regDt: new Date().toISOString(),
       },
     ],
-  }));
-
-  return markingList;
+  };
 };

--- a/src/mocks/data/markingList.ts
+++ b/src/mocks/data/markingList.ts
@@ -37,7 +37,7 @@ export const createMockMarking = (
     northRightLng: number;
   },
   nickname?: string,
-) => {
+): Marking => {
   return {
     markingId: id,
     region: "**시 **구 **동",
@@ -48,7 +48,7 @@ export const createMockMarking = (
           )}`.repeat(Math.random() * 10)
         : `content ${id} `.repeat(Math.random() * 10),
     previewImage: "fa805c91-8228-4ec4-927f-9eb876a480c3",
-    isVisible: "PUBLIC" as "PUBLIC" | "PRIVATE" | "FOLLOW_ONLY",
+    isVisible: "PUBLIC",
     regDt: new Date().toISOString(),
     userId: id,
     nickName: nickname ?? `User${id}`,

--- a/src/mocks/data/profileMarking.ts
+++ b/src/mocks/data/profileMarking.ts
@@ -1,3 +1,13 @@
+import { otherUsers } from "./otherUser";
+
+let markingCount = 0;
+const makeRandomMarking = (markingId: number) => ({
+  markingId,
+  previewImage: `a18b127f-06e6-4954-9f45-${Math.ceil(Math.random() * 100000)}a7299a`,
+  lat: Math.random() > 0.5 ? 35 + Math.random() : 35 - Math.random(),
+  lng: Math.random() > 0.5 ? 129 + Math.random() : 129 - Math.random(),
+});
+
 export const profileMarkingThumbnail: Record<
   string,
   { markingId: number; previewImage: string; lat: number; lng: number }[]
@@ -6,12 +16,20 @@ export const profileMarkingThumbnail: Record<
     {
       length: 120,
     },
-    (_, i) => ({
-      markingId: i,
-      previewImage: `a18b127f-06e6-4954-9f45-${Math.ceil(Math.random() * 100000)}a7299a`,
-      lat: Math.random() > 0.5 ? 35 + Math.random() : 35 - Math.random(),
-      lng: Math.random() > 0.5 ? 129 + Math.random() : 129 - Math.random(),
+    () => makeRandomMarking(markingCount++),
+  ),
+  // otherUser 에 대한 랜덤한 마킹 생성
+  // 마이 페이지 -> 팔로잉 , 팔로워 리스트에서 접근 가능한 유저들입니다.
+  ...Object.fromEntries(
+    otherUsers.map(({ nickname }, idx) => {
+      return [
+        nickname,
+        idx < 10
+          ? []
+          : Array.from({ length: Math.random() * 30 }, () =>
+              makeRandomMarking(markingCount++),
+            ),
+      ];
     }),
   ),
-  나는야게스트: [],
 };

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1771,11 +1771,19 @@ const getUserMarkingListHandler = [
 
       const url = new URL(request.url);
 
-      const southBottomLat = Number(url.searchParams.get("southBottomLat"));
-      const northTopLat = Number(url.searchParams.get("northTopLat"));
-      const southLeftLng = Number(url.searchParams.get("southLeftLng"));
-      const northRightLng = Number(url.searchParams.get("northRightLng"));
+      const southBottomLat =
+        Number(url.searchParams.get("southBottomLat")) || 37.56055534657849;
+      const northTopLat =
+        Number(url.searchParams.get("northTopLat")) || 37.572444179048894;
+      const southLeftLng =
+        Number(url.searchParams.get("southLeftLng")) || 126.98218424603498;
+      const northRightLng =
+        Number(url.searchParams.get("northRightLng")) || 126.97381575396503;
 
+      // TODO 실제 서버에선  mapViewMode 가 ALL_VIEW 일 경우엔 사실 southBottomLat , ... 등의 queryParams가 존재하지 않습니다.
+      // 쿼리 파라미터 값과 상관 없이 모든 데이터를 가져오기 때문입니다.
+      // 하지만 우리는 가상 DB를 만들지 않고 랜덤한 마킹 리스트를 생성하기 때문에 해당 부분을 구현하는데 어려움이 있습니다.
+      // 이에 임시 방편으로 mapViewMode여서 queryParams 가 없는 경우를 고려하여 기본 값을 넣어주도록 합니다.
       const markingList =
         nickname === "뽀송송"
           ? myMarkingList

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -22,7 +22,7 @@ import { MARKER_END_POINT } from "@/entities/marking/constants";
 import { API_BASE_URL } from "@/shared/constants";
 import { getMockMarkerList } from "./data/markerList";
 // data
-import { getMockMarkingList } from "./data/markingList";
+import { createMockMarking, getMockMarkingList } from "./data/markingList";
 import userInfoData from "./data/myInfo.json";
 import { getMyMark } from "./data/myMark";
 import { otherUsers, roleGuestUser } from "./data/otherUser";
@@ -1922,6 +1922,45 @@ const getSavedMarkerListHandler = [
   }),
 ];
 
+// 해당 핸들러는 내 마킹이 아닌 경우에는 랜덤한 마킹을 만들어 반환합니다.
+// 이에 이 핸들러는 내 마킹이 아닌 경우엔 부정확한 결과를 보여 줄 수 있습니다.
+const getMarkingDetailRequestHandler = [
+  http.get(
+    `${API_BASE_URL}/markings/:markingId`,
+    async ({ request, params }) => {
+      const token = await request.headers.get("Authorization");
+      if (!token || token === "staleAccessToken") {
+        return HttpResponse.json(
+          {
+            code: 401,
+            message: "토큰 검증에 실패 했습니다.",
+          },
+          {
+            status: 401,
+          },
+        );
+      }
+
+      const content = myMarkingList.find(
+        ({ markingId }) => markingId === Number(params.markingId),
+      );
+
+      return HttpResponse.json({
+        code: 200,
+        message: "success",
+        content:
+          content ??
+          createMockMarking(Number(params.markingId), {
+            southBottomLat: 35.0,
+            northTopLat: 35.1,
+            southLeftLng: 129.0,
+            northRightLng: 129.1,
+          }),
+      });
+    },
+  ),
+];
+
 // * 나중에 msw 사용을 대비하여 만들었습니다.
 export const handlers = [
   ...signUpByEmailHandlers,
@@ -1956,4 +1995,5 @@ export const handlers = [
   ...getLikedMarkerListHandler,
   ...getSavedMarkerListHandler,
   ...getProfileThumbnailHandler,
+  ...getMarkingDetailRequestHandler,
 ];

--- a/src/pages/[nickname]/marking/page.tsx
+++ b/src/pages/[nickname]/marking/page.tsx
@@ -102,25 +102,6 @@ export const UserMarkingPage = withAuth(() => {
             </div>
           )}
 
-        {clickedMarking && (
-          <>
-            <MarkingItem
-              {...clickedMarking}
-              onRegionClick={() =>
-                handleRegionClick({
-                  markingId: clickedMarking.markingId,
-                  lat: clickedMarking.lat,
-                  lng: clickedMarking.lng,
-                })
-              }
-              isFollowing={myFollowingIdsMap[clickedMarking.userId]}
-              isLiked={myLikedIdsMap[clickedMarking.markingId]}
-              isBookmarked={myBookmarkIdsMap[clickedMarking.markingId]}
-            />
-            <DividerLine axis="row" />
-          </>
-        )}
-
         <div className="flex w-full justify-end">
           <SortTypeFilter
             options={sortTypeOptions}
@@ -132,6 +113,24 @@ export const UserMarkingPage = withAuth(() => {
         </div>
 
         <MarkingList display="list">
+          {clickedMarking && (
+            <>
+              <MarkingItem
+                {...clickedMarking}
+                onRegionClick={() =>
+                  handleRegionClick({
+                    markingId: clickedMarking.markingId,
+                    lat: clickedMarking.lat,
+                    lng: clickedMarking.lng,
+                  })
+                }
+                isFollowing={myFollowingIdsMap[clickedMarking.userId]}
+                isLiked={myLikedIdsMap[clickedMarking.markingId]}
+                isBookmarked={myBookmarkIdsMap[clickedMarking.markingId]}
+              />
+              <DividerLine axis="row" />
+            </>
+          )}
           {markingList?.map((marking) => {
             if (marking.markingId === markingId) return;
 

--- a/src/pages/[nickname]/marking/page.tsx
+++ b/src/pages/[nickname]/marking/page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { MarkingList } from "@/widgets/map/ui/markingList";
 import { MarkingItem } from "@/widgets/marking/ui";
 import { SortTypeFilter } from "@/features/marking/ui";
@@ -15,6 +15,7 @@ import {
   useGetMyLikedIdsMap,
   useGetProfile,
 } from "@/entities/profile/api";
+import { ROUTER_PATH } from "@/shared/constants";
 import { useInfiniteScroll, withAuth } from "@/shared/lib";
 import { useNicknameParams } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
@@ -23,6 +24,7 @@ import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
 
 export const UserMarkingPage = withAuth(() => {
   const { state } = useLocation() as { state: null | { markingId: number } };
+  const navigate = useNavigate();
 
   const sortTypeOptions: Exclude<SortType, "DISTANCE">[] = [
     "RECENT",
@@ -33,7 +35,7 @@ export const UserMarkingPage = withAuth(() => {
   >(sortTypeOptions[0]);
 
   const markingId = state?.markingId;
-  const { nicknameParams } = useNicknameParams();
+  const { nicknameParams, isMyPage } = useNicknameParams();
 
   const { nickname: myNickname, token } = useAuthStore.getState();
 
@@ -86,7 +88,17 @@ export const UserMarkingPage = withAuth(() => {
             <MarkingItem
               {...clickedMarking}
               onRegionClick={() => {
-                // todo 맵 페이지로 이동
+                navigate(isMyPage ? ROUTER_PATH.MY_MARK : ROUTER_PATH.PLACE, {
+                  state: {
+                    markingInfo: {
+                      position: {
+                        lat: clickedMarking.lat,
+                        lng: clickedMarking.lng,
+                      },
+                      markingId: clickedMarking.markingId,
+                    },
+                  },
+                });
               }}
               isFollowing={myFollowingIdsMap[clickedMarking.userId]}
               isLiked={myLikedIdsMap[clickedMarking.markingId]}
@@ -114,7 +126,17 @@ export const UserMarkingPage = withAuth(() => {
               <MarkingItem
                 key={marking.markingId}
                 onRegionClick={() => {
-                  // todo 맵 페이지로 이동
+                  navigate(isMyPage ? ROUTER_PATH.MY_MARK : ROUTER_PATH.PLACE, {
+                    state: {
+                      markingInfo: {
+                        position: {
+                          lat: marking.lat,
+                          lng: marking.lng,
+                        },
+                        markingId: marking.markingId,
+                      },
+                    },
+                  });
                 }}
                 isLiked={myLikedIdsMap[marking.markingId]}
                 isBookmarked={myBookmarkIdsMap[marking.markingId]}

--- a/src/pages/[nickname]/marking/page.tsx
+++ b/src/pages/[nickname]/marking/page.tsx
@@ -4,7 +4,8 @@ import { MarkingList } from "@/widgets/map/ui/markingList";
 import { MarkingItem } from "@/widgets/marking/ui";
 import { SortTypeFilter } from "@/features/marking/ui";
 import {
-  SortType,
+  type Marking,
+  type SortType,
   useGetAllMarkingsOfUser,
   useGetMarkingDetail,
 } from "@/entities/marking/api";
@@ -60,6 +61,24 @@ export const UserMarkingPage = withAuth(() => {
     }
   });
 
+  const handleRegionClick = ({
+    markingId,
+    lat,
+    lng,
+  }: Pick<Marking, "markingId" | "lat" | "lng">) => {
+    navigate(isMyPage ? ROUTER_PATH.MY_MARK : ROUTER_PATH.PLACE, {
+      state: {
+        markingInfo: {
+          position: {
+            lat,
+            lng,
+          },
+          markingId,
+        },
+      },
+    });
+  };
+
   // todo ui 표시
   if (!token || !myFollowingIdsMap || !myBookmarkIdsMap || !myLikedIdsMap)
     return null;
@@ -87,19 +106,13 @@ export const UserMarkingPage = withAuth(() => {
           <>
             <MarkingItem
               {...clickedMarking}
-              onRegionClick={() => {
-                navigate(isMyPage ? ROUTER_PATH.MY_MARK : ROUTER_PATH.PLACE, {
-                  state: {
-                    markingInfo: {
-                      position: {
-                        lat: clickedMarking.lat,
-                        lng: clickedMarking.lng,
-                      },
-                      markingId: clickedMarking.markingId,
-                    },
-                  },
-                });
-              }}
+              onRegionClick={() =>
+                handleRegionClick({
+                  markingId: clickedMarking.markingId,
+                  lat: clickedMarking.lat,
+                  lng: clickedMarking.lng,
+                })
+              }
               isFollowing={myFollowingIdsMap[clickedMarking.userId]}
               isLiked={myLikedIdsMap[clickedMarking.markingId]}
               isBookmarked={myBookmarkIdsMap[clickedMarking.markingId]}
@@ -125,19 +138,13 @@ export const UserMarkingPage = withAuth(() => {
             return (
               <MarkingItem
                 key={marking.markingId}
-                onRegionClick={() => {
-                  navigate(isMyPage ? ROUTER_PATH.MY_MARK : ROUTER_PATH.PLACE, {
-                    state: {
-                      markingInfo: {
-                        position: {
-                          lat: marking.lat,
-                          lng: marking.lng,
-                        },
-                        markingId: marking.markingId,
-                      },
-                    },
-                  });
-                }}
+                onRegionClick={() =>
+                  handleRegionClick({
+                    markingId: marking.markingId,
+                    lat: marking.lat,
+                    lng: marking.lng,
+                  })
+                }
                 isLiked={myLikedIdsMap[marking.markingId]}
                 isBookmarked={myBookmarkIdsMap[marking.markingId]}
                 isFollowing={myFollowingIdsMap[marking.userId]}

--- a/src/widgets/map/ui/localMarkingList.tsx
+++ b/src/widgets/map/ui/localMarkingList.tsx
@@ -1,8 +1,9 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useMap } from "@vis.gl/react-google-maps";
-import { useMapQueryParams, usePlaceQueryParams } from "@/features/map/hooks";
+import { useMapQueryParams } from "@/features/map/hooks";
 import { RangeFilter, SortTypeFilter } from "@/features/marking/ui";
 import {
+  Marking,
   useGetAddressFromLatLng,
   useGetMarkingList,
 } from "@/entities/marking/api";
@@ -27,11 +28,10 @@ export const LocalMarkingListBottomSheet = () => {
 };
 
 const LocalMarkingList = () => {
+  const location = useLocation();
   const navigate = useNavigate();
   const map = useMap();
-  const { boundsParams, sortTypeParam, setMapQueryParams } =
-    useMapQueryParams();
-  const { setPlaceQueryParams } = usePlaceQueryParams();
+  const { boundsParams, sortTypeParam } = useMapQueryParams();
 
   const {
     data: markingList,
@@ -50,6 +50,37 @@ const LocalMarkingList = () => {
     }
   });
 
+  // 동네 마킹에서 특정 썸네일을 클릭하면 해당 썸네일을 중심으로 하는 이 장소 마킹 페이지로 이동합니다.
+  const handleClick = ({
+    lat,
+    lng,
+    markingId,
+  }: Pick<Marking, "lat" | "lng" | "markingId">) => {
+    const searchParams = new URLSearchParams(location.search);
+    searchParams.set("lat", lat.toString());
+    searchParams.set("lng", lng.toString());
+    searchParams.set("sortType", "POPULARITY");
+    navigate(
+      {
+        pathname: ROUTER_PATH.PLACE,
+        search: searchParams.toString(),
+      },
+      {
+        state: {
+          markingInfo: {
+            position: {
+              lat,
+              lng,
+            },
+            markingId,
+          },
+        },
+      },
+    );
+    map.setCenter({ lat, lng });
+    map.setZoom(mapOptions.maxZoom);
+  };
+
   return (
     <>
       <MarkingList display="grid">
@@ -58,15 +89,7 @@ const LocalMarkingList = () => {
             key={markingId}
             type="button"
             className="aspect-square"
-            onClick={() => {
-              navigate(ROUTER_PATH.PLACE);
-              map.setCenter({ lat, lng });
-              map.setZoom(mapOptions.maxZoom);
-              setPlaceQueryParams({ lat, lng });
-              setMapQueryParams({
-                sortType: "POPULARITY",
-              });
-            }}
+            onClick={() => handleClick({ lat, lng, markingId })}
           >
             <img
               className="w-full h-full object-cover"

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -58,7 +58,6 @@ export const MapInitializer = () => {
 
       await map.setCenter(position);
       const bounds = map.getBounds();
-
       const newSearchParams = new URLSearchParams({
         // bounds 에 에 대한 searchParams
         boundsNELat: bounds.getNorthEast().lat().toString(),
@@ -68,6 +67,7 @@ export const MapInitializer = () => {
         // 정렬에 대한 searchParams
         sortType: pathname === ROUTER_PATH.MY_MARK ? "RECENT" : "POPULARITY",
       });
+      // 이 장소 마킹에서는 lat , lng 에 대한 서치 파라미터도 업데이트 합니다.
       if (pathname === ROUTER_PATH.PLACE) {
         newSearchParams.set("lat", position.lat.toString());
         newSearchParams.set("lng", position.lng.toString());

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -150,6 +150,10 @@ export const MapInitializer = () => {
   // 해당 이펙트는 place가 ROUTER_PATH.PLACE 면서 state가 없을 때 실행됩니다.
   // 이펙트의 용도는 placeParams의 값이 존재하지 않거나 boundsParams의 범위를 벗어난 경우에 placeParams 값을 boundsParams의 중심으로 설정하기 위함입니다.
   useEffect(() => {
+    if (ROUTER_PATH.PLACE !== pathname || state) {
+      return;
+    }
+
     const { southWestLat, northEastLat, southWestLng, northEastLng } =
       boundsParams;
 
@@ -157,29 +161,27 @@ export const MapInitializer = () => {
       return;
     }
 
-    if (ROUTER_PATH.PLACE === pathname && !state) {
-      const { lat, lng } = placeParams;
+    const { lat, lng } = placeParams;
 
-      if (!(southWestLat && northEastLat && southWestLng && northEastLng)) {
-        return;
-      }
-
-      if (
-        lat &&
-        lng &&
-        lat >= southWestLat &&
-        lat <= northEastLat &&
-        lng >= southWestLng &&
-        lng <= northEastLng
-      ) {
-        return;
-      }
-
-      setPlaceQueryParams({
-        lat: (southWestLat + northEastLat) / 2,
-        lng: (southWestLng + northEastLng) / 2,
-      });
+    if (!(southWestLat && northEastLat && southWestLng && northEastLng)) {
+      return;
     }
+
+    if (
+      lat &&
+      lng &&
+      lat >= southWestLat &&
+      lat <= northEastLat &&
+      lng >= southWestLng &&
+      lng <= northEastLng
+    ) {
+      return;
+    }
+
+    setPlaceQueryParams({
+      lat: (southWestLat + northEastLat) / 2,
+      lng: (southWestLng + northEastLng) / 2,
+    });
   }, [pathname, state, boundsParams]);
 
   // 해당 이펙트는 Link 나 navigate 등으로 라우팅 될 때 router state 가 존재하지 않는 경우 실행됩니다.

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -7,6 +7,7 @@ import {
   useGetMapCurrentBounds,
   useMapMode,
   useMapQueryParams,
+  usePlaceQueryParams,
 } from "@/features/map/hooks";
 import { useMapStore } from "@/features/map/store";
 import { CurrentLocationLoading } from "@/entities/map/ui";
@@ -35,6 +36,7 @@ export const MapInitializer = () => {
 
   const { boundsParams, hasBoundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
+  const { placeParams, setPlaceQueryParams } = usePlaceQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
 
   const handleOpen = useSnackBar();
@@ -87,6 +89,7 @@ export const MapInitializer = () => {
 
   // 해당 이펙트는 Link 나 navigate 등으로 라우팅 될 때 router state 가 존재하지 않는 경우 실행됩니다.
   // 즉 , 초기진입 했을 때에만 실행 됩니다.
+  // boundsParams 를 적절한 값으로 업데이트 합니다.
   useEffect(() => {
     if (!map || !isMapIdle || state) return;
 
@@ -143,6 +146,41 @@ export const MapInitializer = () => {
       setIsMapIdle(false);
     };
   }, [map, isMapIdle]);
+
+  // 해당 이펙트는 place가 ROUTER_PATH.PLACE 면서 state가 없을 때 실행됩니다.
+  // 이펙트의 용도는 placeParams의 값이 존재하지 않거나 boundsParams의 범위를 벗어난 경우에 placeParams 값을 boundsParams의 중심으로 설정하기 위함입니다.
+  useEffect(() => {
+    const { southWestLat, northEastLat, southWestLng, northEastLng } =
+      boundsParams;
+
+    if (!(southWestLat && northEastLat && southWestLng && northEastLng)) {
+      return;
+    }
+
+    if (ROUTER_PATH.PLACE === pathname && !state) {
+      const { lat, lng } = placeParams;
+
+      if (!(southWestLat && northEastLat && southWestLng && northEastLng)) {
+        return;
+      }
+
+      if (
+        lat &&
+        lng &&
+        lat >= southWestLat &&
+        lat <= northEastLat &&
+        lng >= southWestLng &&
+        lng <= northEastLng
+      ) {
+        return;
+      }
+
+      setPlaceQueryParams({
+        lat: (southWestLat + northEastLat) / 2,
+        lng: (southWestLng + northEastLng) / 2,
+      });
+    }
+  }, [pathname, state, boundsParams]);
 
   // 해당 이펙트는 Link 나 navigate 등으로 라우팅 될 때 router state 가 존재하지 않는 경우 실행됩니다.
   // 즉 , 초기진입 했을 때에만 실행 됩니다.

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MAP_INITIAL_BOUNDS } from "@/features/map/constants";
 import {
@@ -7,7 +7,6 @@ import {
   useGetMapCurrentBounds,
   useMapMode,
   useMapQueryParams,
-  usePlaceQueryParams,
 } from "@/features/map/hooks";
 import { useMapStore } from "@/features/map/store";
 import { CurrentLocationLoading } from "@/entities/map/ui";
@@ -24,7 +23,10 @@ interface MarkingInfo {
 }
 
 export const MapInitializer = () => {
-  const { state, pathname } = useLocation();
+  const location = useLocation();
+  const { state, pathname } = location;
+
+  const navigate = useNavigate();
 
   const map = useMap();
   const mapMode = useMapMode();
@@ -33,7 +35,6 @@ export const MapInitializer = () => {
 
   const { boundsParams, hasBoundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
-  const { setPlaceQueryParams } = usePlaceQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
 
   const handleOpen = useSnackBar();
@@ -46,6 +47,7 @@ export const MapInitializer = () => {
 
   // 해당 이펙트는 /:nickname 에서 state 를 통해 마킹 정보를 전달 받은 경우 실행됩니다.
   // state.markingInfo.position 으로 맵을 이동 시킨 후 해당 위치의 마킹을 불러옵니다.
+  // ! state 를 유지 한 채로 initialize 하기 위해 navigate 를 사용하여 초기화 합니다.
   useEffect(() => {
     if (!state || !state.markingInfo || !isMapIdle || !map) {
       return;
@@ -53,12 +55,33 @@ export const MapInitializer = () => {
 
     (async function () {
       const { position } = state.markingInfo as MarkingInfo;
+
       await map.setCenter(position);
-      setPlaceQueryParams(position);
-      setMapQueryParams({
-        bounds: getMapBounds(),
+      const bounds = map.getBounds();
+
+      const newSearchParams = new URLSearchParams({
+        // bounds 에 에 대한 searchParams
+        boundsNELat: bounds.getNorthEast().lat().toString(),
+        boundsNELng: bounds.getNorthEast().lng().toString(),
+        boundsSWLat: bounds.getSouthWest().lat().toString(),
+        boundsSWLng: bounds.getSouthWest().lng().toString(),
+        // 정렬에 대한 searchParams
         sortType: pathname === ROUTER_PATH.MY_MARK ? "RECENT" : "POPULARITY",
       });
+      if (pathname === ROUTER_PATH.PLACE) {
+        newSearchParams.set("lat", position.lat.toString());
+        newSearchParams.set("lng", position.lng.toString());
+      }
+
+      navigate(
+        {
+          ...location,
+          search: newSearchParams.toString(),
+        },
+        {
+          state,
+        },
+      );
     })();
   }, [map, isMapIdle, state]);
 

--- a/src/widgets/map/ui/mapInitializer.tsx
+++ b/src/widgets/map/ui/mapInitializer.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MAP_INITIAL_BOUNDS } from "@/features/map/constants";
 import {
@@ -6,12 +7,25 @@ import {
   useGetMapCurrentBounds,
   useMapMode,
   useMapQueryParams,
+  usePlaceQueryParams,
 } from "@/features/map/hooks";
 import { useMapStore } from "@/features/map/store";
 import { CurrentLocationLoading } from "@/entities/map/ui";
+import { Marking } from "@/entities/marking/api";
+import { ROUTER_PATH } from "@/shared/constants";
 import { useSnackBar } from "@/shared/lib";
 
+interface MarkingInfo {
+  position: {
+    lat: Marking["lat"];
+    lng: Marking["lng"];
+  };
+  markingId: Marking["markingId"];
+}
+
 export const MapInitializer = () => {
+  const { state, pathname } = useLocation();
+
   const map = useMap();
   const mapMode = useMapMode();
 
@@ -19,6 +33,7 @@ export const MapInitializer = () => {
 
   const { boundsParams, hasBoundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
+  const { setPlaceQueryParams } = usePlaceQueryParams();
   const getMapBounds = useGetMapCurrentBounds();
 
   const handleOpen = useSnackBar();
@@ -29,8 +44,28 @@ export const MapInitializer = () => {
     (state) => state.setIsCenterOnMyLocation,
   );
 
+  // 해당 이펙트는 /:nickname 에서 state 를 통해 마킹 정보를 전달 받은 경우 실행됩니다.
+  // state.markingInfo.position 으로 맵을 이동 시킨 후 해당 위치의 마킹을 불러옵니다.
   useEffect(() => {
-    if (!map || !isMapIdle) return;
+    if (!state || !state.markingInfo || !isMapIdle || !map) {
+      return;
+    }
+
+    (async function () {
+      const { position } = state.markingInfo as MarkingInfo;
+      await map.setCenter(position);
+      setPlaceQueryParams(position);
+      setMapQueryParams({
+        bounds: getMapBounds(),
+        sortType: pathname === ROUTER_PATH.MY_MARK ? "RECENT" : "POPULARITY",
+      });
+    })();
+  }, [map, isMapIdle, state]);
+
+  // 해당 이펙트는 Link 나 navigate 등으로 라우팅 될 때 router state 가 존재하지 않는 경우 실행됩니다.
+  // 즉 , 초기진입 했을 때에만 실행 됩니다.
+  useEffect(() => {
+    if (!map || !isMapIdle || state) return;
 
     const defaultSortType = mapMode === "MY_MARK" ? "RECENT" : "POPULARITY";
 
@@ -86,12 +121,14 @@ export const MapInitializer = () => {
     };
   }, [map, isMapIdle]);
 
+  // 해당 이펙트는 Link 나 navigate 등으로 라우팅 될 때 router state 가 존재하지 않는 경우 실행됩니다.
+  // 즉 , 초기진입 했을 때에만 실행 됩니다.
   useEffect(() => {
-    if (!hasBoundsParams) {
+    if (!hasBoundsParams || state) {
       return;
     }
     handleOpen("스팟을 발견하고 마킹으로 추억을 남겨보세요", { type: "map" });
-  }, [hasBoundsParams]);
+  }, [hasBoundsParams, state]);
 
   if (!map || loading || !isMapIdle) {
     return <CurrentLocationLoading />;

--- a/src/widgets/map/ui/myMarkingList.tsx
+++ b/src/widgets/map/ui/myMarkingList.tsx
@@ -1,8 +1,13 @@
+import { useLocation } from "react-router-dom";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MarkingItem } from "@/widgets/marking/ui";
 import { useMapQueryParams } from "@/features/map/hooks";
 import { RangeFilter, SortTypeFilter } from "@/features/marking/ui";
-import { useGetUserMarkingList } from "@/entities/marking/api";
+import { LatLng } from "@/entities/auth/api";
+import {
+  useGetMarkingDetail,
+  useGetUserMarkingList,
+} from "@/entities/marking/api";
 import { TemporaryMarkingBar } from "@/entities/marking/ui";
 import {
   useGetMyBookmarkIdsMap,
@@ -11,9 +16,12 @@ import {
 } from "@/entities/profile/api";
 import { useInfiniteScroll } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
+import { DividerLine } from "@/shared/ui/divider";
 import { MarkingList } from "./markingList";
 
 export const MyMarkingList = () => {
+  const { state } = useLocation();
+
   const map = useMap();
 
   const { sortTypeParam, boundsParams, setMapQueryParams } =
@@ -32,8 +40,11 @@ export const MyMarkingList = () => {
     nickname: nickname || "",
     sortType: sortTypeParam,
   });
-  const { data: myBookmarkedMap } = useGetMyBookmarkIdsMap();
-  const { data: myLikedMap } = useGetMyLikedIdsMap();
+  const { data: myBookmarkIdsMap = {} } = useGetMyBookmarkIdsMap();
+  const { data: myLikedIdsMap = {} } = useGetMyLikedIdsMap();
+  const { data: clickedMarking } = useGetMarkingDetail({
+    markingId: state?.markingInfo?.markingId,
+  });
 
   const [setNode] = useInfiniteScroll(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -41,7 +52,13 @@ export const MyMarkingList = () => {
     }
   });
 
-  if (!myBookmarkedMap || !myLikedMap) return null;
+  const handleRegionClick = ({ lat, lng }: LatLng) => {
+    map.setCenter({
+      lat,
+      lng,
+    });
+    map.setZoom(19);
+  };
 
   // todo 회원이 아닐 경우
   if (!nickname) return null;
@@ -56,6 +73,24 @@ export const MyMarkingList = () => {
           <div className="pt-4">
             <TemporaryMarkingBar tempCnt={profile.tempCnt} />
           </div>
+        )}
+
+        {/* 내 마킹 페이지에서 특정 마커를 클릭한 경우 나타나는 마킹 아이템 */}
+        {clickedMarking && (
+          <>
+            <MarkingItem
+              {...clickedMarking}
+              onRegionClick={() =>
+                handleRegionClick({
+                  lat: clickedMarking.lat,
+                  lng: clickedMarking.lng,
+                })
+              }
+              isLiked={myLikedIdsMap[clickedMarking.markingId]}
+              isBookmarked={myBookmarkIdsMap[clickedMarking.markingId]}
+            />
+            <DividerLine axis="row" />
+          </>
         )}
 
         <div className="flex w-full justify-end">
@@ -75,15 +110,11 @@ export const MyMarkingList = () => {
           {markingList?.map((marking) => (
             <MarkingItem
               key={marking.markingId}
-              onRegionClick={() => {
-                map.setCenter({
-                  lat: marking.lat,
-                  lng: marking.lng,
-                });
-                map.setZoom(19);
-              }}
-              isLiked={myLikedMap[marking.markingId]}
-              isBookmarked={myBookmarkedMap[marking.markingId]}
+              onRegionClick={() =>
+                handleRegionClick({ lat: marking.lat, lng: marking.lng })
+              }
+              isLiked={myLikedIdsMap[marking.markingId]}
+              isBookmarked={myBookmarkIdsMap[marking.markingId]}
               queryKeys={["marker", "markingList"]}
               {...marking}
             />

--- a/src/widgets/map/ui/myMarkingList.tsx
+++ b/src/widgets/map/ui/myMarkingList.tsx
@@ -75,24 +75,6 @@ export const MyMarkingList = () => {
           </div>
         )}
 
-        {/* 내 마킹 페이지에서 특정 마커를 클릭한 경우 나타나는 마킹 아이템 */}
-        {clickedMarking && (
-          <>
-            <MarkingItem
-              {...clickedMarking}
-              onRegionClick={() =>
-                handleRegionClick({
-                  lat: clickedMarking.lat,
-                  lng: clickedMarking.lng,
-                })
-              }
-              isLiked={myLikedIdsMap[clickedMarking.markingId]}
-              isBookmarked={myBookmarkIdsMap[clickedMarking.markingId]}
-            />
-            <DividerLine axis="row" />
-          </>
-        )}
-
         <div className="flex w-full justify-end">
           <RangeFilter
             options={["ALL_VIEW", "CURRENT_LOCATION", "MAP_LOCATION"]}
@@ -107,6 +89,23 @@ export const MyMarkingList = () => {
         </div>
 
         <MarkingList display="list">
+          {/* 내 마킹 페이지에서 특정 마커를 클릭한 경우 나타나는 마킹 아이템 */}
+          {clickedMarking && (
+            <>
+              <MarkingItem
+                {...clickedMarking}
+                onRegionClick={() =>
+                  handleRegionClick({
+                    lat: clickedMarking.lat,
+                    lng: clickedMarking.lng,
+                  })
+                }
+                isLiked={myLikedIdsMap[clickedMarking.markingId]}
+                isBookmarked={myBookmarkIdsMap[clickedMarking.markingId]}
+              />
+              <DividerLine axis="row" />
+            </>
+          )}
           {markingList?.map((marking) => (
             <MarkingItem
               key={marking.markingId}

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -80,7 +80,17 @@ export const PlaceMarkingList = () => {
         label={<h1 className="text-grey-900 title-1">이 장소 관련 마킹</h1>}
       />
 
-      <section className="px-4 pb-4 flex flex-col gap-4">
+      <div className="flex justify-end w-full px-4 mb-4">
+        <SortTypeFilter
+          options={["POPULARITY", "RECENT"]}
+          selectedOption={sortTypeParam || "POPULARITY"}
+          onSelect={(sortType) => {
+            setMapQueryParams({ sortType });
+          }}
+        />
+      </div>
+
+      <MarkingList display="list" className="px-4">
         {/* 내 마킹 페이지에서 특정 마커를 클릭한 경우 나타나는 마킹 아이템 */}
         {clickedMarking && (
           <>
@@ -98,45 +108,32 @@ export const PlaceMarkingList = () => {
             <DividerLine axis="row" />
           </>
         )}
+        {markingList?.map((marking) => {
+          if (clickedMarking?.markingId === marking.markingId) {
+            return null;
+          }
 
-        <div className="flex justify-end w-full">
-          <SortTypeFilter
-            options={["POPULARITY", "RECENT"]}
-            selectedOption={sortTypeParam || "POPULARITY"}
-            onSelect={(sortType) => {
-              setMapQueryParams({ sortType });
-            }}
-          />
-        </div>
-
-        <MarkingList display="list">
-          {markingList?.map((marking) => {
-            if (clickedMarking?.markingId === marking.markingId) {
-              return null;
-            }
-
-            return (
-              <MarkingItem
-                key={marking.markingId}
-                onRegionClick={() =>
-                  handleRegionClick({ lat: marking.lat, lng: marking.lng })
-                }
-                onDelete={() => {
-                  queryClient.invalidateQueries({
-                    queryKey: ["markingList"],
-                  });
-                }}
-                queryKeys={["marker", "markingList"]}
-                isFollowing={myFollowingIdsMap[marking.userId]}
-                isLiked={myLikedIdsMap[marking.markingId]}
-                isBookmarked={myBookmarkIdsMap[marking.markingId]}
-                {...marking}
-              />
-            );
-          })}
-        </MarkingList>
-        <div className="h-[.125rem]" ref={setNode} />
-      </section>
+          return (
+            <MarkingItem
+              key={marking.markingId}
+              onRegionClick={() =>
+                handleRegionClick({ lat: marking.lat, lng: marking.lng })
+              }
+              onDelete={() => {
+                queryClient.invalidateQueries({
+                  queryKey: ["markingList"],
+                });
+              }}
+              queryKeys={["marker", "markingList"]}
+              isFollowing={myFollowingIdsMap[marking.userId]}
+              isLiked={myLikedIdsMap[marking.markingId]}
+              isBookmarked={myBookmarkIdsMap[marking.markingId]}
+              {...marking}
+            />
+          );
+        })}
+      </MarkingList>
+      <div className="h-[.125rem]" ref={setNode} />
     </>
   );
 };

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -27,7 +27,7 @@ export const PlaceMarkingList = () => {
 
   const { boundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
-  const { boundsAdjacentPlace, setPlaceQueryParams } = usePlaceQueryParams();
+  const { boundsAdjacentPlace } = usePlaceQueryParams();
 
   const { data: myFollowingIdsMap = {} } = useGetMyFollowingIdsMap();
   const { data: myBookmarkIdsMap = {} } = useGetMyBookmarkIdsMap();
@@ -61,10 +61,6 @@ export const PlaceMarkingList = () => {
       lng,
     });
     await map.setZoom(mapOptions.maxZoom);
-    setPlaceQueryParams({
-      lat,
-      lng,
-    });
   };
 
   return (

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -1,10 +1,11 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMap } from "@vis.gl/react-google-maps";
 import { MarkingItem } from "@/widgets/marking/ui";
 import { useMapQueryParams, usePlaceQueryParams } from "@/features/map/hooks";
 import { SortTypeFilter } from "@/features/marking/ui";
-import { useGetMarkingList } from "@/entities/marking/api";
+import { LatLng } from "@/entities/auth/api";
+import { useGetMarkingDetail, useGetMarkingList } from "@/entities/marking/api";
 import {
   useGetMyFollowingIdsMap,
   useGetMyBookmarkIdsMap,
@@ -12,6 +13,7 @@ import {
 } from "@/entities/profile/api";
 import { ROUTER_PATH } from "@/shared/constants";
 import { useInfiniteScroll } from "@/shared/lib";
+import { DividerLine } from "@/shared/ui/divider";
 import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
 import { mapOptions } from "../constants";
 import { MarkingList } from "./markingList";
@@ -19,15 +21,17 @@ import { MarkingList } from "./markingList";
 export const PlaceMarkingList = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const { state } = location;
+
   const { boundsParams, sortTypeParam, setMapQueryParams } =
     useMapQueryParams();
-  const { boundsAdjacentPlace } = usePlaceQueryParams();
+  const { boundsAdjacentPlace, setPlaceQueryParams } = usePlaceQueryParams();
 
-  const { data: myFollowingMap = {} } = useGetMyFollowingIdsMap();
-  const { data: myBookmarkedMap = {} } = useGetMyBookmarkIdsMap();
-  const { data: myLikedMap = {} } = useGetMyLikedIdsMap();
-
-  const { setPlaceQueryParams } = usePlaceQueryParams();
+  const { data: myFollowingIdsMap = {} } = useGetMyFollowingIdsMap();
+  const { data: myBookmarkIdsMap = {} } = useGetMyBookmarkIdsMap();
+  const { data: myLikedIdsMap = {} } = useGetMyLikedIdsMap();
 
   const {
     data: markingList,
@@ -39,6 +43,9 @@ export const PlaceMarkingList = () => {
     sortType: sortTypeParam,
     searchType: "LOCATION",
   });
+  const { data: clickedMarking } = useGetMarkingDetail({
+    markingId: state?.markingInfo?.markingId,
+  });
 
   const [setNode] = useInfiniteScroll(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -47,6 +54,18 @@ export const PlaceMarkingList = () => {
   });
 
   const map = useMap();
+
+  const handleRegionClick = async ({ lat, lng }: LatLng) => {
+    await map.setCenter({
+      lat,
+      lng,
+    });
+    await map.setZoom(mapOptions.maxZoom);
+    setPlaceQueryParams({
+      lat,
+      lng,
+    });
+  };
 
   return (
     <>
@@ -61,45 +80,57 @@ export const PlaceMarkingList = () => {
         label={<h1 className="text-grey-900 title-1">이 장소 관련 마킹</h1>}
       />
 
-      <div className="flex justify-end w-full mb-4 px-4">
-        <SortTypeFilter
-          options={["POPULARITY", "RECENT"]}
-          selectedOption={sortTypeParam || "POPULARITY"}
-          onSelect={(sortType) => {
-            setMapQueryParams({ sortType });
-          }}
-        />
-      </div>
+      <section className="px-4 pb-4 flex flex-col gap-4">
+        {/* 내 마킹 페이지에서 특정 마커를 클릭한 경우 나타나는 마킹 아이템 */}
+        {clickedMarking && (
+          <>
+            <MarkingItem
+              {...clickedMarking}
+              onRegionClick={() =>
+                handleRegionClick({
+                  lat: clickedMarking.lat,
+                  lng: clickedMarking.lng,
+                })
+              }
+              isLiked={myLikedIdsMap[clickedMarking.markingId]}
+              isBookmarked={myBookmarkIdsMap[clickedMarking.markingId]}
+            />
+            <DividerLine axis="row" />
+          </>
+        )}
 
-      <MarkingList display="list" className="px-4">
-        {markingList?.map((marking) => (
-          <MarkingItem
-            key={marking.markingId}
-            onRegionClick={async () => {
-              await map.setCenter({
-                lat: marking.lat,
-                lng: marking.lng,
-              });
-              await map.setZoom(mapOptions.maxZoom);
-              setPlaceQueryParams({
-                lat: marking.lat,
-                lng: marking.lng,
-              });
+        <div className="flex justify-end w-full">
+          <SortTypeFilter
+            options={["POPULARITY", "RECENT"]}
+            selectedOption={sortTypeParam || "POPULARITY"}
+            onSelect={(sortType) => {
+              setMapQueryParams({ sortType });
             }}
-            onDelete={() => {
-              queryClient.invalidateQueries({
-                queryKey: ["markingList"],
-              });
-            }}
-            queryKeys={["marker", "markingList"]}
-            isLiked={myLikedMap[marking.markingId]}
-            isBookmarked={myBookmarkedMap[marking.markingId]}
-            isFollowing={myFollowingMap[marking.userId]}
-            {...marking}
           />
-        ))}
-      </MarkingList>
-      <div className="h-[.125rem]" ref={setNode} />
+        </div>
+
+        <MarkingList display="list">
+          {markingList?.map((marking) => (
+            <MarkingItem
+              key={marking.markingId}
+              onRegionClick={() =>
+                handleRegionClick({ lat: marking.lat, lng: marking.lng })
+              }
+              onDelete={() => {
+                queryClient.invalidateQueries({
+                  queryKey: ["markingList"],
+                });
+              }}
+              queryKeys={["marker", "markingList"]}
+              isFollowing={myFollowingIdsMap[marking.userId]}
+              isLiked={myLikedIdsMap[marking.markingId]}
+              isBookmarked={myBookmarkIdsMap[marking.markingId]}
+              {...marking}
+            />
+          ))}
+        </MarkingList>
+        <div className="h-[.125rem]" ref={setNode} />
+      </section>
     </>
   );
 };

--- a/src/widgets/map/ui/placeMarkingList.tsx
+++ b/src/widgets/map/ui/placeMarkingList.tsx
@@ -110,24 +110,30 @@ export const PlaceMarkingList = () => {
         </div>
 
         <MarkingList display="list">
-          {markingList?.map((marking) => (
-            <MarkingItem
-              key={marking.markingId}
-              onRegionClick={() =>
-                handleRegionClick({ lat: marking.lat, lng: marking.lng })
-              }
-              onDelete={() => {
-                queryClient.invalidateQueries({
-                  queryKey: ["markingList"],
-                });
-              }}
-              queryKeys={["marker", "markingList"]}
-              isFollowing={myFollowingIdsMap[marking.userId]}
-              isLiked={myLikedIdsMap[marking.markingId]}
-              isBookmarked={myBookmarkIdsMap[marking.markingId]}
-              {...marking}
-            />
-          ))}
+          {markingList?.map((marking) => {
+            if (clickedMarking?.markingId === marking.markingId) {
+              return null;
+            }
+
+            return (
+              <MarkingItem
+                key={marking.markingId}
+                onRegionClick={() =>
+                  handleRegionClick({ lat: marking.lat, lng: marking.lng })
+                }
+                onDelete={() => {
+                  queryClient.invalidateQueries({
+                    queryKey: ["markingList"],
+                  });
+                }}
+                queryKeys={["marker", "markingList"]}
+                isFollowing={myFollowingIdsMap[marking.userId]}
+                isLiked={myLikedIdsMap[marking.markingId]}
+                isBookmarked={myBookmarkIdsMap[marking.markingId]}
+                {...marking}
+              />
+            );
+          })}
         </MarkingList>
         <div className="h-[.125rem]" ref={setNode} />
       </section>


### PR DESCRIPTION
# 관련 이슈 번호
close #499 
# 설명

내 활동에서 마킹 아이템의 지역 버튼을 클릭 하면  내 마킹으로 이동하고 , 맵의 중심을 해당 마커 위치로 생성합니다 

남의 활동에서 마킹 아이템의 지역 버튼을 클릭하면 유저 마킹으로 이도하고 맵의 중심을 해당 마커위치로 생성합니다 .

마커가 클릭 되면 라우터 상태값을 가진 채로 라우팅이 되며 라우팅 된 페이지에선 라우터 상태값을 이용해 `useGetMarkingDetail` 쿼리를 호출해 특정 마킹 아이템을 렌더링 합니다.

# 맵 이니셜라이저 파트에서 라우터 상태를 들고 맵이 마운트 된 경우에 대한 로직 추가 

```tsx 
// 맵 이니셜라저 내부 이펙트 
  // 해당 이펙트는 /:nickname 에서 state 를 통해 마킹 정보를 전달 받은 경우 실행됩니다.
  // state.markingInfo.position 으로 맵을 이동 시킨 후 해당 위치의 마킹을 불러옵니다.
  // ! state 를 유지 한 채로 initialize 하기 위해 navigate 를 사용하여 초기화 합니다.
  useEffect(() => {
    if (!state || !state.markingInfo || !isMapIdle || !map) {
      return;
    }

    (async function () {
      const { position } = state.markingInfo as MarkingInfo;

      await map.setCenter(position);
      const bounds = map.getBounds();

      const newSearchParams = new URLSearchParams({
        // bounds 에 에 대한 searchParams
        boundsNELat: bounds.getNorthEast().lat().toString(),
        boundsNELng: bounds.getNorthEast().lng().toString(),
        boundsSWLat: bounds.getSouthWest().lat().toString(),
        boundsSWLng: bounds.getSouthWest().lng().toString(),
        // 정렬에 대한 searchParams
        sortType: pathname === ROUTER_PATH.MY_MARK ? "RECENT" : "POPULARITY",
      });
      if (pathname === ROUTER_PATH.PLACE) {
        newSearchParams.set("lat", position.lat.toString());
        newSearchParams.set("lng", position.lng.toString());
      }

      navigate(
        {
          ...location,
          search: newSearchParams.toString(),
        },
        {
          state,
        },
      );
    })();
  }, [map, isMapIdle, state]);
``` 

다음과 같은 이펙트를 추가했습니다.  

이제 맵 이니셜라이저에선 `useLoacation` 을 구독하고 있으며 기존 존재하는 이펙트는 `location.state` 값이 존재하지 않을 때에만  발동하도록 설정해줬습니다.

기존 `set ... Params` 로 경로를 변경시켰더니 `location.state` 가 유지 안된채로 경로가 업데이트 되더군요

그래서 `state` 를 유지한채로 서치파라미터를 업데이트 하기 위해 `useNavigate` 를 이용해주었습니다.

# `usePlaceQueryParams` 초기화 로직 맵 이니셜라이저로 이동 

기존엔 `lat , lng` 값을 초기화 하는 로직이 `usePlace..` 내부에 존재하여 해당 훅이 여러 컴포넌트에서 호출 될 때 예기치 못한 `lat , lng` 값의 변경들이 있어 추적하기 매우 어렵더군요 

> 버그를 좀 고치느라 애를 썼습니다 . 그런데 그거 아시나요 어떤 메소드가 호출된 위치를 추적하고 싶으면 메소드 안에 `console.trace` 를 넣어주면 어떤 함수가 호출된 콜스택이 로그 됩니다 . 완전 좋더군요 

그래서 그런 초기화 로직을 훅 내부가 아닌 `MapInitializer ` 쪽에서 해주었습니다.



# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
