### PR TITLE
[Hotfix] SnackbarController 내부 removeOverlay를 setSnackbarProps 내부로 이동

### DIFF
--- a/src/app/SnackbarController.tsx
+++ b/src/app/SnackbarController.tsx
@@ -5,10 +5,7 @@ import { Snackbar } from "@/shared/ui/snackbar";
 
 export const SnackbarController = () => {
   const addOverlay = useSnackBarStore((state) => state.addOverlay);
-  const removeOverlay = useSnackBarStore((state) => state.removeOverlay);
   const snackbarProps = useSnackBarStore((state) => state.snackbarProps);
-
-  removeOverlay(SNACKBAR_ID);
 
   useEffect(() => {
     if (snackbarProps === null) return;

--- a/src/shared/store/snackbar.ts
+++ b/src/shared/store/snackbar.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { SNACKBAR_ID } from "../constants";
 import { type OverlayStore, useOverlayStore } from "../store/overlay";
 import type { SnackBarProps } from "../ui/snackbar";
 
@@ -10,7 +11,7 @@ interface SnackbarStore extends OverlayStore {
   ) => void;
 }
 
-export const useSnackBarStore = create<SnackbarStore>((set) => ({
+export const useSnackBarStore = create<SnackbarStore>((set, get) => ({
   ...useOverlayStore.getState(),
 
   snackbarProps: null,
@@ -18,6 +19,8 @@ export const useSnackBarStore = create<SnackbarStore>((set) => ({
     children: SnackBarProps["children"],
     snackbarOptions?: Omit<SnackBarProps, "children">,
   ) => {
+    const removeOverlay = get().removeOverlay;
+    removeOverlay(SNACKBAR_ID);
     set({
       snackbarProps: {
         ...snackbarOptions,


### PR DESCRIPTION
# 관련 이슈 번호
close #538 
# 설명

스낵바 컨트롤러 내부에서 컴포넌트 렌더링 시 상태를 업데이트 하던 로직을 제거하고 

setSnackbarProps 메소드가 호출 될 때 removeOverlay를 호출하도록 기능을 수정했습니다. 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
