### PR TITLE
[Hotfix] 로드 할 이미지가 없는 경우 use .. ImageState 의 로딩 상태가 변경되지 않던 버그 수정

### DIFF
--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -194,10 +194,22 @@ export const useInfiniteImageState = () => {
   const loadImage = async (source: string[]) => {
     const newImages = source.filter((src) => !imageState[src]);
     if (newImages.length === 0) {
+      // 처음 loadImages 가 호출 되었을 때 로드 할 이미지가 없을 수 있기 때문에
+      // 이미지 로딩 상태를 false 로 변경합니다.
+
+      if (isFirstPageImageLoading) {
+        setIsFirstPageImageLoading(false);
+      }
+
+      if (isImageLoading) {
+        setIsImageLoading(false);
+      }
+
       return;
     }
 
     setIsImageLoading(true);
+
     const imagePromises = await Promise.allSettled(
       newImages.map(
         (src) =>

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -110,8 +110,8 @@ interface ImageState {
 /**
  *  해당 훅은 훅 마운트 이후 source 데이터가 변경되지 않는 이미지 로딩에 사용 됩니다.
  */
-export const useImageState = (source?: string | string[]) => {
-  const [isLoading, setIsLoading] = useState(() => (source ? true : false));
+export const useImageState = (source: string | string[]) => {
+  const [isLoading, setIsLoading] = useState(true);
   const [imageState, setImageState] = useState<ImageState>({});
 
   const loadImage = async (source: string | string[]) => {

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -116,10 +116,6 @@ export const useImageState = (source: string | string[]) => {
 
   const loadImage = async (source: string | string[]) => {
     if (typeof source === "string") {
-      if (imageState[source]) {
-        return;
-      }
-
       setIsLoading(true);
 
       const img = new Image();
@@ -137,19 +133,9 @@ export const useImageState = (source: string | string[]) => {
       return;
     }
 
-    const newImages = source.filter((src) => !imageState[src]);
-
-    if (newImages.length === 0) {
-      if (isLoading) {
-        setIsLoading(false);
-      }
-
-      return;
-    }
-
     setIsLoading(true);
     const imagePromises = await Promise.allSettled(
-      newImages.map(
+      source.map(
         (src) =>
           new Promise<string>((resolve, reject) => {
             const img = new Image();
@@ -179,9 +165,7 @@ export const useImageState = (source: string | string[]) => {
   };
 
   useEffect(() => {
-    if (source) {
-      loadImage(source);
-    }
+    loadImage(source);
   }, [source]);
 
   return { isLoading, imageState };

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -116,11 +116,7 @@ export const useImageState = (source: string | string[]) => {
 
   const loadImage = async (source: string | string[]) => {
     if (typeof source === "string") {
-      if (!imageState[source]) {
-        if (isLoading) {
-          setIsLoading(false);
-        }
-
+      if (imageState[source]) {
         return;
       }
 

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -117,6 +117,10 @@ export const useImageState = (source: string | string[]) => {
   const loadImage = async (source: string | string[]) => {
     if (typeof source === "string") {
       if (!imageState[source]) {
+        if (isLoading) {
+          setIsLoading(false);
+        }
+
         return;
       }
 
@@ -138,7 +142,12 @@ export const useImageState = (source: string | string[]) => {
     }
 
     const newImages = source.filter((src) => !imageState[src]);
+
     if (newImages.length === 0) {
+      if (isLoading) {
+        setIsLoading(false);
+      }
+
       return;
     }
 


### PR DESCRIPTION
# 관련 이슈 번호
close #521 
# 설명

버그가 나타났던 원인은 `use ... ImageState` 를 호출하는 쿼리에서 로드 할 이미지가 없을 때  `is ... ImageLoading` 의 상태가 false 로 변경되지 않았기 때문에 발생했습니다. 

이러한 문제가 발생한 이유는 `loadImage` 메소드에서 로드 할 이미지가 없다면 로딩 상태를 변경시키지 않은 채로 얼리 리턴 했기 때문입니다.

이에 `useImageState , useInfiniteImageState` 에서 로드 할 이미지가 없어 얼리 리턴 전 만약 로딩 상태가 true 라면 false 로 변경 한 후 함수 스택을 종료 합니다. 

> 겸사 겸사 하면서 `useImageState` 의 인수를 컨디셔널에서 아닌걸로 바꿧습니다.
> 실제 사용처에서도 undefined 가 아닌 값만 이용해서 받고 있기도 하고 함수가 인수를 조건부적으로 받는게 좋지 않은 패턴이라고 봐서요 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
