### PR TITLE
[Feat] 500에러와 알 수 없는 에러 처리

### DIFF
--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -19,6 +19,9 @@ export const useCreateQueryClient = () => {
            * 만약 retry를 필요로 하는 경우에선 개별적인 query 문에서 retry 를 정의 해줍니다.
            */
           retry: false,
+          throwOnError(error) {
+            return error instanceof HttpError && error.code >= 500;
+          },
         },
         mutations: {
           /**
@@ -27,6 +30,9 @@ export const useCreateQueryClient = () => {
            * 만약 retry를 필요로 하는 경우에선 개별적인 query 문에서 retry 를 정의 해줍니다.
            */
           retry: false,
+          throwOnError(error) {
+            return error instanceof HttpError && error.code >= 500;
+          },
         },
       },
 

--- a/src/pages/errorBoundary.tsx
+++ b/src/pages/errorBoundary.tsx
@@ -3,8 +3,10 @@ import {
   AUTH_ERROR_MESSAGE,
   NOT_FOUND_ERROR_MESSAGE,
 } from "@/shared/constants";
+import { HttpError } from "@/shared/lib";
 import { NonAuthorized, NonLogin, NonPetInfo, NonUserInfo } from "./authError";
 import { NotFound } from "./notFound";
+import { ServerError } from "./serverError";
 import { UnknownError } from "./unknownError";
 
 export const ErrorBoundary = () => {
@@ -43,6 +45,10 @@ export const ErrorBoundary = () => {
     isRouteErrorResponse(error)
   ) {
     return <NotFound />;
+  }
+
+  if (error instanceof HttpError && error.code >= 500) {
+    return <ServerError />;
   }
 
   return <UnknownError />;

--- a/src/pages/errorBoundary.tsx
+++ b/src/pages/errorBoundary.tsx
@@ -1,5 +1,8 @@
-import { useRouteError } from "react-router-dom";
-import { AUTH_ERROR_MESSAGE } from "@/shared/constants";
+import { isRouteErrorResponse, useRouteError } from "react-router-dom";
+import {
+  AUTH_ERROR_MESSAGE,
+  NOT_FOUND_ERROR_MESSAGE,
+} from "@/shared/constants";
 import { NonAuthorized, NonLogin, NonPetInfo, NonUserInfo } from "./authError";
 import { NotFound } from "./notFound";
 
@@ -34,5 +37,13 @@ export const ErrorBoundary = () => {
     return <NonAuthorized />;
   }
 
-  return <NotFound />;
+  if (
+    (error instanceof Error && error.message === NOT_FOUND_ERROR_MESSAGE) ||
+    isRouteErrorResponse(error)
+  ) {
+    return <NotFound />;
+  }
+
+  // todo 알 수 없는 에러 페이지 만들기
+  // return <div>알 수 없는 에러</div>;
 };

--- a/src/pages/errorBoundary.tsx
+++ b/src/pages/errorBoundary.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/shared/constants";
 import { NonAuthorized, NonLogin, NonPetInfo, NonUserInfo } from "./authError";
 import { NotFound } from "./notFound";
+import { UnknownError } from "./unknownError";
 
 export const ErrorBoundary = () => {
   const error = useRouteError();
@@ -44,6 +45,5 @@ export const ErrorBoundary = () => {
     return <NotFound />;
   }
 
-  // todo 알 수 없는 에러 페이지 만들기
-  // return <div>알 수 없는 에러</div>;
+  return <UnknownError />;
 };

--- a/src/pages/serverError.tsx
+++ b/src/pages/serverError.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/shared/ui/button";
+
+export const ServerError = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col gap-4 justify-center items-center mx-auto my-0 h-screen max-w-[37.5rem]">
+      <img src="/default-image.png" alt="logo" width="64" height="64" />
+
+      <h1 className="title-1 text-grey-700">SYSTEM ERROR</h1>
+
+      <div className="flex flex-col items-center body-2 text-grey-500">
+        <span>서비스 이용에 불편을 드려 죄송합니다.</span>
+        <span>잠시 후 다시 확인해주세요.</span>
+      </div>
+
+      <Button
+        variant="filled"
+        colorType="secondary"
+        size="xSmall"
+        fullWidth={false}
+        onClick={() => {
+          navigate(-1);
+        }}
+      >
+        이전으로
+      </Button>
+    </div>
+  );
+};

