### PR TITLE
[Feat] useGetMyProfile staleTime infinity 로 변경

### DIFF
--- a/src/app/FooterNavigationBar.tsx
+++ b/src/app/FooterNavigationBar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from "react-router-dom";
-import { useGetProfile } from "@/entities/profile/api";
+import { useGetMyProfile } from "@/entities/profile/api";
 import { EmptyProfileImage, ProfileImage } from "@/entities/profile/ui";
 import { ROUTER_PATH } from "@/shared/constants";
 import { useAuthStore } from "@/shared/store";
@@ -31,10 +31,7 @@ export const FooterNavigationBar = () => {
 const MyPageNavLink = () => {
   const role = useAuthStore((state) => state.role);
   const nickname = useAuthStore((state) => state.nickname);
-
-  const { data } = useGetProfile({
-    nickname,
-  });
+  const { data } = useGetMyProfile();
 
   const { active, inactive, base } = footerNavigationBarStyles;
 

--- a/src/entities/profile/api/getProfile.ts
+++ b/src/entities/profile/api/getProfile.ts
@@ -45,6 +45,7 @@ export const useGetMyProfile = () => {
   return useQuery({
     queryKey: profileQueryKey.profile(nickname!),
     queryFn: nickname && token ? () => getProfile({ nickname }) : skipToken,
+    staleTime: Infinity,
     gcTime: 0,
     select: (data) => {
       const myFollowingIdsMap = makeIdsMap(data.followingsIds || []);

--- a/src/entities/profile/api/getProfile.ts
+++ b/src/entities/profile/api/getProfile.ts
@@ -38,14 +38,21 @@ const makeIdsMap = (ids: number[]) => {
   );
 };
 
-export const useGetMyProfile = () => {
+interface UseGetMyProfileParams {
+  staleTime: number;
+}
+
+export const useGetMyProfile = (
+  params: UseGetMyProfileParams = { staleTime: Infinity },
+) => {
+  const { staleTime } = params;
   const token = useAuthStore((state) => state.token);
   const nickname = useAuthStore((state) => state.nickname);
 
   return useQuery({
     queryKey: profileQueryKey.profile(nickname!),
     queryFn: nickname && token ? () => getProfile({ nickname }) : skipToken,
-    staleTime: Infinity,
+    staleTime,
     gcTime: 0,
     select: (data) => {
       const myFollowingIdsMap = makeIdsMap(data.followingsIds || []);

--- a/src/entities/profile/api/queryKey.ts
+++ b/src/entities/profile/api/queryKey.ts
@@ -1,7 +1,10 @@
+import { useAuthStore } from "@/shared/store";
+
 export const profileQueryKey = {
   profileAll: () => ["profile"],
   profile: (nickname: string) => [
     ...profileQueryKey.profileAll(),
     { nickname },
   ],
+  myProfile: () => profileQueryKey.profile(useAuthStore.getState().nickname!),
 };

--- a/src/features/follow/api/deleteFollowing.ts
+++ b/src/features/follow/api/deleteFollowing.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { profileQueryKey } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { FOLLOW_END_POINT } from "../constants";
 
@@ -12,7 +13,11 @@ export const useDeleteFollowing = () => {
     },
     onSuccess: (_data, nickname) => {
       queryClient.invalidateQueries({
-        queryKey: ["profile", nickname],
+        queryKey: profileQueryKey.profile(nickname),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
       });
     },
   });

--- a/src/features/follow/api/postFollowing.ts
+++ b/src/features/follow/api/postFollowing.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { profileQueryKey } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { FOLLOW_END_POINT } from "../constants";
 
@@ -12,7 +13,11 @@ export const usePostFollowing = () => {
       }),
     onSuccess: (_data, nickname) => {
       queryClient.invalidateQueries({
-        queryKey: ["profile", nickname],
+        queryKey: profileQueryKey.profile(nickname),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
       });
     },
   });

--- a/src/features/marking/api/deleteLikeMarking.ts
+++ b/src/features/marking/api/deleteLikeMarking.ts
@@ -7,6 +7,7 @@ import { useMapMode } from "@/features/map/hooks";
 import type { GetMyLikedMarkingListResponse } from "@/entities/marking/api";
 import { markingQueryKey } from "@/entities/marking/api";
 import type { Marking } from "@/entities/marking/types/server";
+import { profileQueryKey } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -49,6 +50,9 @@ export const useDeleteLikeMarking = () => {
           queryKey: markingQueryKey.myActivityMarkingList("LIKED"),
         });
       }
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
+      });
     },
   });
 };

