### PR TITLE
[Refactor] 이메일 회원가입 폼 리팩토링

### DIFF
--- a/src/features/auth/api/postCheckCode.ts
+++ b/src/features/auth/api/postCheckCode.ts
@@ -1,8 +1,4 @@
-import {
-  type MutationState,
-  useMutation,
-  useMutationState,
-} from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { apiClient, HttpError } from "@/shared/lib";
 import { SIGN_UP_END_POINT } from "../constants";
 
@@ -19,27 +15,10 @@ const postCheckCode = async ({ email, authNum }: PostCheckCodeRequest) => {
   });
 };
 
-const mutationKey = ["checkVerificationCode"];
-
 export const usePostCheckCode = () => {
   return useMutation<unknown, HttpError, PostCheckCodeRequest>({
-    mutationKey,
+    mutationKey: ["checkVerificationCode"],
     mutationFn: postCheckCode,
     gcTime: 0,
   });
-};
-
-export const usePostCheckCodeState = () => {
-  const mutationState = useMutationState<
-    MutationState<unknown, HttpError, PostCheckCodeRequest>
-  >({
-    filters: {
-      mutationKey,
-      exact: true,
-    },
-  });
-
-  const lastMutationState = mutationState[mutationState.length - 1];
-
-  return lastMutationState;
 };

--- a/src/features/auth/api/postCheckCode.ts
+++ b/src/features/auth/api/postCheckCode.ts
@@ -15,6 +15,7 @@ const postCheckCode = async ({ email, authNum }: PostCheckCodeRequest) => {
   // postman에 token이 필요 없다고 명시되어 있음
   return apiClient.post(SIGN_UP_END_POINT.CHECK_VERIFICATION_CODE, {
     body: { email, authNum },
+    snackbarOnError: (error) => error.code !== 400,
   });
 };
 

--- a/src/features/auth/api/postSendCode.ts
+++ b/src/features/auth/api/postSendCode.ts
@@ -1,8 +1,4 @@
-import {
-  type MutationState,
-  useMutation,
-  useMutationState,
-} from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { apiClient, HttpError, useSnackBar } from "@/shared/lib";
 import { SIGN_UP_END_POINT } from "../constants";
 
@@ -17,32 +13,15 @@ const postSendCode = async ({ email }: PostSendCodeRequest) => {
   });
 };
 
-const mutationKey = ["sendVerificationCode"];
-
 export const usePostSendCode = () => {
   const handleOpenSnackbar = useSnackBar();
 
   return useMutation<unknown, HttpError, PostSendCodeRequest>({
-    mutationKey,
+    mutationKey: ["sendVerificationCode"],
     mutationFn: postSendCode,
     gcTime: 0,
     onSuccess: () => {
       handleOpenSnackbar("메일로 인증코드가 전송되었습니다");
     },
   });
-};
-
-export const usePostSendCodeState = () => {
-  const mutationState = useMutationState<
-    MutationState<unknown, HttpError, PostSendCodeRequest>
-  >({
-    filters: {
-      mutationKey,
-      exact: true,
-    },
-  });
-
-  const lastMutationState = mutationState[mutationState.length - 1];
-
-  return lastMutationState;
 };

--- a/src/features/auth/api/postSendCode.ts
+++ b/src/features/auth/api/postSendCode.ts
@@ -3,7 +3,7 @@ import {
   useMutation,
   useMutationState,
 } from "@tanstack/react-query";
-import { apiClient, HttpError } from "@/shared/lib";
+import { apiClient, HttpError, useSnackBar } from "@/shared/lib";
 import { SIGN_UP_END_POINT } from "../constants";
 
 export interface PostSendCodeRequest {
@@ -20,10 +20,15 @@ const postSendCode = async ({ email }: PostSendCodeRequest) => {
 const mutationKey = ["sendVerificationCode"];
 
 export const usePostSendCode = () => {
+  const handleOpenSnackbar = useSnackBar();
+
   return useMutation<unknown, HttpError, PostSendCodeRequest>({
     mutationKey,
     mutationFn: postSendCode,
     gcTime: 0,
+    onSuccess: () => {
+      handleOpenSnackbar("메일로 인증코드가 전송되었습니다");
+    },
   });
 };
 

--- a/src/features/auth/constants/form.ts
+++ b/src/features/auth/constants/form.ts
@@ -334,3 +334,5 @@ export const dogBreeds = [
 ];
 
 export const REGION_API_DEBOUNCE_DELAY = 500;
+
+export const VERIFICATION_CODE_LENGTH = 7;

--- a/src/features/auth/store/index.ts
+++ b/src/features/auth/store/index.ts
@@ -2,3 +2,4 @@ export * from "./form";
 export * from "./petInformationForm";
 export * from "./region";
 export * from "./signUpByEmailForm";
+export * from "./verifyEmail";

--- a/src/features/auth/store/verifyEmail.tsx
+++ b/src/features/auth/store/verifyEmail.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext } from "react";
+import { usePostCheckCode, usePostSendCode } from "../api";
+
+const VerifyEmailContext = createContext<{
+  sendCodeMutation: ReturnType<typeof usePostSendCode>;
+  checkCodeMutation: ReturnType<typeof usePostCheckCode>;
+  isModifiedEmail: (email: string) => boolean;
+  isModifiedCode: (code: string) => boolean;
+  isDuplicateEmail: boolean;
+  isSentCode: boolean;
+  isNotMatchedCode: boolean;
+  isVerified: boolean;
+} | null>(null);
+
+export const useVerifyEmailContext = () => {
+  const context = useContext(VerifyEmailContext);
+
+  if (!context) {
+    throw new Error(
+      "useVerifyEmailContext은 VerifyEmailProvider 내에서만 사용 가능합니다.",
+    );
+  }
+
+  return context;
+};
+
+export const VerifyEmailProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const sendCodeMutation = usePostSendCode();
+  const checkCodeMutation = usePostCheckCode();
+
+  const isModifiedEmail = (email: string) =>
+    email !== sendCodeMutation.variables?.email;
+  const isModifiedCode = (code: string) =>
+    code !== checkCodeMutation.variables?.authNum;
+
+  const isDuplicateEmail = sendCodeMutation.error?.code === 409;
+  const isSentCode = sendCodeMutation.status === "success";
+
+  const isNotMatchedCode = checkCodeMutation.error?.code === 400;
+  const isVerified = checkCodeMutation.status === "success";
+
+  return (
+    <VerifyEmailContext.Provider
+      value={{
+        sendCodeMutation,
+        checkCodeMutation,
+        isModifiedEmail,
+        isModifiedCode,
+        isDuplicateEmail,
+        isSentCode,
+        isNotMatchedCode,
+        isVerified,
+      }}
+    >
+      {children}
+    </VerifyEmailContext.Provider>
+  );
+};

