### PR TITLE
[Refactor] input 컴포넌트 props에서 statusText 삭제

### DIFF
--- a/src/entities/auth/ui/input.stories.tsx
+++ b/src/entities/auth/ui/input.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { within, userEvent, expect } from "@storybook/test";
-import { EmailInput, PasswordInput } from "./input";
+import { PasswordInput } from "./input";
 
 const meta: Meta = {
   title: "entities/auth/Input",
@@ -10,42 +10,6 @@ export default meta;
 
 type Story = StoryObj<typeof PasswordInput>;
 
-export const Email: Story = {
-  args: {
-    label: "이메일",
-    id: "email",
-    statusText: "",
-  },
-  argTypes: {
-    statusText: {
-      control: {
-        type: "text",
-      },
-    },
-    isError: {
-      control: {
-        type: "boolean",
-      },
-    },
-  },
-  render: (args) => {
-    const { isError } = args;
-
-    return (
-      <div className="w-[300px] border border-grey-300 px-2 py-2">
-        <EmailInput
-          {...args}
-          statusText={
-            isError
-              ? "올바른 이메일 형식으로 입력해 주세요"
-              : "이메일 형식으로 입력해 주세요"
-          }
-        />
-      </div>
-    );
-  },
-};
-
 export const Password: Story = {
   args: {
     label: "비밀번호",
@@ -53,11 +17,6 @@ export const Password: Story = {
     placeholder: "비밀번호를 입력해주세요",
   },
   argTypes: {
-    statusText: {
-      control: {
-        type: "text",
-      },
-    },
     isError: {
       control: {
         type: "boolean",
@@ -66,18 +25,9 @@ export const Password: Story = {
   },
 
   render: (args) => {
-    const { isError } = args;
-
     return (
       <div className="w-[300px] border border-grey-300 px-2 py-2">
-        <PasswordInput
-          {...args}
-          statusText={
-            isError
-              ? "비밀번호는 6자 이상이어야 합니다"
-              : "비밀번호를 입력해주세요"
-          }
-        />
+        <PasswordInput {...args} />
       </div>
     );
   },

--- a/src/entities/auth/ui/input.tsx
+++ b/src/entities/auth/ui/input.tsx
@@ -4,16 +4,6 @@ import { Input, type InputProps } from "@/shared/ui/input";
 
 type FixedInputProps = "type" | "componentType";
 
-export const EmailInput = (props: Omit<InputProps, FixedInputProps>) => (
-  <Input
-    type="email"
-    inputMode="email"
-    placeholder="이메일을 입력해주세요"
-    componentType="outlinedText"
-    {...props}
-  />
-);
-
 export const PasswordInput = (props: Omit<InputProps, FixedInputProps>) => {
   const [isVisibilityOn, setIsVisibilityOn] = useState<boolean>(false);
 

--- a/src/features/auth/ui/loginForm.tsx
+++ b/src/features/auth/ui/loginForm.tsx
@@ -67,7 +67,9 @@ export const Email = () => {
         onBlur={() => setIsFocused(false)}
         isError={isError}
       />
-      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+      <StatusText isError={isError}>
+        {isFocused || isError ? statusText : ""}
+      </StatusText>
     </InputWrapper>
   );
 };

--- a/src/features/auth/ui/loginForm.tsx
+++ b/src/features/auth/ui/loginForm.tsx
@@ -1,6 +1,8 @@
-import { EmailInput, PasswordInput } from "@/entities/auth/ui";
+import { useState } from "react";
+import { PasswordInput } from "@/entities/auth/ui";
 import { useSnackBarStore } from "@/shared/store";
 import { Button } from "@/shared/ui/button";
+import { Input, InputWrapper, StatusText } from "@/shared/ui/input";
 import { usePostLogin } from "../api";
 import { useLoginFormStore } from "../store";
 
@@ -21,6 +23,8 @@ export const Form = ({ children }: FormProps) => {
  * 폼에서 email,  에러 상태 , 상태 메시지 상태를 변경 시킵니다.
  */
 export const Email = () => {
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   const isValidEmail = useLoginFormStore((state) => state.isValidEmail);
   const statusText = useLoginFormStore((state) => state.statusText);
 
@@ -45,16 +49,26 @@ export const Email = () => {
     setIsValidEmail(isEmailEmpty || isValidEmail);
   };
 
+  const isError = !isValidEmail;
+
   return (
-    <EmailInput
-      id="email"
-      name="email"
-      label="이메일"
-      fullWidth
-      onChange={handleChange}
-      isError={!isValidEmail}
-      statusText={statusText}
-    />
+    <InputWrapper>
+      <Input
+        type="email"
+        inputMode="email"
+        placeholder="이메일을 입력해주세요"
+        componentType="outlinedText"
+        id="email"
+        name="email"
+        label="이메일"
+        fullWidth
+        onChange={handleChange}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        isError={isError}
+      />
+      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+    </InputWrapper>
   );
 };
 

--- a/src/features/auth/ui/loginForm.tsx
+++ b/src/features/auth/ui/loginForm.tsx
@@ -61,7 +61,6 @@ export const Email = () => {
         id="email"
         name="email"
         label="이메일"
-        fullWidth
         onChange={handleChange}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
@@ -87,7 +86,6 @@ export const Password = () => {
       id="password"
       name="password"
       label="비밀번호"
-      fullWidth
       onChange={handleChange}
     />
   );

--- a/src/features/auth/ui/nicknameInput.tsx
+++ b/src/features/auth/ui/nicknameInput.tsx
@@ -92,7 +92,7 @@ export const NicknameInput = forwardRef<HTMLInputElement, NicknameInputProps>(
             />
           }
         />
-        {isFocused && (
+        {(isFocused || isNicknameError) && (
           <StatusText isError={isNicknameError}>{statusText}</StatusText>
         )}
       </InputWrapper>

--- a/src/features/auth/ui/nicknameInput.tsx
+++ b/src/features/auth/ui/nicknameInput.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useState } from "react";
 import { useAuthStore } from "@/shared/store";
-import { Input } from "@/shared/ui/input";
+import { Input, InputWrapper, StatusText } from "@/shared/ui/input";
 import { usePostCheckDuplicateNickname } from "../api";
 import { validateNickname } from "../lib";
 
@@ -11,6 +11,7 @@ interface NicknameInputProps {
 
 export const NicknameInput = forwardRef<HTMLInputElement, NicknameInputProps>(
   ({ nickname: controlledNickname, onChange }, ref) => {
+    const [isFocused, setIsFocused] = useState<boolean>(false);
     const MAX_LENGTH = 20;
 
     const isControlled = typeof controlledNickname !== "undefined";
@@ -62,29 +63,39 @@ export const NicknameInput = forwardRef<HTMLInputElement, NicknameInputProps>(
       statusText = "사용 가능한 닉네임입니다.";
     }
 
+    const isNicknameError = !isValidNickname && !isNicknameEmpty;
+
     return (
-      <Input
-        ref={ref}
-        type="text"
-        id="nickname"
-        name="nickname"
-        label="닉네임"
-        placeholder="닉네임을 입력해 주세요"
-        statusText={statusText}
-        essential
-        componentType="outlinedText"
-        isError={!isValidNickname && !isNicknameEmpty}
-        value={isControlled ? controlledNickname : nickname}
-        onChange={handleChange}
-        onBlur={handleBlur}
-        maxLength={MAX_LENGTH}
-        trailingNode={
-          <ValueLength
-            value={isControlled ? controlledNickname : nickname}
-            maxLength={MAX_LENGTH}
-          />
-        }
-      />
+      <InputWrapper>
+        <Input
+          ref={ref}
+          type="text"
+          id="nickname"
+          name="nickname"
+          label="닉네임"
+          placeholder="닉네임을 입력해 주세요"
+          essential
+          componentType="outlinedText"
+          isError={isNicknameError}
+          value={isControlled ? controlledNickname : nickname}
+          onChange={handleChange}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => {
+            setIsFocused(false);
+            handleBlur();
+          }}
+          maxLength={MAX_LENGTH}
+          trailingNode={
+            <ValueLength
+              value={isControlled ? controlledNickname : nickname}
+              maxLength={MAX_LENGTH}
+            />
+          }
+        />
+        {isFocused && (
+          <StatusText isError={isNicknameError}>{statusText}</StatusText>
+        )}
+      </InputWrapper>
     );
   },
 );

--- a/src/features/auth/ui/petInformationForm.tsx
+++ b/src/features/auth/ui/petInformationForm.tsx
@@ -202,11 +202,11 @@ const NameInput = () => {
         isError={isError}
         essential
       />
-      {isFocused && (
-        <StatusText isError={isError}>
-          20자 이내의 한글 영문의 이름을 입력해 주세요
-        </StatusText>
-      )}
+      <StatusText isError={isError}>
+        {isFocused || isError
+          ? "20자 이내의 한글 영문의 이름을 입력해 주세요"
+          : ""}
+      </StatusText>
     </InputWrapper>
   );
 };

--- a/src/features/auth/ui/petInformationForm.tsx
+++ b/src/features/auth/ui/petInformationForm.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/shared/ui/button";
 import { Checkbox } from "@/shared/ui/checkbox";
 import { SelectChip } from "@/shared/ui/chip";
 import { EditIcon, SearchIcon } from "@/shared/ui/icon";
-import { Input } from "@/shared/ui/input";
+import { Input, InputWrapper, StatusText } from "@/shared/ui/input";
 import { Select } from "@/shared/ui/select";
 import { TextArea } from "@/shared/ui/textarea";
 import { personalities, dogBreeds } from "../constants/form";
@@ -182,20 +182,32 @@ const NameInput = () => {
     setName(filteredName);
   };
 
+  const isError = !isNameEmpty && !isValidName;
+
+  const [isFocused, setFocused] = useState<boolean>(false);
+
   return (
-    <Input
-      componentType="outlinedText"
-      id="name"
-      label="이름이 어떻게 되나요?"
-      placeholder="한글 또는 영문의 이름을 입력해 주세요"
-      maxLength={MAX_LENGTH}
-      trailingNode={<TextCounter text={name} maxLength={MAX_LENGTH} />}
-      value={name}
-      onChange={handleChange}
-      isError={!isNameEmpty && !isValidName}
-      statusText="20자 이내의 한글 영문의 이름을 입력해 주세요"
-      essential
-    />
+    <InputWrapper>
+      <Input
+        componentType="outlinedText"
+        id="name"
+        label="이름이 어떻게 되나요?"
+        placeholder="한글 또는 영문의 이름을 입력해 주세요"
+        maxLength={MAX_LENGTH}
+        trailingNode={<TextCounter text={name} maxLength={MAX_LENGTH} />}
+        value={name}
+        onChange={handleChange}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        isError={isError}
+        essential
+      />
+      {isFocused && (
+        <StatusText isError={isError}>
+          20자 이내의 한글 영문의 이름을 입력해 주세요
+        </StatusText>
+      )}
+    </InputWrapper>
   );
 };
 

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { EmailInput, PasswordInput } from "@/entities/auth/ui";
+import { PasswordInput } from "@/entities/auth/ui";
 import { useSnackBarStore } from "@/shared/store";
 import { Button } from "@/shared/ui/button";
-import { Input, StatusText } from "@/shared/ui/input";
+import { Input, InputWrapper, StatusText } from "@/shared/ui/input";
 import { usePostSignUpByEmail } from "../api";
 import { VERIFICATION_CODE_LENGTH } from "../constants";
 import {
@@ -64,6 +64,8 @@ const VerifyEmail = () => {
 };
 
 const Email = () => {
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   const {
     sendCodeMutation,
     checkCodeMutation,
@@ -103,18 +105,27 @@ const Email = () => {
       ? "이미 가입된 이메일 입니다"
       : "올바른 이메일 형식입니다";
 
+  const isError = (!isEmailEmpty && !isValidEmail) || isDuplicatedEmail;
+
   return (
-    <EmailInput
-      id="email"
-      name="email"
-      label="이메일"
-      disabled={isVerified}
-      isError={(!isEmailEmpty && !isValidEmail) || isDuplicatedEmail}
-      placeholder="이메일을 입력해 주세요"
-      statusText={statusText}
-      essential
-      onChange={handleChange}
-    />
+    <InputWrapper>
+      <Input
+        type="email"
+        inputMode="email"
+        placeholder="이메일을 입력해주세요"
+        componentType="outlinedText"
+        id="email"
+        name="email"
+        label="이메일"
+        disabled={isVerified}
+        isError={isError}
+        essential
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onChange={handleChange}
+      />
+      <StatusText isError={isError}>{isFocused ? statusText : ""}</StatusText>
+    </InputWrapper>
   );
 };
 
@@ -212,7 +223,6 @@ const VerificationCode = () => {
         name="verificationCode"
         type="text"
         placeholder="인증코드 7자리를 입력해 주세요"
-        statusText={undefined}
         maxLength={VERIFICATION_CODE_LENGTH}
         value={verificationCode}
         onChange={handleChange}
@@ -222,7 +232,6 @@ const VerificationCode = () => {
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
       />
-
       <StatusText isError={isError}>{statusText}</StatusText>
     </div>
   );
@@ -284,17 +293,21 @@ const Password = () => {
       ? ""
       : "비밀번호 형식에 맞게 입력해 주세요";
 
+  const isError = !isValidPassword && !isPasswordEmpty;
+
   return (
-    <PasswordInput
-      id="password"
-      label="비밀번호"
-      name="password"
-      placeholder="비밀번호를 입력해 주세요"
-      statusText={statusText}
-      essential
-      onChange={handleChange}
-      isError={!isValidPassword && !isPasswordEmpty}
-    />
+    <InputWrapper>
+      <PasswordInput
+        id="password"
+        label="비밀번호"
+        name="password"
+        placeholder="비밀번호를 입력해 주세요"
+        essential
+        onChange={handleChange}
+        isError={isError}
+      />
+      <StatusText isError={isError}>{statusText}</StatusText>
+    </InputWrapper>
   );
 };
 
@@ -335,7 +348,6 @@ const PasswordConfirm = () => {
           id="password-confirm"
           name="passwordConfirm"
           placeholder="비밀번호를 다시 한번 입력해 주세요"
-          statusText={undefined}
           essential
           onChange={handleChange}
           isError={!isConfirmPasswordEmpty && !isValidConfirmPassword}

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -295,6 +295,7 @@ const Password = () => {
       ? ""
       : "비밀번호 형식에 맞게 입력해 주세요";
 
+  const [isFocused, setIsFocused] = useState<boolean>(false);
   const isError = !isValidPassword && !isPasswordEmpty;
 
   return (
@@ -305,10 +306,14 @@ const Password = () => {
         name="password"
         placeholder="비밀번호를 입력해 주세요"
         essential
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
         onChange={handleChange}
         isError={isError}
       />
-      <StatusText isError={isError}>{statusText}</StatusText>
+      <StatusText isError={isError}>
+        {isFocused || isError ? statusText : ""}
+      </StatusText>
     </InputWrapper>
   );
 };
@@ -343,6 +348,10 @@ const PasswordConfirm = () => {
     setConfirmPassword(passwordConfirm);
   };
 
+  const isError = !isConfirmPasswordEmpty && !isValidConfirmPassword;
+
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   return (
     <>
       <InputWrapper>
@@ -352,12 +361,12 @@ const PasswordConfirm = () => {
           placeholder="비밀번호를 다시 한번 입력해 주세요"
           essential
           onChange={handleChange}
-          isError={!isConfirmPasswordEmpty && !isValidConfirmPassword}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          isError={isError}
         />
-        <StatusText
-          isError={!isConfirmPasswordEmpty && !isValidConfirmPassword}
-        >
-          {isConfirmPasswordEmpty ? "" : statusText}
+        <StatusText isError={isError}>
+          {isFocused || isError ? statusText : ""}
         </StatusText>
       </InputWrapper>
       <span className="body-3 px-3 pt-1 text-grey-500">

--- a/src/features/auth/ui/signUpByEmailForm.tsx
+++ b/src/features/auth/ui/signUpByEmailForm.tsx
@@ -124,7 +124,9 @@ const Email = () => {
         onBlur={() => setIsFocused(false)}
         onChange={handleChange}
       />
-      <StatusText isError={isError}>{isFocused ? statusText : ""}</StatusText>
+      <StatusText isError={isError}>
+        {isFocused || isError ? statusText : ""}
+      </StatusText>
     </InputWrapper>
   );
 };
@@ -215,7 +217,7 @@ const VerificationCode = () => {
     statusText = "인증시간이 만료되었습니다. 재전송 버튼을 눌러주세요";
 
   return (
-    <div className="w-full">
+    <InputWrapper>
       <Input
         ref={verificationCodeRef}
         componentType="outlinedText"
@@ -233,7 +235,7 @@ const VerificationCode = () => {
         onBlur={() => setIsFocused(false)}
       />
       <StatusText isError={isError}>{statusText}</StatusText>
-    </div>
+    </InputWrapper>
   );
 };
 
@@ -343,7 +345,7 @@ const PasswordConfirm = () => {
 
   return (
     <>
-      <div>
+      <InputWrapper>
         <PasswordInput
           id="password-confirm"
           name="passwordConfirm"
@@ -357,7 +359,7 @@ const PasswordConfirm = () => {
         >
           {isConfirmPasswordEmpty ? "" : statusText}
         </StatusText>
-      </div>
+      </InputWrapper>
       <span className="body-3 px-3 pt-1 text-grey-500">
         영문, 숫자, 특수문자 3가지 조합을 포함하는 8자 이상 15자 이내로 입력해
         주세요.

--- a/src/features/setting/ui/passwordChangeModal.tsx
+++ b/src/features/setting/ui/passwordChangeModal.tsx
@@ -43,7 +43,9 @@ const CurrentPasswordInput = () => {
         onChange={({ target }) => setCurrentPassword(target.value)}
         isError={isError}
       />
-      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+      {(isFocused || isError) && (
+        <StatusText isError={isError}>{statusText}</StatusText>
+      )}
     </InputWrapper>
   );
 };
@@ -83,7 +85,9 @@ const NewPasswordInput = () => {
         onChange={({ target }) => setNewPassword(target.value)}
         isError={isError}
       />
-      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+      {(isFocused || isError) && (
+        <StatusText isError={isError}>{statusText}</StatusText>
+      )}
     </InputWrapper>
   );
 };
@@ -124,7 +128,9 @@ const ConfirmNewPasswordInput = () => {
         onChange={({ target }) => setConfirmPassword(target.value)}
         isError={isError}
       />
-      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+      {(isFocused || isError) && (
+        <StatusText isError={isError}>{statusText}</StatusText>
+      )}
     </InputWrapper>
   );
 };

--- a/src/features/setting/ui/passwordChangeModal.tsx
+++ b/src/features/setting/ui/passwordChangeModal.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { PasswordInput } from "@/entities/auth/ui";
 import { useSnackBarStore } from "@/shared/store";
+import { InputWrapper, StatusText } from "@/shared/ui/input";
 import { Modal } from "@/shared/ui/modal";
 import { usePutChangePassword } from "../api";
 import { usePasswordChangeFormStore } from "../store";
@@ -25,17 +26,25 @@ const CurrentPasswordInput = () => {
       ? ""
       : "비밀번호 형식에 맞게 입력해 주세요";
 
+  const isError = isFilledCurrentPassword && !isValidPassword;
+
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   return (
-    <PasswordInput
-      id="current-password"
-      label="현재 비밀번호"
-      name="current-password"
-      placeholder="현재 비밀번호를 입력해주세요"
-      essential
-      onChange={({ target }) => setCurrentPassword(target.value)}
-      statusText={statusText}
-      isError={isFilledCurrentPassword && !isValidPassword}
-    />
+    <InputWrapper>
+      <PasswordInput
+        id="current-password"
+        label="현재 비밀번호"
+        name="current-password"
+        placeholder="현재 비밀번호를 입력해주세요"
+        essential
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onChange={({ target }) => setCurrentPassword(target.value)}
+        isError={isError}
+      />
+      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+    </InputWrapper>
   );
 };
 
@@ -57,17 +66,25 @@ const NewPasswordInput = () => {
       ? "사용가능한 비밀번호 입니다"
       : "비밀번호 형식에 맞게 입력해 주세요";
 
+  const isError = isFilledNewPassword && !isValidNewPassword;
+
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   return (
-    <PasswordInput
-      id="new-password"
-      label="새 비밀번호"
-      name="new-password"
-      placeholder="비밀번호를 입력해 주세요"
-      essential
-      onChange={({ target }) => setNewPassword(target.value)}
-      statusText={statusText}
-      isError={isFilledNewPassword && !isValidNewPassword}
-    />
+    <InputWrapper>
+      <PasswordInput
+        id="new-password"
+        label="새 비밀번호"
+        name="new-password"
+        placeholder="비밀번호를 입력해 주세요"
+        essential
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onChange={({ target }) => setNewPassword(target.value)}
+        isError={isError}
+      />
+      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+    </InputWrapper>
   );
 };
 
@@ -90,16 +107,25 @@ const ConfirmNewPasswordInput = () => {
       ? "비밀번호가 일치합니다"
       : "비밀번호가 서로 일치하지 않습니다";
 
+  const isError =
+    isFilledConfirmPassword && !isSameNewPasswordAndConfirmPassword;
+
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   return (
-    <PasswordInput
-      id="confirm-new-password"
-      name="confirm-new-password"
-      placeholder="비밀번호를 다시 한 번 입력해주세요"
-      essential
-      onChange={({ target }) => setConfirmPassword(target.value)}
-      statusText={statusText}
-      isError={isFilledConfirmPassword && !isSameNewPasswordAndConfirmPassword}
-    />
+    <InputWrapper>
+      <PasswordInput
+        id="confirm-new-password"
+        name="confirm-new-password"
+        placeholder="비밀번호를 다시 한 번 입력해주세요"
+        essential
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onChange={({ target }) => setConfirmPassword(target.value)}
+        isError={isError}
+      />
+      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+    </InputWrapper>
   );
 };
 

--- a/src/features/setting/ui/passwordChangeModal.tsx
+++ b/src/features/setting/ui/passwordChangeModal.tsx
@@ -43,9 +43,9 @@ const CurrentPasswordInput = () => {
         onChange={({ target }) => setCurrentPassword(target.value)}
         isError={isError}
       />
-      {(isFocused || isError) && (
-        <StatusText isError={isError}>{statusText}</StatusText>
-      )}
+      <StatusText isError={isError}>
+        {isError || isFocused ? statusText : ""}
+      </StatusText>
     </InputWrapper>
   );
 };
@@ -85,9 +85,9 @@ const NewPasswordInput = () => {
         onChange={({ target }) => setNewPassword(target.value)}
         isError={isError}
       />
-      {(isFocused || isError) && (
-        <StatusText isError={isError}>{statusText}</StatusText>
-      )}
+      <StatusText isError={isError}>
+        {isError || isFocused ? statusText : ""}
+      </StatusText>
     </InputWrapper>
   );
 };
@@ -128,9 +128,9 @@ const ConfirmNewPasswordInput = () => {
         onChange={({ target }) => setConfirmPassword(target.value)}
         isError={isError}
       />
-      {(isFocused || isError) && (
-        <StatusText isError={isError}>{statusText}</StatusText>
-      )}
+      <StatusText isError={isError}>
+        {isError || isFocused ? statusText : ""}
+      </StatusText>
     </InputWrapper>
   );
 };

--- a/src/features/setting/ui/passwordCheckModal.tsx
+++ b/src/features/setting/ui/passwordCheckModal.tsx
@@ -1,7 +1,8 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useIsMutating } from "@tanstack/react-query";
 import { PasswordInput } from "@/entities/auth/ui";
 import { InfoIcon } from "@/shared/ui/icon";
+import { InputWrapper, StatusText } from "@/shared/ui/input";
 import { Modal } from "@/shared/ui/modal";
 import { Notice } from "@/shared/ui/notice";
 import { useDeleteAccount } from "../api";
@@ -43,17 +44,25 @@ const CurrentPasswordInput = () => {
       ? ""
       : "비밀번호 형식에 맞게 입력해 주세요";
 
+  const isError = !isEmptyCurrentPassword && !isValidPassword;
+
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   return (
-    <PasswordInput
-      id="password"
-      label="현재 비밀번호"
-      statusText={statusText}
-      isError={!isEmptyCurrentPassword && !isValidPassword}
-      essential
-      onChange={({ target }) => {
-        setPassword(target.value);
-      }}
-    />
+    <InputWrapper>
+      <PasswordInput
+        id="password"
+        label="현재 비밀번호"
+        isError={isError}
+        essential
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onChange={({ target }) => {
+          setPassword(target.value);
+        }}
+      />
+      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+    </InputWrapper>
   );
 };
 

--- a/src/features/setting/ui/passwordCheckModal.tsx
+++ b/src/features/setting/ui/passwordCheckModal.tsx
@@ -61,7 +61,9 @@ const CurrentPasswordInput = () => {
           setPassword(target.value);
         }}
       />
-      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+      {(isFocused || isError) && (
+        <StatusText isError={isError}>{statusText}</StatusText>
+      )}
     </InputWrapper>
   );
 };

--- a/src/features/setting/ui/passwordSetModal.tsx
+++ b/src/features/setting/ui/passwordSetModal.tsx
@@ -42,7 +42,9 @@ const NewPasswordInput = () => {
         onChange={({ target }) => setNewPassword(target.value)}
         isError={isError}
       />
-      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+      {(isFocused || isError) && (
+        <StatusText isError={isError}>{statusText}</StatusText>
+      )}
     </InputWrapper>
   );
 };
@@ -84,7 +86,9 @@ const ConfirmNewPasswordInput = () => {
         isError={isError}
       />
 
-      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+      {(isFocused || isError) && (
+        <StatusText isError={isError}>{statusText}</StatusText>
+      )}
     </InputWrapper>
   );
 };

--- a/src/features/setting/ui/passwordSetModal.tsx
+++ b/src/features/setting/ui/passwordSetModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { PasswordInput } from "@/entities/auth/ui";
+import { InputWrapper, StatusText } from "@/shared/ui/input";
 import { Modal } from "@/shared/ui/modal";
 import { usePutSetPassword } from "../api";
 import { usePasswordSetFormStore } from "../store";
@@ -24,17 +25,25 @@ const NewPasswordInput = () => {
       ? "사용가능한 비밀번호 입니다"
       : "비밀번호 형식에 맞게 입력해 주세요";
 
+  const isError = isFilledNewPassword && !isValidNewPassword;
+
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   return (
-    <PasswordInput
-      id="new-password"
-      label="새 비밀번호"
-      name="new-password"
-      placeholder="비밀번호를 입력해 주세요"
-      essential
-      onChange={({ target }) => setNewPassword(target.value)}
-      statusText={statusText}
-      isError={isFilledNewPassword && !isValidNewPassword}
-    />
+    <InputWrapper>
+      <PasswordInput
+        id="new-password"
+        label="새 비밀번호"
+        name="new-password"
+        placeholder="비밀번호를 입력해 주세요"
+        essential
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onChange={({ target }) => setNewPassword(target.value)}
+        isError={isError}
+      />
+      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+    </InputWrapper>
   );
 };
 
@@ -57,16 +66,26 @@ const ConfirmNewPasswordInput = () => {
       ? "비밀번호가 일치합니다"
       : "비밀번호가 서로 일치하지 않습니다";
 
+  const isError =
+    isFilledConfirmPassword && !isSameNewPasswordAndConfirmPassword;
+
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
   return (
-    <PasswordInput
-      id="confirm-new-password"
-      name="confirm-new-password"
-      placeholder="비밀번호를 다시 한 번 입력해주세요"
-      essential
-      onChange={({ target }) => setConfirmPassword(target.value)}
-      statusText={statusText}
-      isError={isFilledConfirmPassword && !isSameNewPasswordAndConfirmPassword}
-    />
+    <InputWrapper>
+      <PasswordInput
+        id="confirm-new-password"
+        name="confirm-new-password"
+        placeholder="비밀번호를 다시 한 번 입력해주세요"
+        essential
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onChange={({ target }) => setConfirmPassword(target.value)}
+        isError={isError}
+      />
+
+      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
+    </InputWrapper>
   );
 };
 

--- a/src/shared/ui/input/input.stories.tsx
+++ b/src/shared/ui/input/input.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Input } from "./input";
+import { Input, InputWrapper, StatusText } from "./input";
 
 /*----------leadingIcon, trailingIcon 등에 들어갈 svg 컴포넌트 ---------- */
 const SearchIcon = () => (
@@ -732,6 +732,21 @@ export const WithoutLabel: Story = {
           <Input {...args} />
         </div>
       </div>
+    );
+  },
+};
+
+export const WithStatusText: Story = {
+  args: {
+    ...Default.args,
+    componentType: "outlinedText",
+  },
+  render: (args) => {
+    return (
+      <InputWrapper>
+        <Input {...args} />
+        <StatusText isError={args.isError}>status text</StatusText>
+      </InputWrapper>
     );
   },
 };

--- a/src/shared/ui/input/input.stories.tsx
+++ b/src/shared/ui/input/input.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { within, userEvent, expect } from "@storybook/test";
 import { Input } from "./input";
 
 /*----------leadingIcon, trailingIcon 등에 들어갈 svg 컴포넌트 ---------- */
@@ -87,13 +86,6 @@ const meta: Meta<typeof Input> = {
       },
       description:
         "Input 컴포넌트에서 에러 상태를 나타냅니다. 에러 상태일 때는 error 디자인이 전체 영역과 statusText에 적용됩니다.",
-    },
-    statusText: {
-      control: {
-        type: "text",
-      },
-      description:
-        "Input 컴포넌트에서 다양한 상황을 나타내는 텍스트입니다. 만약 statusText를 props로 전달하지 않을 시 statusText가 존재하는 영역은 렌더링 되지 않습니다.",
     },
     leadingNode: {
       description:
@@ -209,7 +201,6 @@ export const Default: Story = {
               label="calender"
               componentType="calender"
               type="date"
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
@@ -218,7 +209,6 @@ export const Default: Story = {
               {...args}
               componentType="searchText"
               label="searchText"
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
@@ -227,25 +217,17 @@ export const Default: Story = {
               {...args}
               componentType="outlinedText"
               label="outlinedText"
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
-            <Input
-              {...args}
-              componentType="text"
-              label="text"
-              statusText="올바른 입력값을 입력해주세요"
-              disabled
-            />
+            <Input {...args} componentType="text" label="text" disabled />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
             <Input
               {...args}
               componentType="timerText"
               label="timerText"
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
@@ -259,7 +241,6 @@ export const Default: Story = {
               label="calender"
               type="date"
               isError
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
@@ -269,7 +250,6 @@ export const Default: Story = {
               componentType="searchText"
               label="searchText"
               isError
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
@@ -279,7 +259,6 @@ export const Default: Story = {
               componentType="outlinedText"
               label="outlinedText"
               isError
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
@@ -289,7 +268,6 @@ export const Default: Story = {
               componentType="text"
               label="text"
               isError
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
@@ -299,7 +277,6 @@ export const Default: Story = {
               componentType="timerText"
               label="timerText"
               isError
-              statusText="올바른 입력값을 입력해주세요"
               disabled
             />
           </div>
@@ -312,40 +289,23 @@ export const Default: Story = {
               label="calender"
               componentType="calender"
               type="date"
-              statusText="올바른 입력값을 입력해주세요"
             />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
-            <Input
-              {...args}
-              componentType="searchText"
-              label="searchText"
-              statusText="올바른 입력값을 입력해주세요"
-            />
+            <Input {...args} componentType="searchText" label="searchText" />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
             <Input
               {...args}
               componentType="outlinedText"
               label="outlinedText"
-              statusText="올바른 입력값을 입력해주세요"
             />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
-            <Input
-              {...args}
-              componentType="text"
-              label="text"
-              statusText="올바른 입력값을 입력해주세요"
-            />
+            <Input {...args} componentType="text" label="text" />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
-            <Input
-              {...args}
-              componentType="timerText"
-              label="timerText"
-              statusText="올바른 입력값을 입력해주세요"
-            />
+            <Input {...args} componentType="timerText" label="timerText" />
           </div>
         </div>
         <div className="flex flex-col gap-3">
@@ -357,7 +317,6 @@ export const Default: Story = {
               label="calender"
               type="date"
               isError
-              statusText="올바른 입력값을 입력해주세요"
             />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
@@ -366,7 +325,6 @@ export const Default: Story = {
               componentType="searchText"
               label="searchText"
               isError
-              statusText="올바른 입력값을 입력해주세요"
             />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
@@ -375,17 +333,10 @@ export const Default: Story = {
               componentType="outlinedText"
               label="outlinedText"
               isError
-              statusText="올바른 입력값을 입력해주세요"
             />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
-            <Input
-              {...args}
-              componentType="text"
-              label="text"
-              isError
-              statusText="올바른 입력값을 입력해주세요"
-            />
+            <Input {...args} componentType="text" label="text" isError />
           </div>
           <div className="w-[328px] border border-grey-200 p-4 px-2">
             <Input
@@ -393,7 +344,6 @@ export const Default: Story = {
               componentType="timerText"
               label="timerText"
               isError
-              statusText="올바른 입력값을 입력해주세요"
             />
           </div>
         </div>
@@ -570,7 +520,6 @@ export const InputWithIcons: Story = {
 export const InputExample: Story = {
   args: {
     ...Default.args,
-    statusText: "올바른 입력값을 입력해주세요",
   },
   parameters: {
     ...Default.parameters,
@@ -740,49 +689,6 @@ export const InputExample: Story = {
   },
 };
 
-export const StatusText: Story = {
-  args: {
-    ...Default.args,
-    componentType: "outlinedText",
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Input 컴포넌트는 statusText가 문자열일 경우엔 layout shift 현상을 방지하기 위해 항상 같은 높이를 유지합니다.",
-      },
-    },
-  },
-
-  render: (args) => {
-    return (
-      <div>
-        <div className="flex gap-10 px-2 py-2">
-          <div className="h-fit w-96 border border-grey-300 px-2 py-2">
-            <p>status text = ""</p>
-            <Input {...args} statusText="" />
-          </div>
-          <div className="h-fit w-96 border border-grey-300 px-2 py-2">
-            <p>status text = "올바른 이메일을 입력해주세요"</p>
-            <Input {...args} statusText="올바른 이메일을 입력해주세요" />
-          </div>
-          <div className="h-fit w-96 border border-grey-300 px-2 py-2">
-            <p>status text = undefined</p>
-            <Input {...args} />
-          </div>
-          <div className="h-fit w-96 border border-grey-300 px-2 py-2">
-            <p>status text = width보다 긴 경우</p>
-            <Input
-              {...args}
-              statusText="width 보다 긴 텍스트의 경우에는 불가피하게 layout shift를 발생 시킵니다.UX 향상을 위해 statusText에 사용될 문자열의 길이를 주의해주세요"
-            />
-          </div>
-        </div>
-      </div>
-    );
-  },
-};
-
 export const Essential: Story = {
   args: {
     ...Default.args,
@@ -827,51 +733,5 @@ export const WithoutLabel: Story = {
         </div>
       </div>
     );
-  },
-};
-
-export const WhenInputFocused: Story = {
-  args: {
-    ...Default.args,
-    componentType: "outlinedText",
-    label: "Title",
-    trailingNode: <MockUpIcon />,
-    statusText: "올바른 이메일을 입력해주세요",
-  },
-
-  render: (args) => {
-    return (
-      <div className="flex gap-10">
-        <div className="border border-grey-300 px-2 py-2">
-          <Input
-            {...args}
-            // 더 극적인 상황을 위해 onFocus , onBlur 이벤트를 추가합니다.
-            onFocus={() => console.log("onFocus")}
-            onBlur={() => console.log("onBlur")}
-          />
-        </div>
-      </div>
-    );
-  },
-
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    // 테스트에 필요한 엘리먼트들을 가져옵니다
-    const $input = canvas.getByRole("textbox");
-    const $statusText = canvasElement.querySelector("p");
-    const p_originalHeight = $statusText?.clientHeight;
-    const p_originalTextContent = $statusText?.textContent;
-
-    const statusText = "올바른 이메일을 입력해주세요";
-
-    // 아무런 이벤트가 발생하지 않더라도 p 태그는 존재해야 한다.
-    expect($statusText).toBeInTheDocument();
-
-    await userEvent.click($input);
-    expect($statusText?.textContent).toBe(statusText);
-    expect($statusText?.clientHeight).toBe(p_originalHeight);
-
-    await userEvent.click(document.body);
-    expect($statusText?.textContent).toBe(p_originalTextContent);
   },
 };

--- a/src/shared/ui/input/input.tsx
+++ b/src/shared/ui/input/input.tsx
@@ -15,7 +15,6 @@ export interface InputProps
   disabled?: boolean;
   trailingNode?: React.ReactNode;
   leadingNode?: React.ReactNode;
-  fullWidth?: boolean;
 }
 
 export const InputWrapper = ({ children }: { children: React.ReactNode }) => {
@@ -31,7 +30,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       essential = false,
       isError = false,
       disabled = false,
-      fullWidth = true,
       trailingNode,
       leadingNode,
       ...rest
@@ -62,7 +60,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const restClasses = Object.values(restStylesObject).join(" ");
 
     return (
-      <div className={`flex ${fullWidth && "w-full"} flex-col items-start`}>
+      <div>
         {label && (
           <div className="flex gap-1 pb-2">
             <label htmlFor={id} className="title-3 text-grey-700">

--- a/src/shared/ui/input/input.tsx
+++ b/src/shared/ui/input/input.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef } from "react";
-import { useState } from "react";
 import { Badge } from "../badge";
 import { inputStyles, baseStyles } from "./input.styles";
 
@@ -11,7 +10,6 @@ export interface InputProps
   id: string;
   componentType: keyof typeof inputStyles;
   label?: string;
-  statusText?: string;
   essential?: boolean;
   isError?: boolean;
   disabled?: boolean;
@@ -20,49 +18,26 @@ export interface InputProps
   fullWidth?: boolean;
 }
 
+export const InputWrapper = ({ children }: { children: React.ReactNode }) => {
+  return <div className="flex flex-col w-full">{children}</div>;
+};
+
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       id,
       componentType,
       label,
-      statusText,
       essential = false,
       isError = false,
       disabled = false,
       fullWidth = true,
       trailingNode,
       leadingNode,
-      ...props
+      ...rest
     },
     ref,
   ) => {
-    // focus 상태에만 글자가 보이게 하기 위한 state
-    const [isFocused, setIsFocused] = useState<boolean>(false);
-    const shouldShowStatusText = statusText !== undefined;
-
-    // 외부에서  onFocus , onBlur 이벤트가 존재할 수 있기 때문에 이벤트 핸들러를 추가합니다.
-    const { onFocus, onBlur, ...rest } = props;
-    const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-      if (onFocus) {
-        onFocus(event);
-      }
-
-      if (shouldShowStatusText) {
-        setIsFocused(true);
-      }
-    };
-
-    const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-      if (onBlur) {
-        onBlur(event);
-      }
-
-      if (shouldShowStatusText) {
-        setIsFocused(false);
-      }
-    };
-
     // 휴먼에러를 방지하기 위해 leadingNode,trailingNode 유효성 확인
     if (React.Children.count(leadingNode) > 1) {
       throw new Error("leadingNode 하나의 노드만 가질 수 있습니다.");
@@ -107,21 +82,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             className={baseStyles.input}
             autoComplete="off"
             disabled={disabled}
-            // focus 상태일 때만 statusText를 보여주기 위한 이벤트 핸들러
-            onFocus={handleFocus}
-            onBlur={handleBlur}
             {...rest}
           />
           {trailingNode}
         </div>
-        {shouldShowStatusText && (
-          <p className={`${statusTextClass} ${baseStyles.statusText}`}>
-            {
-              // 에러 상태일 경우엔 focus 유무와 상관없이 statusText를 띄우고 에러가 아닐 경우엔 focus 시에만 나타나게 하자
-              isError ? statusText : isFocused ? statusText : ""
-            }
-          </p>
-        )}
       </div>
     );
   },


### PR DESCRIPTION
# 관련 이슈 번호

close #555 

# 설명

기존에는 focus 여부에 따라 status text 렌더링 여부가 결정되었으나 요구 사항이 변경됨에 따라 다양한 상황에서 렌더링 여부가 결정되었습니다.
따라서 유지보수하기에 input 컴포넌트에서 status text를 분리하는 것이 좋다고 판단하였습니다.

focus 여부에 따라 렌더링 될 경우 아래와 같은 jsx를 작성하면 됩니다.

```typescript
const [isFocused, setIsFocused] = useState<boolean>(false);

// jsx
<InputWrapper>
      <Input
        onFocus={() => setIsFocused(true)}
        onBlur={() => setIsFocused(false)}
        isError={isError}
      />
      {isFocused && <StatusText isError={isError}>{statusText}</StatusText>}
</InputWrapper>
```