--- a/src/features/marking/api/deleteSavedMarking.ts
+++ b/src/features/marking/api/deleteSavedMarking.ts
@@ -7,6 +7,7 @@ import { useMapMode } from "@/features/map/hooks";
 import { GetMySavedMarkingListResponse } from "@/entities/marking/api";
 import { markingQueryKey } from "@/entities/marking/api";
 import type { Marking } from "@/entities/marking/types/server";
+import { profileQueryKey } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -49,6 +50,10 @@ export const useDeleteSavedMarking = () => {
           queryKey: markingQueryKey.myActivityMarkingList("SAVED"),
         });
       }
+
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
+      });
     },
   });
 };

--- a/src/features/marking/api/deleteTemporaryMarking.ts
+++ b/src/features/marking/api/deleteTemporaryMarking.ts
@@ -6,6 +6,7 @@ import {
 import type { GetTemporaryMarkingListResponse } from "@/entities/marking/api";
 import { markingQueryKey } from "@/entities/marking/api";
 import type { TempMarking } from "@/entities/marking/types/server";
+import { profileQueryKey } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -46,6 +47,9 @@ export const useDeleteTemporaryMarking = () => {
       );
       queryClient.invalidateQueries({
         queryKey: markingQueryKey.myTemporaryMarkingList(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
       });
     },
   });

--- a/src/features/marking/api/postAddTempMarking.tsx
+++ b/src/features/marking/api/postAddTempMarking.tsx
@@ -1,6 +1,7 @@
 // Marking Form 임시 저장 API
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMapStore } from "@/features/map/store";
+import { profileQueryKey } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { useSnackBarStore } from "@/shared/store";
 import { MARKING_END_POINT } from "../constants";
@@ -47,6 +48,7 @@ export const usePostAddTempMarking = () => {
   );
   const setMode = useMapStore((state) => state.setMode);
   const setSnackbarProps = useSnackBarStore((state) => state.setSnackbarProps);
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationKey: ["markingFormModal"],
@@ -63,7 +65,11 @@ export const usePostAddTempMarking = () => {
           type: "map",
         },
       );
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
+      });
     },
+
     onError: (error) => {
       console.error(error);
     },

--- a/src/features/marking/api/postLikeMarking.ts
+++ b/src/features/marking/api/postLikeMarking.ts
@@ -1,5 +1,6 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { Marking } from "@/entities/marking/types/server";
+import { profileQueryKey } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -8,10 +9,16 @@ interface PostLikeMarkingRequest {
 }
 
 export const usePostLikeMarking = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ markingId }: PostLikeMarkingRequest) =>
       apiClient.post(MARKING_END_POINT.LIKE(markingId), {
         withToken: true,
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
+      });
+    },
   });
 };

--- a/src/features/marking/api/postSaveMarking.ts
+++ b/src/features/marking/api/postSaveMarking.ts
@@ -1,5 +1,6 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { Marking } from "@/entities/marking/types/server";
+import { profileQueryKey } from "@/entities/profile/api";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
 
@@ -14,7 +15,14 @@ const postSaveMarking = async ({ markingId }: PostSaveMarkingRequest) => {
 };
 
 export const usePostSaveMarking = () => {
+  const queryClient = useQueryClient();
+
   return useMutation<unknown, Error, PostSaveMarkingRequest>({
     mutationFn: postSaveMarking,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
+      });
+    },
   });
 };

--- a/src/features/marking/api/putModifyMarking.ts
+++ b/src/features/marking/api/putModifyMarking.ts
@@ -10,6 +10,7 @@ import type {
   MarkingImage,
   Marker,
 } from "@/entities/marking/types/server";
+import { profileQueryKey } from "@/entities/profile/api";
 import { ROUTER_PATH } from "@/shared/constants";
 import { apiClient } from "@/shared/lib";
 import { MARKING_END_POINT } from "../constants";
@@ -125,6 +126,10 @@ export const usePutModifyMarking = ({
         }
 
         queryClient.invalidateQueries({ queryKey: [queryKey] });
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: profileQueryKey.myProfile(),
       });
     },
   });

--- a/src/features/setting/api/putChangePetInfo.ts
+++ b/src/features/setting/api/putChangePetInfo.ts
@@ -2,7 +2,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { profileQueryKey } from "@/entities/profile/api";
 import type { PetInfo } from "@/entities/profile/types/server";
 import { apiClient } from "@/shared/lib";
-import { useAuthStore } from "@/shared/store";
 import { SETTING_END_POINT } from "../constants";
 
 export interface PutChangePetInfoRequest
@@ -30,18 +29,16 @@ const putChangePetInfo = async ({
 
 export const usePutChangePetInfo = () => {
   const queryClient = useQueryClient();
-  const nickname = useAuthStore((state) => state.nickname);
 
   return useMutation<unknown, Error, PutChangePetInfoRequest>({
     mutationFn: putChangePetInfo,
     mutationKey: ["putChangePetInfo"],
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: profileQueryKey.profile(nickname!),
+        queryKey: profileQueryKey.myProfile(),
       });
     },
     onError: (error) => {
-      // TODO 에러 바운더리 나오면 수정 하기
       console.error(error);
     },
   });

