### PR TITLE
[Refactor] 이메일 회원가입 테스트 코드 수정

### DIFF
--- a/src/features/auth/ui/signUpByEmailForm.stories.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.stories.tsx
@@ -394,7 +394,6 @@ export const Test: Story = {
 
             const $statusText =
               await canvas.findByText("비밀번호가 서로 일치하지 않습니다");
-
             expect($statusText).toBeInTheDocument();
             expect($statusText).toHaveClass(statusTextColor.invalid);
 
@@ -408,15 +407,6 @@ export const Test: Story = {
 
         await userEvent.clear($passwordInput);
         await userEvent.clear($passwordConfirmInput);
-
-        // ? status text 요소를 어떻게 찾아서 테스트할지 고민해보기
-        // await step(
-        //   "비밀번호 input 값과 입력값이 동일하면, 안내 문구를 표시하지 않는다.",
-        //   async () => {
-        //     await userEvent.type($passwordInput, invalidEmail);
-        //     await userEvent.type($passwordConfirmInput, invalidEmail);
-        //   },
-        // );
       });
 
       await step("비밀번호 input 값이 유효한 상태에서", async () => {

--- a/src/features/auth/ui/signUpByEmailForm.stories.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, userEvent, within } from "@storybook/test";
+import { expect, userEvent, waitFor, within } from "@storybook/test";
 import { OverlayPortal } from "@/app/OverlayPortal";
 import { useAuthStore } from "@/shared/store/auth";
 import { signUpByEmailHandlers } from "@/mocks/handler";
@@ -75,7 +75,7 @@ export const Test: Story = {
     const $passwordInput = canvasElement.querySelector("#password")!;
     const $passwordConfirmInput =
       canvasElement.querySelector("#password-confirm")!;
-    // const $submitButton = canvas.getByText("다음");
+    const $submitButton = canvas.getByText("다음");
 
     const validEmail = "hi@example.com";
     const invalidEmail = "invalid-email";
@@ -278,12 +278,6 @@ export const Test: Story = {
 
       await userEvent.clear($codeInput);
 
-      // ? 인증시간이 만료될 경우 테스트 작성 (인증 시간 만료된 경우를 어떻게 테스트하지)
-      //  인증시간이 만료되었습니다 재전송 버튼을 눌러주세요 에러 문구를 띄운다.
-      //  타이머도 빨간색으로 표시한다.
-      //  입력값을 모두 삭제한다.
-      //  [확인] 버튼이 비활성화된다.
-
       await step("인증 코드가 일치하지 않을 경우", async () => {
         await userEvent.type($codeInput, "7654321");
         await userEvent.click($checkCodeButton);
@@ -473,18 +467,18 @@ export const Test: Story = {
       });
     });
 
-    // await step(
-    //   "모든 input 값이 유효한 상태에서 [다음] 버튼 클릭 시, auth store에 token과 role이 저장된다.",
-    //   async () => {
-    //     await userEvent.click($submitButton);
+    await step(
+      "모든 input 값이 유효한 상태에서 [다음] 버튼 클릭 시, auth store에 token과 role이 저장된다.",
+      async () => {
+        await userEvent.click($submitButton);
 
-    //     await waitFor(() => {
-    //       const { token, role } = useAuthStore.getState();
+        await waitFor(() => {
+          const { token, role } = useAuthStore.getState();
 
-    //       expect(token).toBe("accessToken-ROLE_GUEST");
-    //       expect(role).toBe("ROLE_NONE");
-    //     });
-    // },
-    // );
+          expect(token).toBe("accessToken-ROLE_NONE");
+          expect(role).toBe("ROLE_NONE");
+        });
+      },
+    );
   },
 };

--- a/src/features/auth/ui/signUpByEmailForm.stories.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.stories.tsx
@@ -321,12 +321,12 @@ export const Test: Story = {
             expect($checkCodeButton).toBeDisabled();
           });
 
