### PR TITLE
[Hotfix] 모달을 감싸는 OverlayWrapper 스타일 버그 수정 

### DIFF
--- a/src/app/OverlayPortal.tsx
+++ b/src/app/OverlayPortal.tsx
@@ -22,7 +22,7 @@ const OverlayWrapper = ({ overlayInfo }: { overlayInfo: OverlayInfo }) => {
   // 만약 disabledInteraction 이 false인 경우 (Overlay와 함께 인터렉션을 할 경우)에는
   // OverlayController 영역을 최소화 합니다.
   const overlayAreaClass = disableInteraction
-    ? "h-screen mx-auto bg-translucent-gray"
+    ? "absolute w-screen h-screen mx-auto bg-translucent-gray"
     : "h-fit";
 
   return (

--- a/src/app/OverlayPortal.tsx
+++ b/src/app/OverlayPortal.tsx
@@ -18,11 +18,12 @@ const OverlayWrapper = ({ overlayInfo }: { overlayInfo: OverlayInfo }) => {
       onClose();
     }
   };
+
   // 만약 disabledInteraction 이 false인 경우 (Overlay와 함께 인터렉션을 할 경우)에는
   // OverlayController 영역을 최소화 합니다.
   const overlayAreaClass = disableInteraction
-    ? "h-screen w-[37.5rem] mx-auto bg-translucent-gray"
-    : "w-screen h-fit";
+    ? "h-screen mx-auto bg-translucent-gray"
+    : "h-fit";
 
   return (
     <div onClick={handleWrapperClick} className={`${overlayAreaClass}`}>


### PR DESCRIPTION
# 관련 이슈 번호
close #559
# 설명

## 버그 설명

![image](https://github.com/user-attachments/assets/a08fd943-ebb2-4a8a-8de5-5795a2700641)

![image](https://github.com/user-attachments/assets/898bc11d-9426-4fe0-b50d-516d86ef445e)

모달을 감싸는 `OverlayWrapper` 의 너비가 정적으로 설정 되어 있고, 포지션이 static 이라서 두 개 이상의 모달이 뜨는 경우 

`OverlayWrapper'가 스크린 밖으로 나가는 스타일 버그가 있었는데 해당 버그를 수정 했습니다. 

![image](https://github.com/user-attachments/assets/69f2f8e2-c568-4035-a5af-afe3e9bb9b1c)


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
