### PR TITLE
[Refactor] Input 최상단 요소 width를 100%로 설정

### DIFF
--- a/src/shared/ui/input/input.tsx
+++ b/src/shared/ui/input/input.tsx
@@ -60,7 +60,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const restClasses = Object.values(restStylesObject).join(" ");
 
     return (
-      <div>
+      <div className="w-full">
         {label && (
           <div className="flex gap-1 pb-2">
             <label htmlFor={id} className="title-3 text-grey-700">


### PR DESCRIPTION
# 관련 이슈 번호

close #555

## 설명

InputWrapper 컴포넌트를 쓰지 않고 Input만 사용하는 경우 width가 짧아지는 문제가 있었습니다.
Input 컴포넌트의 최상단 요소에 width: 100%로 설정하여 해결하였습니다!