### PR TITLE
[Hotfix] markingDetail 핸들러 토큰 검증 로직 제거

### DIFF
--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1944,41 +1944,24 @@ const getSavedMarkerListHandler = [
 // 해당 핸들러는 내 마킹이 아닌 경우에는 랜덤한 마킹을 만들어 반환합니다.
 // 이에 이 핸들러는 내 마킹이 아닌 경우엔 부정확한 결과를 보여 줄 수 있습니다.
 const getMarkingDetailRequestHandler = [
-  http.get(
-    `${API_BASE_URL}/markings/:markingId`,
-    async ({ request, params }) => {
-      const token = request.headers.get("Authorization");
+  http.get(`${API_BASE_URL}/markings/:markingId`, async ({ params }) => {
+    const content = myMarkingList.find(
+      ({ markingId }) => markingId === Number(params.markingId),
+    );
 
-      if (!token?.startsWith("accessToken")) {
-        return HttpResponse.json(
-          {
-            code: 401,
-            message: ERROR_MESSAGE.ACCESS_TOKEN_INVALIDATED,
-          },
-          {
-            status: 401,
-          },
-        );
-      }
-
-      const content = myMarkingList.find(
-        ({ markingId }) => markingId === Number(params.markingId),
-      );
-
-      return HttpResponse.json({
-        code: 200,
-        message: "success",
-        content:
-          content ??
-          createMockMarking(Number(params.markingId), {
-            southBottomLat: 35.0,
-            northTopLat: 35.1,
-            southLeftLng: 129.0,
-            northRightLng: 129.1,
-          }),
-      });
-    },
-  ),
+    return HttpResponse.json({
+      code: 200,
+      message: "success",
+      content:
+        content ??
+        createMockMarking(Number(params.markingId), {
+          southBottomLat: 35.0,
+          northTopLat: 35.1,
+          southLeftLng: 129.0,
+          northRightLng: 129.1,
+        }),
+    });
+  }),
 ];
 
 // * 나중에 msw 사용을 대비하여 만들었습니다.


### PR DESCRIPTION
# 관련 이슈 번호
close #516 
# 설명

미안합니다 문제는 마킹 디테일 목업 데이터에서 토큰 검증 로직이 있던게 문제였더군요 호호 

핸들러에서 해당 내용 삭제 했습니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