--- a/src/pages/serverError.tsx
+++ b/src/pages/serverError.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { ROUTER_PATH } from "@/shared/constants";
 import { Button } from "@/shared/ui/button";
 
 export const ServerError = () => {
@@ -21,10 +22,10 @@ export const ServerError = () => {
         size="xSmall"
         fullWidth={false}
         onClick={() => {
-          navigate(-1);
+          navigate(ROUTER_PATH.MAIN);
         }}
       >
-        이전으로
+        메인 페이지로 이동
       </Button>
     </div>
   );

--- a/src/pages/unknownError.tsx
+++ b/src/pages/unknownError.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/shared/ui/button";
+
+export const UnknownError = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col gap-4 justify-center items-center mx-auto my-0 h-screen max-w-[37.5rem]">
+      <img src="/default-image.png" alt="logo" width="64" height="64" />
+
+      <h1 className="title-1 text-grey-700">UNKNOWN ERROR</h1>
+
+      <div className="flex flex-col items-center body-2 text-grey-500">
+        <span>알 수 없는 에러가 발생했습니다.</span>
+        <span>잠시 후 다시 확인해주세요.</span>
+      </div>
+
+      <Button
+        variant="filled"
+        colorType="secondary"
+        size="xSmall"
+        fullWidth={false}
+        onClick={() => {
+          navigate(-1);
+        }}
+      >
+        이전으로
+      </Button>
+    </div>
+  );
+};


### PR DESCRIPTION
# 관련 이슈 번호

#470 

# 설명

## 500번대 에러 응답 코드

500번대 에러 응답 코드가 오면 throwOnError를 true로 설정하여 ErrorBoundary 컴포넌트에서 catch하도록 구현했습니다.

```typescript
  const queryClient = useRef(
    new QueryClient({
      defaultOptions: {
        queries: {
          // ...
          throwOnError(error) {
            return error instanceof HttpError && error.code >= 500;
          },
        },
        mutations: {
          // ...
          throwOnError(error) {
            return error instanceof HttpError && error.code >= 500;
          },
        },
      },
```


## 500번대 에러 페이지와 알 수 없는 에러 페이지 생성

서버로부터 500번대 에러 응답코드가 왔을 때 보여줄 페이지 컴포넌트(`ServerError`)를 만들었습니다.
그 이외의 예상치 못한 에러가 발생했을 경우 보여줄 `UnknownError` 컴포넌트도 만들었습니다.

## ErrorBoundary

### NotFound가 보이는 경우

존재하지 않은 url 경로로 진입할 경우 프로필 페이지 쪽에서 `NOT_FOUND_ERROR_MESSAGE` 에러를 던집니다.
그리고 `/map/123423`와 같은 존재하지 않은 경로로 진입할 경우, `isRouteErrorResponse(error)`가 true가 되어 NotFound 컴포넌트를 표시합니다.

### ServerError가 보이는 경우

서버에서 온 에러 응답 코드가 500번대일 경우 ServerError 컴포넌트를 보여줍니다.

### 알 수 없는 에러일 경우

예상하지 못한 에러가 발생했을 경우 UnknownError 컴포넌트를 보여줍니다.


```typescript
export const ErrorBoundary = () => {
  const error = useRouteError();

  // ...

  // 
  if (
    (error instanceof Error && error.message === NOT_FOUND_ERROR_MESSAGE) ||
    isRouteErrorResponse(error)
  ) {
    return <NotFound />;
  }

  if (error instanceof HttpError && error.code >= 500) {
    return <ServerError />;
  }

  return <UnknownError />;
};
```
