### PR TITLE
[Feat] 라우터 페이지 레이지 로딩 처리 

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -6,8 +6,12 @@ import { AppProviderLayout } from "./AppProviderLayout";
 
 const MainPage = lazy(() => import("@/pages/page"));
 
-const MapLayout = lazy(() => import("@/pages/map/layout"));
-const MapPage = lazy(() => import("@/pages/map/page"));
+const MapLayout = lazy(() =>
+  import("@/pages/map").then((module) => ({ default: module.MapLayout })),
+);
+const MapPage = lazy(() =>
+  import("@/pages/map").then((module) => ({ default: module.MapPage })),
+);
 const PlaceMarkingPage = lazy(() => import("@/pages/map/place"));
 const MyMarkingPage = lazy(() => import("@/pages/map/my"));
 const MyActivityList = lazy(() => import("@/widgets/map/ui"));

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -4,7 +4,7 @@ import { ROUTER_PATH } from "@/shared/constants";
 import { ErrorBoundary } from "../pages";
 import { AppProviderLayout } from "./AppProviderLayout";
 
-const MainPage = lazy(() => import("@/pages/page"));
+const MainPage = lazy(() => import("@/pages"));
 
 const MapLayout = lazy(() =>
   import("@/pages/map").then((module) => ({ default: module.MapLayout })),
@@ -22,12 +22,19 @@ const FollowingPage = lazy(() => import("@/pages/[nickname]/following"));
 const FollowerPage = lazy(() => import("@/pages/[nickname]/follower"));
 const NotFoundUser = lazy(() => import("@/pages/[nickname]/notFoundUser"));
 
-const LoginPage = lazy(() => import("@/pages/login/page"));
-const LoginLayout = lazy(() => import("@/pages/login/layout"));
-const EmailLoginPage = lazy(() => import("@/pages/login/email"));
+const LoginPage = lazy(() =>
+  import("@/pages/login").then((module) => ({
+    default: module.LoginPage,
+  })),
+);
 
-const SettingPage = lazy(() => import("@/pages/setting/page"));
-const EditInfoPage = lazy(() => import("@/pages/setting/edit-info/page"));
+const LoginLayout = lazy(() =>
+  import("@/pages/login").then((module) => ({ default: module.LoginLayout })),
+);
+
+const EmailLoginPage = lazy(() => import("@/pages/login/email"));
+const SettingPage = lazy(() => import("@/pages/setting"));
+const EditInfoPage = lazy(() => import("@/pages/setting/edit-info"));
 const AccountManagementPage = lazy(
   () => import("@/pages/setting/manage-account"),
 );
@@ -41,16 +48,8 @@ const TemporaryMarkingPage = lazy(() => import("@/pages/temporary-marking"));
 export const router = createBrowserRouter([
   {
     path: ROUTER_PATH.MAIN,
-    element: (
-      <Suspense>
-        <AppProviderLayout />
-      </Suspense>
-    ),
-    errorElement: (
-      <Suspense>
-        <ErrorBoundary />
-      </Suspense>
-    ),
+    element: <AppProviderLayout />,
+    errorElement: <ErrorBoundary />,
     children: [
       {
         index: true,

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,108 +1,197 @@
+import { lazy, Suspense } from "react";
 import { createBrowserRouter } from "react-router-dom";
-import { NotFoundUser, ProfilePage } from "@/pages/[nickname]";
-import { FollowerPage } from "@/pages/[nickname]/follower";
-import { FollowingPage } from "@/pages/[nickname]/following";
-import { UserMarkingPage } from "@/pages/[nickname]/marking";
-import { LoginPage, LoginLayout } from "@/pages/login";
-import { EmailLoginPage } from "@/pages/login/email";
-import { MapLayout, MapPage } from "@/pages/map";
-import { MyMarkingPage } from "@/pages/map/my";
-import { PlaceMarkingPage } from "@/pages/map/place";
-import { SettingPage } from "@/pages/setting";
-import { EditInfoPage } from "@/pages/setting/edit-info/page";
-import { AccountManagementPage } from "@/pages/setting/manage-account";
-import { SignUpPage } from "@/pages/sign-up";
-import PetInfoPage from "@/pages/sign-up/pet-info/page";
-import { UserInfoRegistrationPage } from "@/pages/sign-up/user-info";
-import { TemporaryMarkingPage } from "@/pages/temporary-marking";
-import { MyActivityList } from "@/widgets/map/ui";
 import { ROUTER_PATH } from "@/shared/constants";
-import { ErrorBoundary, MainPage } from "../pages";
+import { ErrorBoundary } from "../pages";
 import { AppProviderLayout } from "./AppProviderLayout";
+
+const MainPage = lazy(() => import("@/pages/page"));
+
+const MapLayout = lazy(() => import("@/pages/map/layout"));
+const MapPage = lazy(() => import("@/pages/map/page"));
+const PlaceMarkingPage = lazy(() => import("@/pages/map/place"));
+const MyMarkingPage = lazy(() => import("@/pages/map/my"));
+const MyActivityList = lazy(() => import("@/widgets/map/ui"));
+
+const ProfilePage = lazy(() => import("@/pages/[nickname]"));
+const UserMarkingPage = lazy(() => import("@/pages/[nickname]/marking"));
+const FollowingPage = lazy(() => import("@/pages/[nickname]/following"));
+const FollowerPage = lazy(() => import("@/pages/[nickname]/follower"));
+const NotFoundUser = lazy(() => import("@/pages/[nickname]/notFoundUser"));
+
+const LoginPage = lazy(() => import("@/pages/login/page"));
+const LoginLayout = lazy(() => import("@/pages/login/layout"));
+const EmailLoginPage = lazy(() => import("@/pages/login/email"));
+
+const SettingPage = lazy(() => import("@/pages/setting/page"));
+const EditInfoPage = lazy(() => import("@/pages/setting/edit-info/page"));
+const AccountManagementPage = lazy(
+  () => import("@/pages/setting/manage-account"),
+);
+const SignUpPage = lazy(() => import("@/pages/sign-up"));
+const PetInfoPage = lazy(() => import("@/pages/sign-up/pet-info"));
+const UserInfoRegistrationPage = lazy(
+  () => import("@/pages/sign-up/user-info"),
+);
+const TemporaryMarkingPage = lazy(() => import("@/pages/temporary-marking"));
 
 export const router = createBrowserRouter([
   {
     path: ROUTER_PATH.MAIN,
-    element: <AppProviderLayout />,
-    errorElement: <ErrorBoundary />,
+    element: (
+      <Suspense>
+        <AppProviderLayout />
+      </Suspense>
+    ),
+    errorElement: (
+      <Suspense>
+        <ErrorBoundary />
+      </Suspense>
+    ),
     children: [
       {
         index: true,
-        element: <MainPage />, // 지도로 라우팅 시키는 경로 , 추후 탐색 페이지로 변경 되어야 함
+        element: (
+          <Suspense>
+            <MainPage />
+          </Suspense>
+        ),
       },
       {
         path: ROUTER_PATH.MAP,
-        element: <MapLayout />, // 지도
+        element: (
+          <Suspense>
+            <MapLayout />
+          </Suspense>
+        ),
         children: [
           {
             index: true,
-            element: <MapPage />,
+            element: (
+              <Suspense>
+                <MapPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.PLACE,
-            element: <PlaceMarkingPage />,
+            element: (
+              <Suspense>
+                <PlaceMarkingPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.MY_MARK,
-            element: <MyMarkingPage />,
+            element: (
+              <Suspense>
+                <MyMarkingPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.MY_ACTIVITY,
-            element: <MyActivityList />,
+            element: (
+              <Suspense>
+                <MyActivityList />
+              </Suspense>
+            ),
           },
         ],
       },
       {
         path: ROUTER_PATH.PROFILE,
-        errorElement: <NotFoundUser />,
+        errorElement: (
+          <Suspense>
+            <NotFoundUser />
+          </Suspense>
+        ),
         children: [
           {
             index: true,
-            element: <ProfilePage />,
+            element: (
+              <Suspense>
+                <ProfilePage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.USER_MARKING,
-            element: <UserMarkingPage />,
+            element: (
+              <Suspense>
+                <UserMarkingPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.FOLLOWINGS,
-            element: <FollowingPage />,
+            element: (
+              <Suspense>
+                <FollowingPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.FOLLOWERS,
-            element: <FollowerPage />,
+            element: (
+              <Suspense>
+                <FollowerPage />
+              </Suspense>
+            ),
           },
         ],
       },
-
       {
         path: ROUTER_PATH.SETTING,
         children: [
           {
             index: true,
-            element: <SettingPage />,
+            element: (
+              <Suspense>
+                <SettingPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.MANAGE_ACCOUNT,
-            element: <AccountManagementPage />,
+            element: (
+              <Suspense>
+                <AccountManagementPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.EDIT_MY_INFO,
-            element: <EditInfoPage />,
+            element: (
+              <Suspense>
+                <EditInfoPage />
+              </Suspense>
+            ),
           },
         ],
       },
       {
         path: ROUTER_PATH.LOGIN,
-        element: <LoginLayout />,
+        element: (
+          <Suspense>
+            <LoginLayout />
+          </Suspense>
+        ),
         children: [
           {
             index: true,
-            element: <LoginPage />,
+            element: (
+              <Suspense>
+                <LoginPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.LOGIN_BY_EMAIL,
-            element: <EmailLoginPage />,
+            element: (
+              <Suspense>
+                <EmailLoginPage />
+              </Suspense>
+            ),
           },
         ],
       },
@@ -111,21 +200,37 @@ export const router = createBrowserRouter([
         children: [
           {
             index: true,
-            element: <SignUpPage />,
+            element: (
+              <Suspense>
+                <SignUpPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.SIGN_UP_USER_INFO,
-            element: <UserInfoRegistrationPage />,
+            element: (
+              <Suspense>
+                <UserInfoRegistrationPage />
+              </Suspense>
+            ),
           },
           {
             path: ROUTER_PATH.SIGN_UP_PET_INFO,
-            element: <PetInfoPage />,
+            element: (
+              <Suspense>
+                <PetInfoPage />
+              </Suspense>
+            ),
           },
         ],
       },
       {
         path: ROUTER_PATH.TEMPORARY_MARKING,
-        element: <TemporaryMarkingPage />,
+        element: (
+          <Suspense>
+            <TemporaryMarkingPage />
+          </Suspense>
+        ),
       },
     ],
   },

--- a/src/features/marking/ui/markingFormModal.stories.tsx
+++ b/src/features/marking/ui/markingFormModal.stories.tsx
@@ -4,7 +4,8 @@ import { GoogleMapsProvider } from "@/app/GoogleMapsProvider";
 // ! 이 부분은 테스트를 위해 FSD 구조를 무시합니다. 실제 구현 시에는 app 레이어에 존재하는 컴포넌트를 import 하지 마세요
 import { OverlayPortal } from "@/app/OverlayPortal";
 import { SnackbarController } from "@/app/SnackbarController";
-import { MapLayout, MapPage } from "@/pages/map";
+import MapLayout from "@/pages/map/layout";
+import MapPage from "@/pages/map/page";
 import { useAuthStore } from "@/shared/store";
 import { markingModalHandlers } from "@/mocks/handler";
 import { useMapStore } from "../../map/store";

--- a/src/features/marking/ui/markingFormModal.stories.tsx
+++ b/src/features/marking/ui/markingFormModal.stories.tsx
@@ -4,8 +4,7 @@ import { GoogleMapsProvider } from "@/app/GoogleMapsProvider";
 // ! 이 부분은 테스트를 위해 FSD 구조를 무시합니다. 실제 구현 시에는 app 레이어에 존재하는 컴포넌트를 import 하지 마세요
 import { OverlayPortal } from "@/app/OverlayPortal";
 import { SnackbarController } from "@/app/SnackbarController";
-import MapLayout from "@/pages/map/layout";
-import MapPage from "@/pages/map/page";
+import { MapLayout, MapPage } from "@/pages/map";
 import { useAuthStore } from "@/shared/store";
 import { markingModalHandlers } from "@/mocks/handler";
 import { useMapStore } from "../../map/store";

--- a/src/pages/[nickname]/follower/index.ts
+++ b/src/pages/[nickname]/follower/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/[nickname]/follower/page.tsx
+++ b/src/pages/[nickname]/follower/page.tsx
@@ -15,7 +15,7 @@ import { LoadingSpinner } from "@/shared/ui/spinner";
  * 팔로워 페이지의 경우 나의 페이지일 경우엔 팔로워 리스트를 보여주고
  * 남의 페이지의 경우엔 남의 팔로워를 보여주나 , 나와의 팔로잉 상태를 보여줘야 합니다.
  */
-export const FollowerPage = withAuth(() => {
+const FollowerPage = withAuth(() => {
   const { nicknameParams, isMyPage } = useNicknameParams();
   const { data: myProfile } = useGetMyProfile();
   const {
@@ -72,3 +72,5 @@ export const FollowerPage = withAuth(() => {
     </section>
   );
 }, ["ROLE_GUEST", "ROLE_USER"]);
+
+export default FollowerPage;

--- a/src/pages/[nickname]/following/index.ts
+++ b/src/pages/[nickname]/following/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/[nickname]/following/page.tsx
+++ b/src/pages/[nickname]/following/page.tsx
@@ -10,7 +10,7 @@ import { useInfiniteScroll, useNicknameParams, withAuth } from "@/shared/lib";
 import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 import { LoadingSpinner } from "@/shared/ui/spinner";
 
-export const FollowingPage = withAuth(() => {
+const FollowingPage = withAuth(() => {
   const { nicknameParams } = useNicknameParams();
 
   const { data: myProfile } = useGetMyProfile();
@@ -59,3 +59,5 @@ export const FollowingPage = withAuth(() => {
     </section>
   );
 }, ["ROLE_GUEST", "ROLE_USER"]);
+
+export default FollowingPage;

--- a/src/pages/[nickname]/index.ts
+++ b/src/pages/[nickname]/index.ts
@@ -1,2 +1,2 @@
-export * from "./page";
+export { default } from "./page";
 export * from "./notFoundUser";

--- a/src/pages/[nickname]/marking/index.ts
+++ b/src/pages/[nickname]/marking/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/[nickname]/marking/page.tsx
+++ b/src/pages/[nickname]/marking/page.tsx
@@ -21,7 +21,7 @@ import { DividerLine } from "@/shared/ui/divider";
 import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 import { LoadingSpinner } from "@/shared/ui/spinner";
 
-export const UserMarkingPage = withAuth(() => {
+const UserMarkingPage = withAuth(() => {
   const { nicknameParams, isMyPage } = useNicknameParams();
 
   const { sortTypeParam, setMapQueryParams } = useMapQueryParams();
@@ -64,6 +64,8 @@ export const UserMarkingPage = withAuth(() => {
     </>
   );
 }, ["ROLE_GUEST", "ROLE_USER"]);
+
+export default UserMarkingPage;
 
 interface MyMarkingListProps {
   nickname: string;

--- a/src/pages/[nickname]/notFoundUser.tsx
+++ b/src/pages/[nickname]/notFoundUser.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/shared/constants";
 import { useRouteHistoryStore } from "@/shared/store/history";
 
-export const NotFoundUser = () => {
+const NotFoundUser = () => {
   const error = useRouteError();
 
   if (
@@ -49,3 +49,5 @@ export const NotFoundUser = () => {
     </section>
   );
 };
+
+export default NotFoundUser;

--- a/src/pages/[nickname]/page.tsx
+++ b/src/pages/[nickname]/page.tsx
@@ -6,7 +6,7 @@ import { OtherProfilePage } from "./otherProfilePage";
  * 해당 컴포넌트는 /:nickname 경로로 들어온 사용자의 프로필 페이지를 나타냅니다.
  * @:nickname: 해당 닉네임을 가진 사용자의 프로필 페이지, 만약 AuthStore에 저장된 닉네임과 같다면 마이페이지처럼 이용 가능 합니다.
  */
-export const ProfilePage = withAuth(() => {
+const ProfilePage = withAuth(() => {
   const { isMyPage } = useNicknameParams();
 
   if (isMyPage) {
@@ -14,3 +14,5 @@ export const ProfilePage = withAuth(() => {
   }
   return <OtherProfilePage />;
 }, ["ROLE_GUEST", "ROLE_USER"]);
+
+export default ProfilePage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,4 @@
-export { default as MainPage } from "./page";
+export { default } from "./page";
 export * from "./notFound";
 export * from "./authError";
 export * from "./errorBoundary";

--- a/src/pages/login/email/index.ts
+++ b/src/pages/login/email/index.ts
@@ -1,1 +1,1 @@
-export { default as EmailLoginPage } from "./page";
+export { default } from "./page";

--- a/src/pages/map/index.ts
+++ b/src/pages/map/index.ts
@@ -1,2 +1,2 @@
-export * from "./layout";
-export * from "./page";
+export { default as MapLayout } from "./layout";
+export { default as MapPage } from "./page";

--- a/src/pages/map/layout.tsx
+++ b/src/pages/map/layout.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/widgets/map/ui";
 import { withAuth } from "@/shared/lib";
 
-export const MapLayout = withAuth(() => {
+const MapLayout = withAuth(() => {
   return (
     <>
       <header className="bg-tangerine-500 px-8 py-5">
@@ -27,3 +27,5 @@ export const MapLayout = withAuth(() => {
     </>
   );
 }, ["ROLE_GUEST", "ROLE_USER", null]);
+
+export default MapLayout;

--- a/src/pages/map/my/index.ts
+++ b/src/pages/map/my/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/map/my/page.tsx
+++ b/src/pages/map/my/page.tsx
@@ -3,7 +3,7 @@ import { MarkingPins } from "@/entities/map/ui";
 import { useGetMyMakerList } from "@/entities/marking/api";
 import { withAuth } from "@/shared/lib";
 
-export const MyMarkingPage = withAuth(() => {
+const MyMarkingPage = withAuth(() => {
   const { data } = useGetMyMakerList();
 
   return (
@@ -13,3 +13,5 @@ export const MyMarkingPage = withAuth(() => {
     </>
   );
 }, ["ROLE_USER"]);
+
+export default MyMarkingPage;

--- a/src/pages/map/page.tsx
+++ b/src/pages/map/page.tsx
@@ -3,7 +3,7 @@ import { useMapQueryParams } from "@/features/map/hooks";
 import { MarkingPins } from "@/entities/map/ui";
 import { useGetBoundaryMarkerList } from "@/entities/marking/api";
 
-export const MapPage = () => {
+const MapPage = () => {
   const { boundsParams } = useMapQueryParams();
   const { data } = useGetBoundaryMarkerList({
     ...boundsParams,
@@ -16,3 +16,5 @@ export const MapPage = () => {
     </>
   );
 };
+
+export default MapPage;

--- a/src/pages/map/place/index.ts
+++ b/src/pages/map/place/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/map/place/page.tsx
+++ b/src/pages/map/place/page.tsx
@@ -8,7 +8,7 @@ import { useMapStore } from "@/features/map/store";
 import { MarkingPins } from "@/entities/map/ui";
 import { useGetBoundaryMarkerList } from "@/entities/marking/api";
 
-export const PlaceMarkingPage = () => {
+const PlaceMarkingPage = () => {
   const { boundsParams } = useMapQueryParams();
   const { data } = useGetBoundaryMarkerList({
     ...boundsParams,
@@ -33,3 +33,5 @@ export const PlaceMarkingPage = () => {
     </>
   );
 };
+
+export default PlaceMarkingPage;

--- a/src/pages/setting/edit-info/index.ts
+++ b/src/pages/setting/edit-info/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/setting/edit-info/page.tsx
+++ b/src/pages/setting/edit-info/page.tsx
@@ -11,7 +11,7 @@ import { ActionChip } from "@/shared/ui/chip";
 import { ArrowRightIcon } from "@/shared/ui/icon";
 import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
-export const EditInfoPage = withAuth(() => {
+const EditInfoPage = withAuth(() => {
   const { data: myInfo } = useGetMyInfo();
 
   if (!myInfo) {
@@ -32,6 +32,8 @@ export const EditInfoPage = withAuth(() => {
     </>
   );
 }, ["ROLE_GUEST", "ROLE_USER"]);
+
+export default EditInfoPage;
 
 const EditInfoPageSkeleton = () => {
   return (

--- a/src/pages/setting/index.ts
+++ b/src/pages/setting/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/setting/manage-account/index.ts
+++ b/src/pages/setting/manage-account/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/setting/manage-account/page.tsx
+++ b/src/pages/setting/manage-account/page.tsx
@@ -10,7 +10,7 @@ import { DividerLine } from "@/shared/ui/divider";
 import { ArrowRightIcon } from "@/shared/ui/icon";
 import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
-export const AccountManagementPage = withAuth(() => {
+const AccountManagementPage = withAuth(() => {
   const { data: myInfo } = useGetMyInfo();
 
   if (!myInfo) {
@@ -31,6 +31,8 @@ export const AccountManagementPage = withAuth(() => {
     </>
   );
 }, ["ROLE_GUEST", "ROLE_USER"]);
+
+export default AccountManagementPage;
 
 const AccountManagementPageSkeleton = () => {
   return (

--- a/src/pages/setting/page.tsx
+++ b/src/pages/setting/page.tsx
@@ -7,7 +7,7 @@ import { DividerLine } from "@/shared/ui/divider";
 import { ArrowRightIcon } from "@/shared/ui/icon";
 import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
-export const SettingPage = withAuth(() => {
+const SettingPage = withAuth(() => {
   return (
     <>
       <section>
@@ -29,6 +29,8 @@ export const SettingPage = withAuth(() => {
     </>
   );
 }, ["ROLE_GUEST", "ROLE_USER"]);
+
+export default SettingPage;
 
 const AccountManagement = () => (
   <Link to={ROUTER_PATH.MANAGE_ACCOUNT} className="setting-item">

--- a/src/pages/setting/settingPage.stories.tsx
+++ b/src/pages/setting/settingPage.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { OverlayPortal } from "@/app/OverlayPortal";
 import { useAuthStore } from "@/shared/store";
-import { SettingPage } from "./page";
+import SettingPage from "./page";
 
 export default {
   title: "pages/my-page/setting",

--- a/src/pages/sign-up/index.ts
+++ b/src/pages/sign-up/index.ts
@@ -1,1 +1,1 @@
-export { default as SignUpPage } from "./page";
+export { default } from "./page";

--- a/src/pages/sign-up/pet-info/index.ts
+++ b/src/pages/sign-up/pet-info/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./page";

--- a/src/pages/sign-up/user-info/index.ts
+++ b/src/pages/sign-up/user-info/index.ts
@@ -1,1 +1,1 @@
-export { default as UserInfoRegistrationPage } from "./page";
+export { default } from "./page";

--- a/src/pages/temporary-marking/index.ts
+++ b/src/pages/temporary-marking/index.ts
@@ -1,1 +1,1 @@
-export * from "./page";
+export { default } from "./page";

--- a/src/pages/temporary-marking/page.tsx
+++ b/src/pages/temporary-marking/page.tsx
@@ -8,7 +8,7 @@ import { useInfiniteScroll, withAuth } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { BackwardNavigationBar } from "@/shared/ui/navigationBar";
 
-export const TemporaryMarkingPage = withAuth(() => {
+const TemporaryMarkingPage = withAuth(() => {
   const navigate = useNavigate();
 
   const nickname = useAuthStore((state) => state.nickname);
@@ -73,3 +73,5 @@ export const TemporaryMarkingPage = withAuth(() => {
     </>
   );
 }, ["ROLE_USER"]);
+
+export default TemporaryMarkingPage;

--- a/src/shared/lib/image.ts
+++ b/src/shared/lib/image.ts
@@ -166,7 +166,7 @@ export const useImageState = (source: string | string[]) => {
 
   useEffect(() => {
     loadImage(source);
-  }, [source]);
+  }, []);
 
   return { isLoading, imageState };
 };

--- a/src/widgets/map/ui/index.ts
+++ b/src/widgets/map/ui/index.ts
@@ -7,4 +7,4 @@ export * from "./mapBottomSheet";
 export * from "./localMarkingListBottomSheet";
 export * from "./placeMarkingListBottomSheet";
 export * from "./myMarkingListBottomSheet";
-export * from "./myActivityList";
+export { default } from "./myActivityList";

--- a/src/widgets/map/ui/myActivityList.tsx
+++ b/src/widgets/map/ui/myActivityList.tsx
@@ -8,7 +8,7 @@ import { useInfiniteScroll, withAuth } from "@/shared/lib";
 import { LoadingSpinner } from "@/shared/ui/spinner";
 import { MarkingList } from "./markingList";
 
-export const MyActivityList = withAuth(() => {
+const MyActivityList = withAuth(() => {
   const map = useMap();
 
   const [activeTab, setActiveTab] = useState<"LIKED" | "SAVED">("LIKED");
@@ -75,3 +75,5 @@ export const MyActivityList = withAuth(() => {
     </>
   );
 }, ["ROLE_GUEST", "ROLE_USER"]);
+
+export default MyActivityList;


### PR DESCRIPTION
# 관련 이슈 번호
close #534, #540 
# 설명

- createBrowser... 에서 모든 페이지와 레이아웃들을 lazy,suspense로 감싸 스플린팅 해주었습니다.
> 여러 레퍼스들에서 suspense를 레이아웃에서만 쓰는 경우도 있고, 안쓰는 경우도 있는데 저희의 경우엔 모두 해주지 않으면 정상적으로 동작하지 않습니다 .. 그래서 모든 페이지와 레이아웃에 서스펜스를 감싸주었습니다.

작업하면서 보니 내 마킹에서 이미지 로드가 무한번 지속되는 모습을 발견했습니다. 이는 `useImageState` 의 `loadImage` 를 호출하는 의존성 배열에 객체가 들어가기 때문임을 발견하고 의존성 배열에서 `source` 인수를 제거 했습니다

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
