### PR TITLE
[Hotfix] postLogout 이 정상적으로 동작하지 않아 무한 재요청 가던 버그 수정

### DIFF
--- a/src/features/setting/api/postLogout.ts
+++ b/src/features/setting/api/postLogout.ts
@@ -13,6 +13,9 @@ const postLogout = async () => {
   });
 };
 
+interface usePostLogoutParams {
+  onSuccess: () => void;
+}
 /**
  * 해당 훅은 token 을 인수로 받는 postLogout 을 반환합니다.
  * 요청이 성공하게 되면 다음과 같은 작업이 기본적으로 일어납니다.
@@ -20,7 +23,7 @@ const postLogout = async () => {
  * 2. queryClient 에서 해당 nickname 을 가진 쿼리를 제거
  * 3. 인수로 받은 onMutate 함수 실행
  */
-export const usePostLogout = () => {
+export const usePostLogout = ({ onSuccess }: usePostLogoutParams) => {
   const queryClient = useQueryClient();
   const resetAuthStore = useAuthStore((state) => state.reset);
   const navigate = useNavigate();
@@ -33,6 +36,7 @@ export const usePostLogout = () => {
       queryClient.removeQueries({ queryKey: ["profile", nickname] });
       resetAuthStore();
       navigate(ROUTER_PATH.MAP);
+      onSuccess();
       setTimeout(() => handleOpenSnackbar("로그아웃 되었습니다"), 500);
     },
     onError: (error) => {

--- a/src/features/setting/api/postLogout.ts
+++ b/src/features/setting/api/postLogout.ts
@@ -1,6 +1,8 @@
+import { useNavigate } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ROUTER_PATH } from "@/shared/constants";
 import { apiClient } from "@/shared/lib";
-import { useAuthStore } from "@/shared/store";
+import { useAuthStore, useSnackbar } from "@/shared/store";
 import { SETTING_END_POINT } from "../constants";
 
 const postLogout = async () => {
@@ -11,10 +13,6 @@ const postLogout = async () => {
   });
 };
 
-interface usePostLogoutParams {
-  onMutate: () => void;
-}
-
 /**
  * 해당 훅은 token 을 인수로 받는 postLogout 을 반환합니다.
  * 요청이 성공하게 되면 다음과 같은 작업이 기본적으로 일어납니다.
@@ -22,20 +20,20 @@ interface usePostLogoutParams {
  * 2. queryClient 에서 해당 nickname 을 가진 쿼리를 제거
  * 3. 인수로 받은 onMutate 함수 실행
  */
-export const usePostLogout = ({ onMutate }: usePostLogoutParams) => {
+export const usePostLogout = () => {
   const queryClient = useQueryClient();
   const resetAuthStore = useAuthStore((state) => state.reset);
+  const navigate = useNavigate();
+  const handleOpenSnackbar = useSnackbar("map");
 
   return useMutation<unknown, Error>({
     mutationFn: postLogout,
-    // 2024/10/03 - 현재는 로그아웃 단계에서 response 값과 상관 없이 로그아웃 처리 하기로 이야기 나눠놓았습니다.
-    onMutate: () => {
+    onSuccess: () => {
       const { nickname } = useAuthStore.getState();
       queryClient.removeQueries({ queryKey: ["profile", nickname] });
-
       resetAuthStore();
-
-      onMutate();
+      navigate(ROUTER_PATH.MAP);
+      setTimeout(() => handleOpenSnackbar("로그아웃 되었습니다"), 500);
     },
     onError: (error) => {
       console.error(error);

--- a/src/features/setting/ui/logoutModal.tsx
+++ b/src/features/setting/ui/logoutModal.tsx
@@ -7,13 +7,11 @@ interface LogoutModalProps {
 }
 
 export const LogoutModal = ({ onCloseLogoutModal }: LogoutModalProps) => {
-  const { mutate: postLogout } = usePostLogout();
-
-  const handleLogout = () => {
-    postLogout(undefined, {
-      onSuccess: () => onCloseLogoutModal(),
-    });
-  };
+  const { mutate: postLogout } = usePostLogout({
+    onSuccess: () => {
+      onCloseLogoutModal();
+    },
+  });
 
   return (
     <Modal modalType="center">
@@ -33,7 +31,7 @@ export const LogoutModal = ({ onCloseLogoutModal }: LogoutModalProps) => {
         </button>
         <button
           className="flex flex-1 justify-center items-center  px-6 text-tangerine-500 btn-2"
-          onClick={handleLogout}
+          onClick={() => postLogout()}
         >
           확인
         </button>

--- a/src/features/setting/ui/logoutModal.tsx
+++ b/src/features/setting/ui/logoutModal.tsx
@@ -1,6 +1,3 @@
-import { useNavigate } from "react-router-dom";
-import { ROUTER_PATH } from "@/shared/constants";
-import { useSnackbar } from "@/shared/store";
 import { CloseIcon } from "@/shared/ui/icon";
 import { Modal } from "@/shared/ui/modal";
 import { usePostLogout } from "../api";
@@ -10,20 +7,12 @@ interface LogoutModalProps {
 }
 
 export const LogoutModal = ({ onCloseLogoutModal }: LogoutModalProps) => {
-  const navigate = useNavigate();
-  const handleOpenSnackbar = useSnackbar("default");
-
-  const { mutate: postLogout } = usePostLogout({
-    onMutate: () => {
-      onCloseLogoutModal();
-      navigate(ROUTER_PATH.MAIN);
-      // 네비게이팅이 완료된 후에 스낵바를 띄우기 위해 setTimeout 사용
-      setTimeout(() => handleOpenSnackbar("로그아웃 되었습니다"), 100);
-    },
-  });
+  const { mutate: postLogout } = usePostLogout();
 
   const handleLogout = () => {
-    postLogout();
+    postLogout(undefined, {
+      onSuccess: () => onCloseLogoutModal(),
+    });
   };
 
   return (


### PR DESCRIPTION
# 관련 이슈 번호

close #558 

# 설명

버그가 등장한 작업은 #489 이후부터지만 원인은 usePostLogout 훅을 생성한 순간부터 존재했습니다. 

`onMutate` 단계에서 성공 유무와 상관 없이 authStore 의 값을 초기화 하게 되는데 

`onMutate` 단계에서 초기화 된 authStorer로 인해 token 값이 null 이 되게 되고 이로 인해 postLogout 요청 자체에서 authorization 값에 엑세스 토큰이 담기지 않은 채로 로그아웃 처리 되게 됩니다. 

> onMutate 가 mutate function 이 시작되기 전에 동작하는지 , 참 요상합니다.. 

이로 인해 매번 로그아웃 요청 때 액세스 토큰이 존재하지 않아 401 에러가 뜨고, 401 에러로 인해 failedQueue 에 담겼다가 무한 재요청을 하게 됩니다. 

순차적으로 요약하자면 

1. 액세스 토큰 없이 postLogout 
2. 서버에서 액세스 토큰이 없어 401 에러 
3. 401 에러로 인해 리프레쉬 토큰으로 액세스 토큰 재발급 
4. failedQueue 에 담겨있던 1번 메소드 재요청 

무한 반복.. 

따라서 토큰을 제거하는 행위를 onMutate 가 아닌 onSuccess로 해주니 해당 버그가 제거 되었습니다. 

![lgoout](https://github.com/user-attachments/assets/398158ba-3360-4ac6-9bff-3a3bc8fb8da4)


다만 해결되지 않은 버그는 onSuccess에서 로그아웃 되었습니다 라는 스낵바를 setTimeout 을 통해 마운트 하고 있는데 

map 페이지로 네비게이팅 된 후에 `handleOpenSnackbar("스팟을 발견하고 마킹으로 추억을 남겨보세요");` 스낵바와 충돌하여 로그아웃 되었습니다 라는 스낵바가 마운트 되지 않게 됩니다. 

이는 setTimeout 의 딜레이를 조금 더 늘리면 억지스럽게 해당 스낵바를 띄울 수 있지만 

이 방법보단 맵 이니셜라이저 부분의 대대적인 리팩토링이 필요할 것으로 생각 됩니다.. 


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
