### PR TITLE
[Refactor] 로그인에서 persistLogin 제거

### DIFF
--- a/src/features/auth/api/postLogin.ts
+++ b/src/features/auth/api/postLogin.ts
@@ -10,7 +10,6 @@ import type { SignUpResponse } from "../types/server";
 export interface PostLoginRequest {
   email: string;
   password: string;
-  persistLogin: boolean;
 }
 
 const postLogin = async (formData: PostLoginRequest) => {

--- a/src/features/auth/store/form.ts
+++ b/src/features/auth/store/form.ts
@@ -8,7 +8,6 @@ interface LoginFormStore extends PostLoginRequest {
 
   setEmail: (email: string) => void;
   setPassword: (password: string) => void;
-  setPersistLogin: (persistLogin: boolean) => void;
   setIsValidEmail: (isEmailValidate: boolean) => void;
   setStatusText: (statusText: string) => void;
 }
@@ -16,13 +15,11 @@ interface LoginFormStore extends PostLoginRequest {
 export const useLoginFormStore = create<LoginFormStore>((set) => ({
   email: "",
   password: "",
-  persistLogin: false,
   isValidEmail: true,
   statusText: "이메일 형식으로 입력해 주세요",
 
   setEmail: (email: string) => set({ email }),
   setPassword: (password: string) => set({ password }),
-  setPersistLogin: (persistLogin: boolean) => set({ persistLogin }),
   setIsValidEmail: (isValidEmail: boolean) => set({ isValidEmail }),
   setStatusText: (statusText: string) => set({ statusText }),
 }));

--- a/src/features/auth/ui/loginForm.stories.tsx
+++ b/src/features/auth/ui/loginForm.stories.tsx
@@ -26,7 +26,6 @@ export const Default: StoryObj<typeof LoginForm> = {
     <LoginForm.Form>
       <LoginForm.Email />
       <LoginForm.Password />
-      <LoginForm.PersistLogin />
       <LoginForm.SubmitButton />
     </LoginForm.Form>
   ),
@@ -93,7 +92,6 @@ const ApiTestComponent = () => {
       <LoginForm.Form>
         <LoginForm.Email />
         <LoginForm.Password />
-        <LoginForm.PersistLogin />
         <LoginForm.SubmitButton />
       </LoginForm.Form>
     </>

--- a/src/features/auth/ui/loginForm.tsx
+++ b/src/features/auth/ui/loginForm.tsx
@@ -77,36 +77,12 @@ export const Password = () => {
   );
 };
 
-export const PersistLogin = () => {
-  const setPersistLogin = useLoginFormStore((state) => state.setPersistLogin);
-
-  const handlePersistLogin = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { checked } = e.target;
-    setPersistLogin(checked);
-  };
-
-  return (
-    <div className="flex items-center gap-1">
-      <input
-        type="checkbox"
-        id="rememberMe"
-        name="rememberMe"
-        onChange={handlePersistLogin}
-      />
-      <label htmlFor="rememberMe" className="btn-3 text-grey-700">
-        로그인 유지
-      </label>
-    </div>
-  );
-};
-
 export const SubmitButton = () => {
   const { mutate: postLoginForm } = usePostLogin();
   const setSnackbarProps = useSnackBarStore((state) => state.setSnackbarProps);
 
   const handleSubmit = () => {
-    const { email, password, isValidEmail, persistLogin } =
-      useLoginFormStore.getState();
+    const { email, password, isValidEmail } = useLoginFormStore.getState();
     const isEmailEmpty = email.length === 0;
     const isPasswordEmpty = password.length === 0;
 
@@ -114,7 +90,7 @@ export const SubmitButton = () => {
       setSnackbarProps("아이디 또는 비밀번호를 모두 입력해 주세요");
       return;
     }
-    postLoginForm({ email, password, persistLogin });
+    postLoginForm({ email, password });
   };
 
   return (

--- a/src/pages/login/email/page.tsx
+++ b/src/pages/login/email/page.tsx
@@ -11,7 +11,6 @@ const EmailLoginPage = () => {
       <LoginForm.Form>
         <LoginForm.Email />
         <LoginForm.Password />
-        <LoginForm.PersistLogin />
         <LoginForm.SubmitButton />
       </LoginForm.Form>
       <div className="flex flex-col items-center justify-center self-stretch">


### PR DESCRIPTION
# 관련 이슈 번호
clsoe #548 
# 설명

![image](https://github.com/user-attachments/assets/da510846-1852-4013-88bf-4d7dd869cda2)

postLogin 요청, LoginFormStore , 컴포넌트 단에서 모두 로그인 유지 파트를  제거했습니다. 

다만 postLogin 요청에서 persistLogin 부분이 없어도 서버 오류가 안생기는지는 배포 된 서버에서 확인해봐야 합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