--- a/src/pages/[nickname]/myProfilePage.tsx
+++ b/src/pages/[nickname]/myProfilePage.tsx
@@ -1,23 +1,35 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { MarkingThumbnailGrid } from "@/widgets/marking/ui";
 import {
   EmptyMyProfileOverView,
   MyProfileOverview,
 } from "@/widgets/profile/ui";
 import { TemporaryMarkingBar } from "@/entities/marking/ui";
-import { useGetMyProfile } from "@/entities/profile/api";
+import { profileQueryKey, useGetMyProfile } from "@/entities/profile/api";
 import { ROUTER_PATH } from "@/shared/constants";
-import { useNicknameParams } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { SettingIcon } from "@/shared/ui/icon";
 import { NavigationBar } from "@/shared/ui/navigationBar";
 import { ProfilePageSkeleton } from "./loading";
 
 export const MyProfilePage = () => {
-  const { nicknameParams } = useNicknameParams();
-  const { data } = useGetMyProfile();
+  const [haveMyProfileInvalidated, setHaveMyProfileInvalidated] =
+    useState<boolean>(false);
 
-  if (!data) {
+  const nickname = useAuthStore((state) => state.nickname);
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useGetMyProfile();
+
+  useEffect(() => {
+    queryClient.invalidateQueries({
+      queryKey: profileQueryKey.profile(nickname!),
+    });
+    setHaveMyProfileInvalidated(true);
+  }, [queryClient, nickname]);
+
+  if (!data || !haveMyProfileInvalidated || isLoading) {
     return <ProfilePageSkeleton />;
   }
 
@@ -29,7 +41,7 @@ export const MyProfilePage = () => {
       <section className="px-4 flex flex-col items-start gap-8">
         {pet ? (
           <MyProfileOverview
-            nickname={nicknameParams}
+            nickname={nickname!}
             followersIds={followersIds}
             followingsIds={followingsIds}
             pet={pet}
@@ -42,7 +54,7 @@ export const MyProfilePage = () => {
           {typeof tempCnt === "number" && tempCnt > 0 && (
             <TemporaryMarkingBar tempCnt={tempCnt} />
           )}
-          <MarkingThumbnailGrid nickname={nicknameParams} />
+          <MarkingThumbnailGrid nickname={nickname!} />
         </div>
       </section>
     </>

--- a/src/pages/[nickname]/myProfilePage.tsx
+++ b/src/pages/[nickname]/myProfilePage.tsx
@@ -24,7 +24,7 @@ export const MyProfilePage = () => {
 
   useEffect(() => {
     queryClient.invalidateQueries({
-      queryKey: profileQueryKey.profile(nickname!),
+      queryKey: profileQueryKey.myProfile(),
     });
     setHaveMyProfileInvalidated(true);
   }, [queryClient, nickname]);

--- a/src/pages/[nickname]/myProfilePage.tsx
+++ b/src/pages/[nickname]/myProfilePage.tsx
@@ -1,13 +1,11 @@
-import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 import { MarkingThumbnailGrid } from "@/widgets/marking/ui";
 import {
   EmptyMyProfileOverView,
   MyProfileOverview,
 } from "@/widgets/profile/ui";
 import { TemporaryMarkingBar } from "@/entities/marking/ui";
-import { profileQueryKey, useGetMyProfile } from "@/entities/profile/api";
+import { useGetMyProfile } from "@/entities/profile/api";
 import { ROUTER_PATH } from "@/shared/constants";
 import { useAuthStore } from "@/shared/store";
 import { SettingIcon } from "@/shared/ui/icon";
@@ -15,21 +13,10 @@ import { NavigationBar } from "@/shared/ui/navigationBar";
 import { ProfilePageSkeleton } from "./loading";
 
 export const MyProfilePage = () => {
-  const [haveMyProfileInvalidated, setHaveMyProfileInvalidated] =
-    useState<boolean>(false);
-
   const nickname = useAuthStore((state) => state.nickname);
-  const queryClient = useQueryClient();
-  const { data, isLoading } = useGetMyProfile();
+  const { data, isLoading } = useGetMyProfile({ staleTime: 0 });
 
-  useEffect(() => {
-    queryClient.invalidateQueries({
-      queryKey: profileQueryKey.myProfile(),
-    });
-    setHaveMyProfileInvalidated(true);
-  }, [queryClient]);
-
-  if (!data || !haveMyProfileInvalidated || isLoading) {
+  if (!data || isLoading) {
     return <ProfilePageSkeleton />;
   }
 

--- a/src/pages/[nickname]/myProfilePage.tsx
+++ b/src/pages/[nickname]/myProfilePage.tsx
@@ -27,7 +27,7 @@ export const MyProfilePage = () => {
       queryKey: profileQueryKey.myProfile(),
     });
     setHaveMyProfileInvalidated(true);
-  }, [queryClient, nickname]);
+  }, [queryClient]);
 
   if (!data || !haveMyProfileInvalidated || isLoading) {
     return <ProfilePageSkeleton />;

--- a/src/widgets/map/ui/myMarkingListBottomSheet.tsx
+++ b/src/widgets/map/ui/myMarkingListBottomSheet.tsx
@@ -13,7 +13,7 @@ import {
   EmptyMyMarkingThumbnailGrid,
   TemporaryMarkingBar,
 } from "@/entities/marking/ui";
-import { useGetProfile } from "@/entities/profile/api";
+import { useGetMyProfile } from "@/entities/profile/api";
 import { useInfiniteScroll } from "@/shared/lib";
 import { useAuthStore } from "@/shared/store";
 import { DividerLine } from "@/shared/ui/divider";
@@ -23,7 +23,7 @@ import { MarkingList } from "./markingList";
 
 export const MyMarkingListBottomSheet = () => {
   const nickname = useAuthStore.getState().nickname;
-  const { data: profile } = useGetProfile({ nickname });
+  const { data: myProfile } = useGetMyProfile();
   const { sortTypeParam, setMapQueryParams, boundsParams } =
     useMapQueryParams();
   const sortTypeOption = ["RECENT", "POPULARITY", "DISTANCE"] as const;
@@ -37,9 +37,9 @@ export const MyMarkingListBottomSheet = () => {
       <h1 className="title-1 text-grey-900 py-4">내 마킹</h1>
 
       <section className="pb-4 flex flex-col gap-4">
-        {typeof profile?.tempCnt === "number" && profile.tempCnt > 0 && (
+        {typeof myProfile?.tempCnt === "number" && myProfile.tempCnt > 0 && (
           <div className="pt-4">
-            <TemporaryMarkingBar tempCnt={profile.tempCnt} />
+            <TemporaryMarkingBar tempCnt={myProfile.tempCnt} />
           </div>
         )}
         <div className="flex w-full justify-end">


### PR DESCRIPTION
# 관련 이슈 번호
close #402 
# 설명

`useGetMyProfile` 의 `staleTIme` 을 인피니티로 변경했습니다. 

다음과 같은 기능들이 추가, 수정 되었습니다.

 1. useGetMyProfile staleTIme infinity 로 수정 
 2. profileQueryKey 에서 myProfile 쿼리키 추가 
```tsx
export const profileQueryKey = {
  profileAll: () => ["profile"],
  profile: (nickname: string) => [
    ...profileQueryKey.profileAll(),
    { nickname },
  ],
  myProfile: () => profileQueryKey.profile(useAuthStore.getState().nickname!),
};
```
3. `myProfile` 쿼리키는 다음과 같은 경우 `invalidate` 됩니다. 

- `myProfilePage` 에 진입 했을 때 
```tsx
export const MyProfilePage = () => {
  const [haveMyProfileInvalidated, setHaveMyProfileInvalidated] =
    useState<boolean>(false);

  const nickname = useAuthStore((state) => state.nickname);
  const queryClient = useQueryClient();
  const { data, isLoading } = useGetMyProfile();

  useEffect(() => {
    queryClient.invalidateQueries({
      queryKey: profileQueryKey.myProfile(),
    });
    setHaveMyProfileInvalidated(true);
  }, [queryClient, nickname]);

  if (!data || !haveMyProfileInvalidated || isLoading) {
    return <ProfilePageSkeleton />;
  }
```

- `following` 추가 및 제거 
- 북마크 추가 및 제거 
- 좋아요 추가 및 제거 
- 임시 저장 게시글 추가 , 제거 및 수정 
- 펫 정보 수정 시 

4.  footerNavigationBar 는 이제 `useGetMyProfile` 을 이용해 정보를 렌더링 합니다. 
5. 내 마킹 리스트 바텀 시트는 `useGetProfile` 이 아닌  `useGetMyProfile` 을 이용 합니다. 

---

팔로잉, 팔로워 리스트 페이지에서 `useGetMyProfile` 을 다시 받아오지 않는 이유는  어차피 해당 페이지에선 `useGetMyProfile().followingIds` 만 사용 하기 때문입니다. 

`followingIds` 만 프레쉬하게 유지 된다면 팔로잉, 팔로워 리스트 페이지에서 `useGetMyProfile` 을 `invalidate` 할 필요가 없다고 판단했습니다. 





# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
