### PR TITLE
[Hotfix] 스낵바 컨트롤러 언마운트 후에 snackbarProps 상태가 유지되던 문제 해결

### DIFF
--- a/src/app/SnackbarController.tsx
+++ b/src/app/SnackbarController.tsx
@@ -6,9 +6,16 @@ import { Snackbar } from "@/shared/ui/snackbar";
 export const SnackbarController = () => {
   const addOverlay = useSnackBarStore((state) => state.addOverlay);
   const snackbarProps = useSnackBarStore((state) => state.snackbarProps);
+  const setSnackbarProps = useSnackBarStore((state) => state.setSnackbarProps);
 
   useEffect(() => {
-    if (snackbarProps === null) return;
+    return () => {
+      setSnackbarProps(null);
+    };
+  }, [setSnackbarProps]);
+
+  useEffect(() => {
+    if (snackbarProps.children === null) return;
 
     const { children, ...snackbarOptions } = snackbarProps;
     addOverlay({
@@ -18,7 +25,7 @@ export const SnackbarController = () => {
         disableInteraction: false,
       },
     });
-  }, [snackbarProps, addOverlay]);
+  }, [snackbarProps, addOverlay, setSnackbarProps]);
 
   return null;
 };

--- a/src/app/SnackbarController.tsx
+++ b/src/app/SnackbarController.tsx
@@ -19,11 +19,13 @@ export const SnackbarController = () => {
         disableInteraction: false,
       },
     });
+  }, [snackbarProps, addOverlay]);
 
+  useEffect(() => {
     return () => {
       setSnackbarProps(null);
     };
-  }, [snackbarProps, addOverlay, setSnackbarProps]);
+  }, [setSnackbarProps]);
 
   return null;
 };

--- a/src/app/SnackbarController.tsx
+++ b/src/app/SnackbarController.tsx
@@ -9,12 +9,6 @@ export const SnackbarController = () => {
   const setSnackbarProps = useSnackBarStore((state) => state.setSnackbarProps);
 
   useEffect(() => {
-    return () => {
-      setSnackbarProps(null);
-    };
-  }, [setSnackbarProps]);
-
-  useEffect(() => {
     if (snackbarProps.children === null) return;
 
     const { children, ...snackbarOptions } = snackbarProps;
@@ -25,6 +19,10 @@ export const SnackbarController = () => {
         disableInteraction: false,
       },
     });
+
+    return () => {
+      setSnackbarProps(null);
+    };
   }, [snackbarProps, addOverlay, setSnackbarProps]);
 
   return null;

--- a/src/shared/store/snackbar.ts
+++ b/src/shared/store/snackbar.ts
@@ -4,7 +4,7 @@ import { type OverlayStore, useOverlayStore } from "../store/overlay";
 import type { SnackBarProps } from "../ui/snackbar";
 
 interface SnackbarStore extends OverlayStore {
-  snackbarProps: SnackBarProps | null;
+  snackbarProps: SnackBarProps;
   setSnackbarProps: (
     children: SnackBarProps["children"],
     snackbarOptions?: Omit<SnackBarProps, "children">,
@@ -14,7 +14,7 @@ interface SnackbarStore extends OverlayStore {
 export const useSnackBarStore = create<SnackbarStore>((set, get) => ({
   ...useOverlayStore.getState(),
 
-  snackbarProps: null,
+  snackbarProps: { children: null },
   setSnackbarProps: (
     children: SnackBarProps["children"],
     snackbarOptions?: Omit<SnackBarProps, "children">,


### PR DESCRIPTION
# 관련 이슈 번호
close #542 
#533 
# 설명
![dsfdsfds](https://github.com/user-attachments/assets/bd3c8af5-1d1c-43ba-b8cd-34f083657658)

버그의 원인은 에러가 발생해 ErrorBoundary 컴포넌트가 마운트 되면 / 경로의 엘리먼트가 언마운트, 에러 바운더리가 마운트 되는 것이 원인이였습니다.

에러 바운더리에서 로그인 하기 버튼을 눌러 다시 `AppProvider...` 컴포넌트가 마운트 되면서 `SnackbarController` 가 다시 마운트 되고 이로 인해 이펙트문이 발동하여 이전에 장착한 스낵바가 다시 오버레이에 추가 되었습니다. 

이를 방지하기 위해 스낵바 컨트롤러에서 클린업 메소드를 붙혀 해당 버그를 수정 했습니다.

```tsx
export const SnackbarController = () => {
  const addOverlay = useSnackBarStore((state) => state.addOverlay);
  const snackbarProps = useSnackBarStore((state) => state.snackbarProps);
  const setSnackbarProps = useSnackBarStore((state) => state.setSnackbarProps);

  useEffect(() => {
    return () => {
      setSnackbarProps(null);
    };
  }, [setSnackbarProps]);

  useEffect(() => {
    if (snackbarProps.children === null) return;
```

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
