### PR TITLE
[Refactor] NavigationBar props children으로 받도록 변경

### DIFF
--- a/src/features/auth/ui/authNavigationBar.tsx
+++ b/src/features/auth/ui/authNavigationBar.tsx
@@ -9,7 +9,7 @@ import { useRouteHistoryStore } from "@/shared/store/history";
 import {
   BackwardNavigationBar,
   CloseNavigationBar,
-} from "@/shared/ui/navigationbar";
+} from "@/shared/ui/navigationBar";
 
 interface AuthNavigationBarProps {
   type?: "backward" | "close";

--- a/src/pages/[nickname]/follower/page.tsx
+++ b/src/pages/[nickname]/follower/page.tsx
@@ -37,9 +37,7 @@ export const FollowerPage = withAuth(() => {
 
   return (
     <section>
-      <BackwardNavigationBar
-        label={<h1 className="title-1 text-grey-900">{nicknameParams}</h1>}
-      />
+      <BackwardNavigationBar>{nicknameParams}</BackwardNavigationBar>
       <FollowNavigationBar nickname={nicknameParams} />
       <FollowItemContainer>
         {followerList?.map(({ userId, nickname, pet }) =>

--- a/src/pages/[nickname]/follower/page.tsx
+++ b/src/pages/[nickname]/follower/page.tsx
@@ -7,7 +7,7 @@ import { FollowingUserItem } from "@/widgets/follow";
 import { useGetFollowerList } from "@/entities/follow/api";
 import { useGetMyProfile } from "@/entities/profile/api";
 import { useInfiniteScroll, useNicknameParams, withAuth } from "@/shared/lib";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 /**
  * 팔로워 페이지의 경우 나의 페이지일 경우엔 팔로워 리스트를 보여주고

--- a/src/pages/[nickname]/following/page.tsx
+++ b/src/pages/[nickname]/following/page.tsx
@@ -30,9 +30,7 @@ export const FollowingPage = withAuth(() => {
 
   return (
     <section>
-      <BackwardNavigationBar
-        label={<h1 className="title-1 text-grey-900">{nicknameParams}</h1>}
-      />
+      <BackwardNavigationBar>{nicknameParams}</BackwardNavigationBar>
       <FollowNavigationBar nickname={nicknameParams} />
       <FollowItemContainer>
         {followingList?.map(({ userId, nickname, pet }) => (

--- a/src/pages/[nickname]/following/page.tsx
+++ b/src/pages/[nickname]/following/page.tsx
@@ -3,7 +3,7 @@ import { FollowingUserItem } from "@/widgets/follow/followingUserItem";
 import { useGetFollowingList } from "@/entities/follow/api";
 import { useGetMyProfile } from "@/entities/profile/api";
 import { useInfiniteScroll, useNicknameParams, withAuth } from "@/shared/lib";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 export const FollowingPage = withAuth(() => {
   const { nicknameParams } = useNicknameParams();

--- a/src/pages/[nickname]/marking/page.tsx
+++ b/src/pages/[nickname]/marking/page.tsx
@@ -19,7 +19,7 @@ import { ROUTER_PATH } from "@/shared/constants";
 import { useInfiniteScroll, withAuth } from "@/shared/lib";
 import { useNicknameParams } from "@/shared/lib";
 import { DividerLine } from "@/shared/ui/divider";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 export const UserMarkingPage = withAuth(() => {
   const { nicknameParams, isMyPage } = useNicknameParams();

--- a/src/pages/[nickname]/marking/page.tsx
+++ b/src/pages/[nickname]/marking/page.tsx
@@ -31,13 +31,9 @@ export const UserMarkingPage = withAuth(() => {
 
   return (
     <div className="px-4">
-      <BackwardNavigationBar
-        label={
-          <h1 className="title-1 text-grey-900 py-4">
-            {isMyPage ? "내" : nicknameParams} 마킹
-          </h1>
-        }
-      />
+      <BackwardNavigationBar>
+        {`${isMyPage ? "내" : nicknameParams} 마킹`}
+      </BackwardNavigationBar>
       <section className="pb-4 flex flex-col gap-4">
         {isMyPage &&
           typeof profile?.tempCnt === "number" &&

--- a/src/pages/[nickname]/myProfilePage.tsx
+++ b/src/pages/[nickname]/myProfilePage.tsx
@@ -10,7 +10,7 @@ import { ROUTER_PATH } from "@/shared/constants";
 import { useNicknameParams } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { SettingIcon } from "@/shared/ui/icon";
-import { NavigationBar } from "@/shared/ui/navigationbar";
+import { NavigationBar } from "@/shared/ui/navigationBar";
 
 export const MyProfilePage = () => {
   const { nicknameParams } = useNicknameParams();

--- a/src/pages/[nickname]/myProfilePage.tsx
+++ b/src/pages/[nickname]/myProfilePage.tsx
@@ -51,18 +51,15 @@ export const MyProfilePage = () => {
 const MyPageNavigationBar = () => {
   const nickname = useAuthStore((state) => state.nickname);
   return (
-    <NavigationBar
-      componentType="buttonRight"
-      label={<h1 className="text-grey-900 title-1">{nickname}님</h1>}
-      button={
-        <Link
-          to={ROUTER_PATH.SETTING}
-          className="px-3 py-3 text-grey-500"
-          aria-label="내 정보 설정하기"
-        >
-          <SettingIcon />
-        </Link>
-      }
-    />
+    <NavigationBar>
+      {`${nickname}님`}
+      <Link
+        to={ROUTER_PATH.SETTING}
+        className="px-3 py-3 text-grey-500"
+        aria-label="내 정보 설정하기"
+      >
+        <SettingIcon />
+      </Link>
+    </NavigationBar>
   );
 };

--- a/src/pages/[nickname]/otherProfilePage.tsx
+++ b/src/pages/[nickname]/otherProfilePage.tsx
@@ -20,9 +20,7 @@ export const OtherProfilePage = () => {
 
   return (
     <>
-      <BackwardNavigationBar
-        label={<h1 className="text-grey-900 title-1">{nicknameParams}님</h1>}
-      />
+      <BackwardNavigationBar>{`${nicknameParams}님`}</BackwardNavigationBar>
       <section className="px-4 flex flex-col items-start gap-8">
         {pet ? (
           <ProfileOverView

--- a/src/pages/[nickname]/otherProfilePage.tsx
+++ b/src/pages/[nickname]/otherProfilePage.tsx
@@ -3,7 +3,7 @@ import { ProfileOverView } from "@/widgets/profile/ui";
 import { useGetProfile } from "@/entities/profile/api";
 import { useGetMyProfile } from "@/entities/profile/api";
 import { useNicknameParams } from "@/shared/lib";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 export const OtherProfilePage = () => {
   const { nicknameParams } = useNicknameParams();

--- a/src/pages/setting/edit-info/page.tsx
+++ b/src/pages/setting/edit-info/page.tsx
@@ -23,10 +23,7 @@ export const EditInfoPage = withAuth(() => {
 
   return (
     <>
-      <BackwardNavigationBar
-        label={<h1 className="title-1 text-grey-700">내 정보 수정</h1>}
-      />
-
+      <BackwardNavigationBar>내 정보 수정</BackwardNavigationBar>
       <section className="flex flex-col gap-4 px-4 py-4">
         <NicknameButton nickLastModDt={nickLastModDt!} />
         <GenderChangeButton gender={gender} />

--- a/src/pages/setting/edit-info/page.tsx
+++ b/src/pages/setting/edit-info/page.tsx
@@ -9,7 +9,7 @@ import type { MyInfo } from "@/entities/auth/api";
 import { useModal, withAuth } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { ArrowRightIcon } from "@/shared/ui/icon";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 export const EditInfoPage = withAuth(() => {
   const { data: myInfo } = useGetMyInfo();

--- a/src/pages/setting/manage-account/page.tsx
+++ b/src/pages/setting/manage-account/page.tsx
@@ -8,7 +8,7 @@ import { SOCIAL_TYPE } from "@/entities/auth/constants";
 import { useModal, withAuth } from "@/shared/lib";
 import { DividerLine } from "@/shared/ui/divider";
 import { ArrowRightIcon } from "@/shared/ui/icon";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 export const AccountManagementPage = withAuth(() => {
   const { data: myInfo } = useGetMyInfo();

--- a/src/pages/setting/manage-account/page.tsx
+++ b/src/pages/setting/manage-account/page.tsx
@@ -21,9 +21,7 @@ export const AccountManagementPage = withAuth(() => {
 
   return (
     <>
-      <BackwardNavigationBar
-        label={<h1 className="title-1 text-grey-700">계정 관리</h1>}
-      />
+      <BackwardNavigationBar>계정 관리</BackwardNavigationBar>
       <section className="flex flex-col gap-4 px-4 py-4">
         <AccountEmail email={email} socialType={socialType} />
         {isPasswordSet ? <PasswordChangeButton /> : <PasswordSetButton />}

--- a/src/pages/setting/page.tsx
+++ b/src/pages/setting/page.tsx
@@ -5,7 +5,7 @@ import { withAuth, useSnackBar } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { DividerLine } from "@/shared/ui/divider";
 import { ArrowRightIcon } from "@/shared/ui/icon";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 export const SettingPage = withAuth(() => {
   return (

--- a/src/pages/setting/page.tsx
+++ b/src/pages/setting/page.tsx
@@ -11,9 +11,7 @@ export const SettingPage = withAuth(() => {
   return (
     <>
       <section>
-        <BackwardNavigationBar
-          label={<h1 className="title-1 text-grey-900">설정</h1>}
-        />
+        <BackwardNavigationBar>설정</BackwardNavigationBar>
         <section className="flex flex-col gap-4 px-4 py-4">
           <AccountManagement />
           <EditMyInfo />

--- a/src/pages/sign-up/page.tsx
+++ b/src/pages/sign-up/page.tsx
@@ -7,7 +7,7 @@ import { useModal } from "@/shared/lib/overlay";
 import { Button } from "@/shared/ui/button";
 import { CloseIcon } from "@/shared/ui/icon";
 import { Modal } from "@/shared/ui/modal";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 const SignUpPage = withAuth(() => {
   const navigate = useNavigate();

--- a/src/pages/temporary-marking/page.tsx
+++ b/src/pages/temporary-marking/page.tsx
@@ -3,7 +3,7 @@ import { TemporaryMarkingItem } from "@/widgets/marking/ui";
 import { useGetTemporaryMarkingList } from "@/entities/marking/api";
 import { useInfiniteScroll, withAuth } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
 export const TemporaryMarkingPage = withAuth(() => {
   const navigate = useNavigate();

--- a/src/pages/temporary-marking/page.tsx
+++ b/src/pages/temporary-marking/page.tsx
@@ -35,10 +35,9 @@ export const TemporaryMarkingPage = withAuth(() => {
 
   return (
     <>
-      <BackwardNavigationBar
-        label={<h1 className="text-grey-900 title-1">임시저장</h1>}
-        onClick={() => navigate(`/@${nickname}`)}
-      />
+      <BackwardNavigationBar onClick={() => navigate(`/@${nickname}`)}>
+        임시저장
+      </BackwardNavigationBar>
       <section className="pt-4 px-4 pb-32 flex flex-col gap-8">
         {data.map(([date, temporaryMarkingList]) => (
           <div className="flex flex-col gap-8">

--- a/src/shared/ui/navigationbar/BackwardNavigationBar.tsx
+++ b/src/shared/ui/navigationbar/BackwardNavigationBar.tsx
@@ -2,7 +2,6 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/shared/ui/button";
 import { WardLeftIcon } from "@/shared/ui/icon";
 import { NavigationBar } from "./NavigationBar";
-import type { NavigationBarProps } from "./NavigationBar";
 
 const BackWardButton = (props: React.HTMLAttributes<HTMLButtonElement>) => {
   const navigate = useNavigate();
@@ -22,19 +21,19 @@ const BackWardButton = (props: React.HTMLAttributes<HTMLButtonElement>) => {
   );
 };
 
-type BackwardNavigationBarProps = Omit<
-  NavigationBarProps,
-  "componentType" | "button"
->;
+interface BackwardNavigationBarProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children?: string;
+}
 
-export const BackwardNavigationBar = (props: BackwardNavigationBarProps) => {
-  const { label, ...rest } = props;
-
+export const BackwardNavigationBar = ({
+  children,
+  ...props
+}: BackwardNavigationBarProps) => {
   return (
-    <NavigationBar
-      componentType="buttonLeft"
-      button={<BackWardButton {...rest} />}
-      label={label}
-    ></NavigationBar>
+    <NavigationBar>
+      <BackWardButton {...props} />
+      {children}
+    </NavigationBar>
   );
 };

--- a/src/shared/ui/navigationbar/CloseNavigationBar.tsx
+++ b/src/shared/ui/navigationbar/CloseNavigationBar.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/shared/ui/button";
 import { CloseIcon } from "@/shared/ui/icon";
-import { NavigationBar, NavigationBarProps } from "./NavigationBar";
+import { NavigationBar } from "./NavigationBar";
 
 const CloseButton = (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
   return (
@@ -17,22 +17,21 @@ const CloseButton = (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
   );
 };
 
-type CloseNavigationBarProps = Omit<
-  NavigationBarProps,
-  "componentType" | "button"
->;
+interface CloseNavigationBarProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children?: string;
+}
 
-export const CloseNavigationBar = (props: CloseNavigationBarProps) => {
+export const CloseNavigationBar = ({
+  children,
+  ...props
+}: CloseNavigationBarProps) => {
   const navigate = useNavigate();
-  const { onClick, label, ...rest } = props;
 
   return (
-    <NavigationBar
-      componentType="buttonRight"
-      button={
-        <CloseButton onClick={onClick || (() => navigate(-1))} {...rest} />
-      }
-      label={label}
-    />
+    <NavigationBar>
+      {children}
+      <CloseButton onClick={() => navigate(-1)} {...props} />
+    </NavigationBar>
   );
 };

--- a/src/shared/ui/navigationbar/Navigation.style.ts
+++ b/src/shared/ui/navigationbar/Navigation.style.ts
@@ -1,7 +1,0 @@
-export const navigationBarStyles = {
-  default: "px-1 justify-between",
-  buttonLeft: "px-1 justify-start",
-  buttonRight: "pl-4 pr-1 justify-between",
-} as const;
-
-export const navigationBaseStyle = "flex py-2 min-w-[280px] items-center";

--- a/src/shared/ui/navigationbar/NavigationBar.tsx
+++ b/src/shared/ui/navigationbar/NavigationBar.tsx
@@ -1,5 +1,4 @@
 import { type ReactElement } from "react";
-import { navigationBarStyles, navigationBaseStyle } from "./Navigation.style";
 
 export interface NavigationBarProps {
   children:
@@ -10,10 +9,9 @@ export interface NavigationBarProps {
 export const NavigationBar = ({ children }: NavigationBarProps) => {
   const isButtonLeft =
     typeof children[1] === "string" || typeof children[1] === "undefined";
-
   return (
     <nav
-      className={`${navigationBaseStyle} ${navigationBarStyles[isButtonLeft ? "buttonLeft" : "buttonRight"]}`}
+      className={`flex py-2 px-1 items-center ${isButtonLeft ? "justify-start" : children[0] ? "justify-between" : "justify-end"}`}
     >
       {children.map((child) =>
         typeof child === "string" ? (

--- a/src/shared/ui/navigationbar/NavigationBar.tsx
+++ b/src/shared/ui/navigationbar/NavigationBar.tsx
@@ -2,13 +2,14 @@ import { type ReactElement } from "react";
 
 export interface NavigationBarProps {
   children:
-    | [ReactElement<HTMLButtonElement>, string | undefined]
-    | [string | undefined, ReactElement<HTMLButtonElement>];
+    | [ReactElement<HTMLButtonElement | HTMLAnchorElement>, string | undefined]
+    | [string | undefined, ReactElement<HTMLButtonElement | HTMLAnchorElement>];
 }
 
 export const NavigationBar = ({ children }: NavigationBarProps) => {
   const isButtonLeft =
     typeof children[1] === "string" || typeof children[1] === "undefined";
+
   return (
     <nav
       className={`flex py-2 px-1 items-center ${isButtonLeft ? "justify-start" : children[0] ? "justify-between" : "justify-end"}`}

--- a/src/shared/ui/navigationbar/NavigationBar.tsx
+++ b/src/shared/ui/navigationbar/NavigationBar.tsx
@@ -1,25 +1,27 @@
+import { type ReactElement } from "react";
 import { navigationBarStyles, navigationBaseStyle } from "./Navigation.style";
 
-export interface NavigationBarProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  componentType: keyof typeof navigationBarStyles;
-  button: React.ReactNode;
-  label?: React.ReactNode;
+export interface NavigationBarProps {
+  children:
+    | [ReactElement<HTMLButtonElement>, string | undefined]
+    | [string | undefined, ReactElement<HTMLButtonElement>];
 }
 
-export const NavigationBar = ({
-  componentType,
-  button,
-  label = <div className="invisible"></div>,
-}: NavigationBarProps) => {
-  const isButtonLeft = componentType === "buttonLeft";
+export const NavigationBar = ({ children }: NavigationBarProps) => {
+  const isButtonLeft =
+    typeof children[1] === "string" || typeof children[1] === "undefined";
 
   return (
     <nav
-      className={`${navigationBaseStyle} ${navigationBarStyles[componentType]}`}
+      className={`${navigationBaseStyle} ${navigationBarStyles[isButtonLeft ? "buttonLeft" : "buttonRight"]}`}
     >
-      {isButtonLeft ? button : label}
-      {isButtonLeft ? label : button}
+      {children.map((child) =>
+        typeof child === "string" ? (
+          <h1 className="text-grey-900 title-1">{child}</h1>
+        ) : (
+          child
+        ),
+      )}
     </nav>
   );
 };

--- a/src/widgets/map/ui/placeMarkingListBottomSheet.tsx
+++ b/src/widgets/map/ui/placeMarkingListBottomSheet.tsx
@@ -18,7 +18,7 @@ import { EmptyMarkingThumbnailGrid } from "@/entities/marking/ui";
 import { ROUTER_PATH } from "@/shared/constants";
 import { useInfiniteScroll } from "@/shared/lib";
 import { DividerLine } from "@/shared/ui/divider";
-import { BackwardNavigationBar } from "@/shared/ui/navigationbar";
+import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 import { mapOptions } from "../constants";
 import { MarkingList } from "./markingList";
 

--- a/src/widgets/map/ui/placeMarkingListBottomSheet.tsx
+++ b/src/widgets/map/ui/placeMarkingListBottomSheet.tsx
@@ -39,8 +39,9 @@ export const PlaceMarkingListBottomSheet = () => {
             sortType: "POPULARITY",
           });
         }}
-        label={<h1 className="text-grey-900 title-1">이 장소 관련 마킹</h1>}
-      />
+      >
+        이 장소 관련 마킹
+      </BackwardNavigationBar>
       <div className="flex justify-end w-full px-4 mb-4">
         <SortTypeFilter
           options={sortTypeOption}


### PR DESCRIPTION
# 관련 이슈 번호
close #504
# 설명

기존의 `NavigationBar` 를 다음과 같이 수정했습니다.

```tsx
import { type ReactElement } from "react";

export interface NavigationBarProps {
  children:
    | [ReactElement<HTMLButtonElement | HTMLAnchorElement>, string | undefined]
    | [string | undefined, ReactElement<HTMLButtonElement | HTMLAnchorElement>];
}

export const NavigationBar = ({ children }: NavigationBarProps) => {
  const isButtonLeft =
    typeof children[1] === "string" || typeof children[1] === "undefined";

  return (
    <nav
      className={`flex py-2 px-1 items-center ${isButtonLeft ? "justify-start" : children[0] ? "justify-between" : "justify-end"}`}
    >
      {children.map((child) =>
        typeof child === "string" ? (
          <h1 className="text-grey-900 title-1">{child}</h1>
        ) : (
          child
        ),
      )}
    </nav>
  );
};
```

이제 네비게이션바의 칠드런은 무조건 두 개만 가능하며 값은 `string | undefined ` 혹은 `button | anchor` 엘리먼트만 가능합니다.

네비게이션 바를 상속받아 생성되는 `Backward , Close .. Bar` 는 다음과 같이 변경되었습니다.

```tsx
export const BackwardNavigationBar = ({
  children,
  ...props
}: BackwardNavigationBarProps) => {
  return (
    <NavigationBar>
      <BackWardButton {...props} />
      {children}
    </NavigationBar>
  );
};
```

```tsx
export const CloseNavigationBar = ({
  children,
  ...props
}: CloseNavigationBarProps) => {
  const navigate = useNavigate();

  return (
    <NavigationBar>
      {children}
      <CloseButton onClick={() => navigate(-1)} {...props} />
    </NavigationBar>
  );
};
```




# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