-          // await step('"인증되었습니다" 안내 문구를 띄운다.', async () => {
-          //   const $statusText = await canvas.findByText("인증되었습니다");
+          await step('"인증되었습니다" 안내 문구를 띄운다.', async () => {
+            const $statusText = await canvas.findByText("인증되었습니다");
 
-          //   expect($statusText).toBeInTheDocument();
-          //   expect($statusText).toHaveClass(statusTextColor.valid);
-          // });
+            expect($statusText).toBeInTheDocument();
+            expect($statusText).toHaveClass(statusTextColor.valid);
+          });
         },
       );
     });

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { EmailInput, PasswordInput } from "@/entities/auth/ui";
 import { useSnackBar } from "@/shared/lib";
 import { Button } from "@/shared/ui/button";
@@ -161,6 +161,8 @@ const SendCodeButton = () => {
 };
 
 const VerificationCode = () => {
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   const {
     checkCodeMutation,
     isModifiedCode,
@@ -180,6 +182,7 @@ const VerificationCode = () => {
   const verificationCodeRef = useRef<HTMLInputElement>(null);
 
   const isTimeOver = timeLeft === 0 && isSentCode;
+  const isError = isTimeOver || isNotMatchedCode;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value: verificationCode } = e.target;
@@ -193,28 +196,35 @@ const VerificationCode = () => {
     }
   };
 
-  let statusText = "인증코드 7자리를 입력해 주세요";
+  let statusText = "";
+  if (isFocused) statusText = "인증코드 7자리를 입력해 주세요";
   if (isVerified) statusText = "인증되었습니다";
   if (isNotMatchedCode) statusText = "인증코드를 다시 확인해 주세요";
   if (isTimeOver)
     statusText = "인증시간이 만료되었습니다. 재전송 버튼을 눌러주세요";
 
   return (
-    <Input
-      ref={verificationCodeRef}
-      componentType="outlinedText"
-      id="verification-code"
-      name="verificationCode"
-      type="text"
-      placeholder="인증코드 7자리를 입력해 주세요"
-      statusText={statusText}
-      maxLength={VERIFICATION_CODE_LENGTH}
-      value={verificationCode}
-      onChange={handleChange}
-      isError={isTimeOver || isNotMatchedCode}
-      disabled={!isSentCode || isVerified}
-      trailingNode={isSentCode && !isVerified && <Timer />}
-    />
+    <div className="w-full">
+      <Input
+        ref={verificationCodeRef}
+        componentType="outlinedText"
+        id="verification-code"
+        name="verificationCode"
+        type="text"
+        placeholder="인증코드 7자리를 입력해 주세요"
+        statusText={undefined}
+        maxLength={VERIFICATION_CODE_LENGTH}
+        value={verificationCode}
+        onChange={handleChange}
+        isError={isError}
+        disabled={!isSentCode || isVerified}
+        trailingNode={isSentCode && !isVerified && <Timer />}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+      />
+
+      <StatusText isError={isError}>{statusText}</StatusText>
+    </div>
   );
 };
 


### PR DESCRIPTION
# 관련 이슈 번호

#23

# 설명

1. 이메일 인증이 완료됐을 경우, 인증코드 input의 status text에서 "인증되었습니다" 텍스트 표시가 outfocus돼도 유지되도록 하였습니다.
    - 기존에는 Input 컴포넌트의 statusText props를 사용하고 있어서 outfocus되면 사라지는 문제가 발생했었습니다.
2. [다음] 버튼 테스트 코드 추가하였습니다.
3. 비밀번호 input과 비밀번호 확인 input에 유효하지 않은 비밀번호 값을 동시에 입력했을 경우의 테스트 코드를 삭제했습니다.
   - ex) 두 개의 input에 `!@#$@`를 입력했을 경우
   - 이 경우에는 비밀번호 확인 input의 status text가 표시되지 않기 때문에 테스트하기 어려울 것 같아 제거했습니다. 좋은 방법이 있다면 알려주세요!