--- a/src/features/auth/store/verifyEmail.tsx
+++ b/src/features/auth/store/verifyEmail.tsx
@@ -6,7 +6,7 @@ const VerifyEmailContext = createContext<{
   checkCodeMutation: ReturnType<typeof usePostCheckCode>;
   isModifiedEmail: (email: string) => boolean;
   isModifiedCode: (code: string) => boolean;
-  isDuplicateEmail: boolean;
+  isDuplicatedEmail: boolean;
   isSentCode: boolean;
   isNotMatchedCode: boolean;
   isVerified: boolean;
@@ -50,7 +50,7 @@ export const VerifyEmailProvider = ({
         checkCodeMutation,
         isModifiedEmail,
         isModifiedCode,
-        isDuplicateEmail,
+        isDuplicatedEmail: isDuplicateEmail,
         isSentCode,
         isNotMatchedCode,
         isVerified,

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -54,10 +54,10 @@ const VerifyEmail = () => {
           <Email />
           <SendCodeButton />
         </div>
-      </div>
-      <div className="flex items-end justify-between gap-2">
-        <VerificationCode />
-        <CheckCodeButton />
+        <div className="flex items-end justify-between gap-2">
+          <VerificationCode />
+          <CheckCodeButton />
+        </div>
       </div>
     </VerifyEmailProvider>
   );
@@ -388,9 +388,7 @@ export const SignUpByEmailForm = () => {
 
   return (
     <form className="flex flex-col gap-8 self-stretch" onSubmit={handleSubmit}>
-      <div className="flex flex-col">
-        <VerifyEmail />
-      </div>
+      <VerifyEmail />
 
       <div>
         <Password />

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -68,7 +68,7 @@ const Email = () => {
     sendCodeMutation,
     checkCodeMutation,
     isModifiedEmail,
-    isDuplicateEmail,
+    isDuplicatedEmail,
     isVerified,
   } = useVerifyEmailContext();
 
@@ -99,7 +99,7 @@ const Email = () => {
 
   const statusText = !isValidEmail
     ? "이메일 형식으로 입력해 주세요"
-    : isDuplicateEmail
+    : isDuplicatedEmail
       ? "이미 가입된 이메일 입니다"
       : "올바른 이메일 형식입니다";
 
@@ -109,7 +109,7 @@ const Email = () => {
       name="email"
       label="이메일"
       disabled={isVerified}
-      isError={(!isEmailEmpty && !isValidEmail) || isDuplicateEmail}
+      isError={(!isEmailEmpty && !isValidEmail) || isDuplicatedEmail}
       placeholder="이메일을 입력해 주세요"
       statusText={statusText}
       essential
@@ -119,7 +119,7 @@ const Email = () => {
 };
 
 const SendCodeButton = () => {
-  const { sendCodeMutation, isDuplicateEmail, isSentCode, isVerified } =
+  const { sendCodeMutation, isDuplicatedEmail, isSentCode, isVerified } =
     useVerifyEmailContext();
 
   const isValidEmail = useSignUpByEmailFormStore((state) => state.isValidEmail);
@@ -150,7 +150,7 @@ const SendCodeButton = () => {
       }}
       disabled={
         !isValidEmail ||
-        isDuplicateEmail ||
+        isDuplicatedEmail ||
         (isSentCode && !isTimeLeftLessThanOneMinute) ||
         isVerified
       }

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -1,16 +1,14 @@
-import { useEffect, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { EmailInput, PasswordInput } from "@/entities/auth/ui";
 import { useSnackBar } from "@/shared/lib";
 import { Button } from "@/shared/ui/button";
-import { Input } from "@/shared/ui/input";
+import { Input, StatusText } from "@/shared/ui/input";
 import {
   usePostCheckCode,
-  usePostCheckCodeState,
   usePostSendCode,
-  usePostSendCodeState,
   usePostSignUpByEmail,
 } from "../api";
+import { VERIFICATION_CODE_LENGTH } from "../constants";
 import { useSignUpByEmailFormStore } from "../store";
 
 const Timer = () => {
@@ -48,51 +46,137 @@ const Timer = () => {
   );
 };
 
-const Email = () => {
-  const queryClient = useQueryClient();
-  const [isFocused, setIsFocused] = useState<boolean>(false);
+const useVerifyEmail = () => {
+  const sendCodeMutation = usePostSendCode();
+  const checkCodeMutation = usePostCheckCode();
 
+  const isModifiedEmail = (email: string) =>
+    email !== sendCodeMutation.variables?.email;
+  const isModifiedCode = (code: string) =>
+    code !== checkCodeMutation.variables?.authNum;
+
+  const isDuplicateEmail = sendCodeMutation.error?.code === 409;
+  const isSentCode = sendCodeMutation.status === "success";
+
+  const isNotMatchedCode = checkCodeMutation.error?.code === 400;
+  const isVerified = checkCodeMutation.status === "success";
+
+  return {
+    sendCodeMutation,
+    checkCodeMutation,
+    isModifiedEmail,
+    isModifiedCode,
+    isDuplicateEmail,
+    isSentCode,
+    isNotMatchedCode,
+    isVerified,
+  };
+};
+
+const VerifyEmail = () => {
+  const { setTimeLeft } = useSignUpByEmailFormStore((state) => state.actions);
+
+  const {
+    sendCodeMutation,
+    checkCodeMutation,
+    isModifiedEmail,
+    isModifiedCode,
+    isDuplicateEmail,
+    isSentCode,
+    isNotMatchedCode,
+    isVerified,
+  } = useVerifyEmail();
+
+  return (
+    <>
+      <div>
+        <div className="flex items-end justify-between gap-2">
+          <Email
+            isModified={isModifiedEmail}
+            isDuplicateEmail={isDuplicateEmail}
+            isVerified={isVerified}
+            resetCache={() => {
+              sendCodeMutation.reset();
+              checkCodeMutation.reset();
+            }}
+          />
+          <SendCodeButton
+            isDuplicateEmail={isDuplicateEmail}
+            isSentCode={isSentCode}
+            isVerified={isVerified}
+            onClick={() => {
+              sendCodeMutation.mutate(
+                { email: useSignUpByEmailFormStore.getState().email },
+                {
+                  onSuccess: () => {
+                    setTimeLeft(1000 * 60 * 3);
+                  },
+                },
+              );
+            }}
+          />
+        </div>
+      </div>
+      <div className="flex items-end justify-between gap-2">
+        <VerificationCode
+          isModified={isModifiedCode}
+          isSentCode={isSentCode}
+          isVerified={isVerified}
+          isNotMatchedCode={isNotMatchedCode}
+          resetCache={() => {
+            checkCodeMutation.reset();
+          }}
+        />
+        <CheckCodeButton
+          isSentCode={isSentCode}
+          isVerified={isVerified}
+          isNotMatchedCode={isNotMatchedCode}
+          onClick={() => {
+            const { email, verificationCode: authNum } =
+              useSignUpByEmailFormStore.getState();
+
+            checkCodeMutation.mutate({ email, authNum });
+          }}
+        />
+      </div>
+    </>
+  );
+};
+
+const Email = ({
+  isModified,
+  isDuplicateEmail,
+  isVerified,
+  resetCache,
+}: {
+  isModified: (email: string) => boolean;
+  isDuplicateEmail: boolean;
+  isVerified: boolean;
+  resetCache: () => void;
+}) => {
   const isEmailEmpty = useSignUpByEmailFormStore((state) => state.isEmailEmpty);
   const isValidEmail = useSignUpByEmailFormStore((state) => state.isValidEmail);
   const { setEmail, resetState } = useSignUpByEmailFormStore(
     (state) => state.actions,
   );
 
-  // 인증 코드 전송 상태
-  const sendCodeState = usePostSendCodeState();
-  const isDuplicateEmail = sendCodeState?.error?.code === 409;
-
-  // 인증 코드 확인 상태
-  const checkCodeState = usePostCheckCodeState();
-  const isSuccessCheckCode = checkCodeState?.status === "success";
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value: email } = e.target;
 
     setEmail(email);
 
-    if (typeof sendCodeState?.variables !== "undefined") {
-      const isModified = sendCodeState.variables?.email !== email;
-
-      if (isModified) {
-        resetState([
-          "verificationCode",
-          "timeLeft",
-          "isTimeLeftLessThanOneMinute",
-        ]);
-        queryClient.clear();
-      }
+    // 이메일이 변경되면
+    // 1. 인증코드, 타이머, 타이머가 1분 남았는지 여부 상태 초기화
+    // 2. 캐시 초기화
+    if (isModified(email)) {
+      resetState([
+        "verificationCode",
+        "timeLeft",
+        "isTimeLeftLessThanOneMinute",
+      ]);
+      resetCache();
     }
   };
-
-  const shouldShowEmailStatusText =
-    isFocused || isValidEmail || !isEmailEmpty || isDuplicateEmail;
-
-  const statusTextColorStyle = isDuplicateEmail
-    ? "text-pink-500"
-    : isValidEmail || isEmailEmpty
-      ? "text-grey-500"
-      : "text-pink-500";
 
   const statusText = !isValidEmail
     ? "이메일 형식으로 입력해 주세요"
@@ -101,81 +185,35 @@ const Email = () => {
       : "올바른 이메일 형식입니다";
 
   return (
-    <div>
-      <div className="flex items-end justify-between gap-2">
-        <EmailInput
-          id="email"
-          name="email"
-          label="이메일"
-          disabled={isSuccessCheckCode}
-          isError={(!isEmailEmpty && !isValidEmail) || isDuplicateEmail}
-          placeholder="이메일을 입력해 주세요"
-          statusText={undefined}
-          essential
-          onChange={handleChange}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-        />
-        <SendCodeButton />
-      </div>
-      {shouldShowEmailStatusText && (
-        <p className={`body-3 pl-1 pr-3 pt-1 h-6 ${statusTextColorStyle}`}>
-          {statusText}
-        </p>
-      )}
-    </div>
+    <EmailInput
+      id="email"
+      name="email"
+      label="이메일"
+      disabled={isVerified}
+      isError={(!isEmailEmpty && !isValidEmail) || isDuplicateEmail}
+      placeholder="이메일을 입력해 주세요"
+      statusText={statusText}
+      essential
+      onChange={handleChange}
+    />
   );
 };
 
-const SendCodeButton = () => {
+const SendCodeButton = ({
+  isDuplicateEmail,
+  isSentCode,
+  isVerified,
+  onClick,
+}: {
+  isDuplicateEmail: boolean;
+  isSentCode: boolean;
+  isVerified: boolean;
+  onClick: () => void;
+}) => {
   const isValidEmail = useSignUpByEmailFormStore((state) => state.isValidEmail);
   const isTimeLeftLessThanOneMinute = useSignUpByEmailFormStore(
     (state) => state.isTimeLeftLessThanOneMinute,
   );
-  const { setTimeLeft } = useSignUpByEmailFormStore((state) => state.actions);
-
-  const {
-    mutate: postVerificationCode,
-    isSuccess: isSuccessSendCode,
-    isIdle,
-    error,
-  } = usePostSendCode();
-  const isDuplicateEmail = error?.code === 409;
-
-  const checkCodeState = usePostCheckCodeState();
-  const isSuccessCheckCode = checkCodeState?.status === "success";
-
-  const handleSendVerificationCode = () => {
-    const { email } = useSignUpByEmailFormStore.getState();
-
-    postVerificationCode(
-      { email },
-      {
-        onSuccess: () => {
-          setTimeLeft(1000 * 60 * 3);
-        },
-      },
-    );
-  };
-
-  if (isIdle) {
-    return (
-      <Button
-        type="button"
-        colorType="secondary"
-        variant="filled"
-        size="medium"
-        fullWidth={false}
-        className="w-[6.5rem]"
-        onClick={handleSendVerificationCode}
-        disabled={!isValidEmail || isDuplicateEmail || isSuccessCheckCode}
-      >
-        코드전송
-      </Button>
-    );
-  }
-
-  const canResendCode = isSuccessSendCode && isTimeLeftLessThanOneMinute;
 
   return (
     <Button
@@ -184,23 +222,33 @@ const SendCodeButton = () => {
       variant="filled"
       size="medium"
       fullWidth={false}
-      className="w-[6.5rem]"
-      onClick={handleSendVerificationCode}
+      className="w-[6.5rem] mb-6"
+      onClick={onClick}
       disabled={
         !isValidEmail ||
         isDuplicateEmail ||
-        !canResendCode ||
-        isSuccessCheckCode
+        (isSentCode && !isTimeLeftLessThanOneMinute) ||
+        isVerified
       }
     >
-      재전송
+      코드전송
     </Button>
   );
 };
 
-const VerificationCode = () => {
-  const CODE_LENGTH = 7;
-
+const VerificationCode = ({
+  isModified,
+  isSentCode,
+  isVerified,
+  isNotMatchedCode,
+  resetCache,
+}: {
+  isModified: (code: string) => boolean;
+  isSentCode: boolean;
+  isVerified: boolean;
+  isNotMatchedCode: boolean;
+  resetCache: () => void;
+}) => {
   const verificationCode = useSignUpByEmailFormStore(
     (state) => state.verificationCode,
   );
@@ -210,23 +258,8 @@ const VerificationCode = () => {
   );
 
   const verificationCodeRef = useRef<HTMLInputElement>(null);
-  const [isFocused, setIsFocused] = useState<boolean>(false);
 
-  const {
-    mutate: postCheckCode,
-    isSuccess: isSuccessCheckCode,
-    variables,
-    error,
-  } = usePostCheckCode();
-  const isErrorCheckCode =
-    error?.code === 400 && variables?.authNum === verificationCode;
-
-  // 인증 코드 전송 상태
-  const sendCodeState = usePostSendCodeState();
-  const isErrorSendCode = sendCodeState?.status === "error";
-  const isSuccessSendCode = sendCodeState?.status === "success";
-
-  const isTimeOver = timeLeft === 0 && isSuccessSendCode;
+  const isTimeOver = timeLeft === 0 && isSentCode;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value: verificationCode } = e.target;
@@ -234,72 +267,71 @@ const VerificationCode = () => {
     const onlyNumbers = verificationCode.replace(/[^0-9]/g, "");
 
     setVerificationCode(onlyNumbers);
-  };
 
-  const handleCheckButtonClick = () => {
-    const { email, verificationCode } = useSignUpByEmailFormStore.getState();
-
-    postCheckCode(
-      { email, authNum: verificationCode },
-      {
-        onError: () => {
-          verificationCodeRef.current?.focus();
-        },
-      },
-    );
+    if (isModified(onlyNumbers)) {
+      resetCache();
+    }
   };
 
   let statusText = "인증코드 7자리를 입력해 주세요";
-  if (isSuccessCheckCode) statusText = "인증되었습니다";
-  if (isErrorCheckCode) statusText = "인증코드를 다시 확인해 주세요";
+  if (isVerified) statusText = "인증되었습니다";
+  if (isNotMatchedCode) statusText = "인증코드를 다시 확인해 주세요";
   if (isTimeOver)
     statusText = "인증시간이 만료되었습니다. 재전송 버튼을 눌러주세요";
 
   return (
-    <div>
-      <div className="flex items-end justify-between gap-2">
-        <Input
-          ref={verificationCodeRef}
-          componentType="outlinedText"
-          id="verification-code"
-          name="verificationCode"
-          type="text"
-          placeholder="인증코드 7자리를 입력해 주세요"
-          statusText={undefined}
-          maxLength={CODE_LENGTH}
-          value={verificationCode}
-          onChange={handleChange}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          isError={isTimeOver || isErrorCheckCode}
-          disabled={!sendCodeState || isErrorSendCode || isSuccessCheckCode}
-          trailingNode={isSuccessSendCode && !isSuccessCheckCode && <Timer />}
-        />
-        <Button
-          type="button"
-          colorType="secondary"
-          variant="filled"
-          size="medium"
-          fullWidth={false}
-          className="w-[6.5rem]"
-          onClick={handleCheckButtonClick}
-          disabled={
-            isTimeOver ||
-            verificationCode.length < CODE_LENGTH ||
-            isErrorCheckCode ||
-            isSuccessCheckCode
-          }
-        >
-          확인
-        </Button>
-      </div>
-      <p
-        className={`body-3 pl-1 pr-3 pt-1 h-6 ${isTimeOver || isErrorCheckCode ? "text-pink-500" : "text-grey-500"}`}
-      >
-        {(isFocused || isTimeOver || isErrorCheckCode || isSuccessCheckCode) &&
-          statusText}
-      </p>
-    </div>
+    <Input
+      ref={verificationCodeRef}
+      componentType="outlinedText"
+      id="verification-code"
+      name="verificationCode"
+      type="text"
+      placeholder="인증코드 7자리를 입력해 주세요"
+      statusText={statusText}
+      maxLength={VERIFICATION_CODE_LENGTH}
+      value={verificationCode}
+      onChange={handleChange}
+      isError={isTimeOver || isNotMatchedCode}
+      disabled={!isSentCode || isVerified}
+      trailingNode={isSentCode && !isVerified && <Timer />}
+    />
+  );
+};
+
+const CheckCodeButton = ({
+  isSentCode,
+  isNotMatchedCode,
+  isVerified,
+  onClick,
+}: {
+  isSentCode: boolean;
+  isNotMatchedCode: boolean;
+  isVerified: boolean;
+  onClick: () => void;
+}) => {
+  const verificationCode = useSignUpByEmailFormStore(
+    (state) => state.verificationCode,
+  );
+  const timeLeft = useSignUpByEmailFormStore((state) => state.timeLeft);
+
+  return (
+    <Button
+      type="button"
+      colorType="secondary"
+      variant="filled"
+      size="medium"
+      fullWidth={false}
+      className="w-[6.5rem] mb-6"
+      onClick={onClick}
+      disabled={
+        verificationCode.length < VERIFICATION_CODE_LENGTH ||
+        (timeLeft === 0 && isSentCode) ||
+        isNotMatchedCode ||
+        isVerified
+      }
+    >
+      확인
+    </Button>
   );
 };
 
@@ -380,11 +412,11 @@ const PasswordConfirm = () => {
           onChange={handleChange}
           isError={!isConfirmPasswordEmpty && !isValidConfirmPassword}
         />
-        <p
-          className={`body-3 pl-1 pr-3 pt-1 h-6 ${!isConfirmPasswordEmpty && !isValidConfirmPassword ? "text-pink-500" : "text-grey-500"}`}
+        <StatusText
+          isError={!isConfirmPasswordEmpty && !isValidConfirmPassword}
         >
           {isConfirmPasswordEmpty ? "" : statusText}
-        </p>
+        </StatusText>
       </div>
       <span className="body-3 px-3 pt-1 text-grey-500">
         영문, 숫자, 특수문자 3가지 조합을 포함하는 8자 이상 15자 이내로 입력해
@@ -438,9 +470,8 @@ export const SignUpByEmailForm = () => {
 
   return (
     <form className="flex flex-col gap-8 self-stretch" onSubmit={handleSubmit}>
-      <div className="flex flex-col gap-2">
-        <Email />
-        <VerificationCode />
+      <div className="flex flex-col">
+        <VerifyEmail />
       </div>
 
       <div>

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -3,13 +3,13 @@ import { EmailInput, PasswordInput } from "@/entities/auth/ui";
 import { useSnackBar } from "@/shared/lib";
 import { Button } from "@/shared/ui/button";
 import { Input, StatusText } from "@/shared/ui/input";
-import {
-  usePostCheckCode,
-  usePostSendCode,
-  usePostSignUpByEmail,
-} from "../api";
+import { usePostSignUpByEmail } from "../api";
 import { VERIFICATION_CODE_LENGTH } from "../constants";
-import { useSignUpByEmailFormStore } from "../store";
+import {
+  useSignUpByEmailFormStore,
+  useVerifyEmailContext,
+  VerifyEmailProvider,
+} from "../store";
 
 const Timer = () => {
   const INTERVAL = 1000;
@@ -46,114 +46,32 @@ const Timer = () => {
   );
 };
 
-const useVerifyEmail = () => {
-  const sendCodeMutation = usePostSendCode();
-  const checkCodeMutation = usePostCheckCode();
-
-  const isModifiedEmail = (email: string) =>
-    email !== sendCodeMutation.variables?.email;
-  const isModifiedCode = (code: string) =>
-    code !== checkCodeMutation.variables?.authNum;
-
-  const isDuplicateEmail = sendCodeMutation.error?.code === 409;
-  const isSentCode = sendCodeMutation.status === "success";
-
-  const isNotMatchedCode = checkCodeMutation.error?.code === 400;
-  const isVerified = checkCodeMutation.status === "success";
-
-  return {
-    sendCodeMutation,
-    checkCodeMutation,
-    isModifiedEmail,
-    isModifiedCode,
-    isDuplicateEmail,
-    isSentCode,
-    isNotMatchedCode,
-    isVerified,
-  };
+const VerifyEmail = () => {
+  return (
+    <VerifyEmailProvider>
+      <div>
+        <div className="flex items-end justify-between gap-2">
+          <Email />
+          <SendCodeButton />
+        </div>
+      </div>
+      <div className="flex items-end justify-between gap-2">
+        <VerificationCode />
+        <CheckCodeButton />
+      </div>
+    </VerifyEmailProvider>
+  );
 };
 
-const VerifyEmail = () => {
-  const { setTimeLeft } = useSignUpByEmailFormStore((state) => state.actions);
-
+const Email = () => {
   const {
     sendCodeMutation,
     checkCodeMutation,
     isModifiedEmail,
-    isModifiedCode,
     isDuplicateEmail,
-    isSentCode,
-    isNotMatchedCode,
     isVerified,
-  } = useVerifyEmail();
+  } = useVerifyEmailContext();
 
-  return (
-    <>
-      <div>
-        <div className="flex items-end justify-between gap-2">
-          <Email
-            isModified={isModifiedEmail}
-            isDuplicateEmail={isDuplicateEmail}
-            isVerified={isVerified}
-            resetCache={() => {
-              sendCodeMutation.reset();
-              checkCodeMutation.reset();
-            }}
-          />
-          <SendCodeButton
-            isDuplicateEmail={isDuplicateEmail}
-            isSentCode={isSentCode}
-            isVerified={isVerified}
-            onClick={() => {
-              sendCodeMutation.mutate(
-                { email: useSignUpByEmailFormStore.getState().email },
-                {
-                  onSuccess: () => {
-                    setTimeLeft(1000 * 60 * 3);
-                  },
-                },
-              );
-            }}
-          />
-        </div>
-      </div>
-      <div className="flex items-end justify-between gap-2">
-        <VerificationCode
-          isModified={isModifiedCode}
-          isSentCode={isSentCode}
-          isVerified={isVerified}
-          isNotMatchedCode={isNotMatchedCode}
-          resetCache={() => {
-            checkCodeMutation.reset();
-          }}
-        />
-        <CheckCodeButton
-          isSentCode={isSentCode}
-          isVerified={isVerified}
-          isNotMatchedCode={isNotMatchedCode}
-          onClick={() => {
-            const { email, verificationCode: authNum } =
-              useSignUpByEmailFormStore.getState();
-
-            checkCodeMutation.mutate({ email, authNum });
-          }}
-        />
-      </div>
-    </>
-  );
-};
-
-const Email = ({
-  isModified,
-  isDuplicateEmail,
-  isVerified,
-  resetCache,
-}: {
-  isModified: (email: string) => boolean;
-  isDuplicateEmail: boolean;
-  isVerified: boolean;
-  resetCache: () => void;
-}) => {
   const isEmailEmpty = useSignUpByEmailFormStore((state) => state.isEmailEmpty);
   const isValidEmail = useSignUpByEmailFormStore((state) => state.isValidEmail);
   const { setEmail, resetState } = useSignUpByEmailFormStore(
@@ -168,13 +86,14 @@ const Email = ({
     // 이메일이 변경되면
     // 1. 인증코드, 타이머, 타이머가 1분 남았는지 여부 상태 초기화
     // 2. 캐시 초기화
-    if (isModified(email)) {
+    if (isModifiedEmail(email)) {
       resetState([
         "verificationCode",
         "timeLeft",
         "isTimeLeftLessThanOneMinute",
       ]);
-      resetCache();
+      sendCodeMutation.reset();
+      checkCodeMutation.reset();
     }
   };
 
@@ -199,21 +118,15 @@ const Email = ({
   );
 };
 
-const SendCodeButton = ({
-  isDuplicateEmail,
-  isSentCode,
-  isVerified,
-  onClick,
-}: {
-  isDuplicateEmail: boolean;
-  isSentCode: boolean;
-  isVerified: boolean;
-  onClick: () => void;
-}) => {
+const SendCodeButton = () => {
+  const { sendCodeMutation, isDuplicateEmail, isSentCode, isVerified } =
+    useVerifyEmailContext();
+
   const isValidEmail = useSignUpByEmailFormStore((state) => state.isValidEmail);
   const isTimeLeftLessThanOneMinute = useSignUpByEmailFormStore(
     (state) => state.isTimeLeftLessThanOneMinute,
   );
+  const { setTimeLeft } = useSignUpByEmailFormStore((state) => state.actions);
 
   return (
     <Button
@@ -223,7 +136,18 @@ const SendCodeButton = ({
       size="medium"
       fullWidth={false}
       className="w-[6.5rem] mb-6"
-      onClick={onClick}
+      onClick={() => {
+        const { email } = useSignUpByEmailFormStore.getState();
+
+        sendCodeMutation.mutate(
+          { email },
+          {
+            onSuccess: () => {
+              setTimeLeft(1000 * 60 * 3);
+            },
+          },
+        );
+      }}
       disabled={
         !isValidEmail ||
         isDuplicateEmail ||
@@ -236,19 +160,15 @@ const SendCodeButton = ({
   );
 };
 
-const VerificationCode = ({
-  isModified,
-  isSentCode,
-  isVerified,
-  isNotMatchedCode,
-  resetCache,
-}: {
-  isModified: (code: string) => boolean;
-  isSentCode: boolean;
-  isVerified: boolean;
-  isNotMatchedCode: boolean;
-  resetCache: () => void;
-}) => {
+const VerificationCode = () => {
+  const {
+    checkCodeMutation,
+    isModifiedCode,
+    isSentCode,
+    isVerified,
+    isNotMatchedCode,
+  } = useVerifyEmailContext();
+
   const verificationCode = useSignUpByEmailFormStore(
     (state) => state.verificationCode,
   );
@@ -268,8 +188,8 @@ const VerificationCode = ({
 
     setVerificationCode(onlyNumbers);
 
-    if (isModified(onlyNumbers)) {
-      resetCache();
+    if (isModifiedCode(onlyNumbers)) {
+      checkCodeMutation.reset();
     }
   };
 
@@ -298,17 +218,10 @@ const VerificationCode = ({
   );
 };
 
-const CheckCodeButton = ({
-  isSentCode,
-  isNotMatchedCode,
-  isVerified,
-  onClick,
-}: {
-  isSentCode: boolean;
-  isNotMatchedCode: boolean;
-  isVerified: boolean;
-  onClick: () => void;
-}) => {
+const CheckCodeButton = () => {
+  const { checkCodeMutation, isSentCode, isNotMatchedCode, isVerified } =
+    useVerifyEmailContext();
+
   const verificationCode = useSignUpByEmailFormStore(
     (state) => state.verificationCode,
   );
@@ -322,7 +235,12 @@ const CheckCodeButton = ({
       size="medium"
       fullWidth={false}
       className="w-[6.5rem] mb-6"
-      onClick={onClick}
+      onClick={() => {
+        const { email, verificationCode: authNum } =
+          useSignUpByEmailFormStore.getState();
+
+        checkCodeMutation.mutate({ email, authNum });
+      }}
       disabled={
         verificationCode.length < VERIFICATION_CODE_LENGTH ||
         (timeLeft === 0 && isSentCode) ||

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -128,8 +128,6 @@ const Email = () => {
 };
 
 const SendCodeButton = () => {
-  const handleOpenSnackbar = useSnackBar();
-
   const isValidEmail = useSignUpByEmailFormStore((state) => state.isValidEmail);
   const isTimeLeftLessThanOneMinute = useSignUpByEmailFormStore(
     (state) => state.isTimeLeftLessThanOneMinute,
@@ -154,7 +152,6 @@ const SendCodeButton = () => {
       { email },
       {
         onSuccess: () => {
-          handleOpenSnackbar("메일로 인증코드가 전송되었습니다");
           setTimeLeft(1000 * 60 * 3);
         },
       },

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -126,3 +126,19 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     );
   },
 );
+
+export const StatusText = ({
+  isError = false,
+  children,
+}: {
+  isError?: boolean;
+  children: React.ReactNode;
+}) => {
+  return (
+    <p
+      className={`${baseStyles.statusText} ${isError ? "text-pink-500" : "text-grey-500"}`}
+    >
+      {children}
+    </p>
+  );
+};


### PR DESCRIPTION
# 관련 이슈 번호

#66

# 설명

## Input의 StatusText 컴포넌트 생성

요구 사항에 따라 Input의 statusText props를 사용하지 못할 때를 대비하여 안내 문구를 나타내는 컴포넌트를 만들었습니다.

```typescript
export const StatusText = ({
  isError = false,
  children,
}: {
  isError?: boolean;
  children: React.ReactNode;
}) => {
  return (
    <p
      className={`${baseStyles.statusText} ${isError ? "text-pink-500" : "text-grey-500"}`}
    >
      {children}
    </p>
  );
};
```

## 인증 코드와 관련된 서버 상태

이메일 Input, 코드 전송 버튼, 코드 입력 input, 코드 확인 버튼은 서버 상태에 의존하고 있습니다.
기존에는 UI와 서버 상태가 혼재되어 컴포넌트 내부가 복잡해졌고, 이를 분리해야 할 필요성을 느꼈습니다.

서버 상태를 하나의 context로 관리하여 ui와 서버 상태를 분리하였습니다.

- isModified*: 마지막으로 보낸 요청 variable과 입력값이 동일한지 확인하는 함수
- isDuplicateEmail: 이미 존재하는 이메일인지
- isSentCode: 인증 코드 전송 요청 성공
- isNotMatchedCode: 인증 코드가 맞지 않은 경우
- isVerified: 인증 코드 확인 요청 성공 (이메일 인증 완료)

```typescript
export const VerifyEmailProvider = ({
  children,
}: {
  children: React.ReactNode;
}) => {
  const sendCodeMutation = usePostSendCode();
  const checkCodeMutation = usePostCheckCode();

  const isModifiedEmail = (email: string) =>
    email !== sendCodeMutation.variables?.email;
  const isModifiedCode = (code: string) =>
    code !== checkCodeMutation.variables?.authNum;

  const isDuplicateEmail = sendCodeMutation.error?.code === 409;
  const isSentCode = sendCodeMutation.status === "success";

  const isNotMatchedCode = checkCodeMutation.error?.code === 400;
  const isVerified = checkCodeMutation.status === "success";

  return (
    <VerifyEmailContext.Provider
      value={{
        sendCodeMutation,
        checkCodeMutation,
        isModifiedEmail,
        isModifiedCode,
        isDuplicateEmail,
        isSentCode,
        isNotMatchedCode,
        isVerified,
      }}
    >
      {children}
    </VerifyEmailContext.Provider>
  );
};
```

각 input과 버튼에서 context를 사용할 수 있도록, VerifyEmail 컴포넌트의 최상위에 VerifyEmailProvider로 감싸주었습니다.

```typescript
const VerifyEmail = () => {
  return (
    <VerifyEmailProvider>
      <div>
        <div className="flex items-end justify-between gap-2">
          <Email />
          <SendCodeButton />
        </div>
        <div className="flex items-end justify-between gap-2">
          <VerificationCode />
          <CheckCodeButton />
        </div>
      </div>
    </VerifyEmailProvider>
  );
};
```

## mutation 상태 초기화

코드 전송 요청 이후 **이메일 입력값이 수정되었을 경우**나 
코드 확인 요청 이후 **코드 입력값이 수정되었을 경우** input과 버튼은 리렌더링이 일어납니다.
email과 verificationCode를 구독해서 요청 이후 입력값이 바뀌었는지 확인해야 했습니다.

이전에는 구독하는 방법 대신 `queryClient.clear()`하여 모든 캐시된 응답 데이터를 삭제했습니다.

특정 mutation만 캐시된 데이터를 삭제할 수 없을까 고민하다 `mutation.reset()`을 발견했습니다.
reset은 mutation의 상태를 초기화하여 응답 결과들은 삭제됩니다.

```typescript
const mutation = useMutation(...)
mutation.reset(); 
```

### 입력값 수정하면 캐시된 데이터를 삭제하는 이유

코드 전송 요청 이후 이메일 입력값을 수정하게 되면, 대부분의 경우 직전에 보낸 요청에 대한 응답을 캐시할 필요가 없어집니다.

여기서 "대부분의 경우"라고 표현한 이유는 캐시해두면 유용한 경우가 있습니다.

예를 들면
1. 이미 존재하는 이메일 입력
2. [코드 전송] 버튼 클릭
3. [코드 전송] 버튼 비활성화
4. 이메일 수정
5. [코드 전송] 버튼 활성화
6. 1번에서 입력한 이메일 값을 다시 입력

이 경우, 캐시를 활용하면 6번 단계에서 [코드 전송] 버튼을 비활성화 상태로 유지할 수 있습니다.
하지만 email 상태를 구독하여 요청 이후 이메일 값이 바뀌었는지 매번 확인해야 합니다.

```typescript
const isSentCode = sendCodeMutation.status === "success" && email === sendCodeMutation.variables?.email;
```

위와 같은 상황이 많이 일어나지 않을 것 같고 오히려 상태 관리하기 힘들 것 같아
요청 이후 입력값이 수정되면 캐시된 데이터를 삭제하였습니다.