### PR TITLE
[Hotfix] 사용자 정보 등록 랜딩 모달이 뜨지 않는 문제 해결

### DIFF
--- a/src/entities/auth/ui/signUpLandingModal.tsx
+++ b/src/entities/auth/ui/signUpLandingModal.tsx
@@ -1,16 +1,17 @@
 import { useNavigate } from "react-router-dom";
 import { ROUTER_PATH } from "@/shared/constants";
-import { useAuthStore } from "@/shared/store/auth";
 import { useRouteHistoryStore } from "@/shared/store/history";
 import { Modal } from "@/shared/ui/modal";
 
 interface SignUpLandingModalProps {
-  onClose: () => Promise<void>;
+  nickname: string;
+  onClose: () => void;
 }
 
-export const SignUpLandingModal = ({ onClose }: SignUpLandingModalProps) => {
-  const { nickname } = useAuthStore.getState();
-
+export const SignUpLandingModal = ({
+  nickname,
+  onClose,
+}: SignUpLandingModalProps) => {
   const lastNoneAuthRoute = useRouteHistoryStore(
     (state) => state.lastNoneAuthRoute,
   );

--- a/src/features/auth/api/putAddUserInfo.ts
+++ b/src/features/auth/api/putAddUserInfo.ts
@@ -1,6 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
 import { apiClient } from "@/shared/lib";
-import { useAuthStore } from "@/shared/store";
 import { SIGN_UP_END_POINT } from "../constants";
 import type { SignUpResponse } from "../types/server";
 
@@ -12,10 +11,10 @@ interface PostAddUserInfoRequest {
   marketingYn: boolean;
 }
 
-type PostAddUserInfoResponse = SignUpResponse<"ROLE_GUEST">;
+type PutAddUserInfoResponse = SignUpResponse<"ROLE_GUEST">;
 
 const putAddUserInfo = async (userInfo: PostAddUserInfoRequest) => {
-  return apiClient.put<PostAddUserInfoResponse>(SIGN_UP_END_POINT.USER_INFO, {
+  return apiClient.put<PutAddUserInfoResponse>(SIGN_UP_END_POINT.USER_INFO, {
     withToken: true,
     credentials:
       process.env.NODE_ENV === "development" ? "include" : "same-origin",
@@ -23,24 +22,12 @@ const putAddUserInfo = async (userInfo: PostAddUserInfoRequest) => {
   });
 };
 
-export const usePutAddUserInfo = ({ onSuccess }: { onSuccess: () => void }) => {
-  const setNickname = useAuthStore((state) => state.setNickname);
-  const setToken = useAuthStore((state) => state.setToken);
-  const setRole = useAuthStore((state) => state.setRole);
-
-  return useMutation<PostAddUserInfoResponse, Error, PostAddUserInfoRequest>({
+export const usePutAddUserInfo = () => {
+  return useMutation<PutAddUserInfoResponse, Error, PostAddUserInfoRequest>({
     mutationFn: putAddUserInfo,
-    onSuccess: (data) => {
-      const { role, nickname, authorization } = data;
-
-      setRole(role);
-      setNickname(nickname);
-      setToken(authorization);
-
-      onSuccess();
-    },
     onError: (error) => {
       console.error(error);
     },
+    gcTime: 0,
   });
 };

--- a/src/features/auth/ui/userInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/userInfoRegistrationForm.stories.tsx
@@ -43,7 +43,9 @@ export const Default: Story = {
     });
 
     useAuthStore.setState({
-      token: "Bearer token",
+      token: "accessToken-ROLE_NONE",
+      role: "ROLE_NONE",
+      nickname: null,
     });
 
     return <Story />;
@@ -387,7 +389,9 @@ export const Default: Story = {
 export const ApiTest: Story = {
   decorators: (Story) => {
     useAuthStore.setState({
-      token: "Bearer token",
+      token: "accessToken-ROLE_NONE",
+      role: "ROLE_NONE",
+      nickname: null,
     });
 
     useUserInfoRegistrationFormStore.setState({

--- a/src/features/auth/ui/userInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/userInfoRegistrationForm.stories.tsx
@@ -481,25 +481,6 @@ export const ApiTest: Story = {
         await userEvent.click($confirmButton);
 
         await userEvent.click($submitButton);
-
-        // await waitFor(() => {
-        //   const { nickname, role } = useAuthStore.getState();
-
-        //   expect(role).toBe("ROLE_GUEST");
-        //   expect(nickname).toBe(validNickname);
-        // });
-
-        // await step(
-        //   "스토어에 닉네임이 저장된 후엔 회원 가입 축하 모달이 나타난다.",
-        //   async () => {
-        //     const { nickname } = useAuthStore.getState();
-        //     const $landingHeadLineTitle = canvas.getByText(`${nickname}`);
-        //     const $landingHeadLineContent =
-        //       canvas.getByText("회원가입을 축하해요");
-        //     expect($landingHeadLineTitle).toBeInTheDocument();
-        //     expect($landingHeadLineContent).toBeInTheDocument();
-        //   },
-        // );
       },
     );
   },

--- a/src/features/auth/ui/userInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/userInfoRegistrationForm.stories.tsx
@@ -482,24 +482,24 @@ export const ApiTest: Story = {
 
         await userEvent.click($submitButton);
 
-        await waitFor(() => {
-          const { nickname, role } = useAuthStore.getState();
+        // await waitFor(() => {
+        //   const { nickname, role } = useAuthStore.getState();
 
-          expect(role).toBe("ROLE_GUEST");
-          expect(nickname).toBe(validNickname);
-        });
+        //   expect(role).toBe("ROLE_GUEST");
+        //   expect(nickname).toBe(validNickname);
+        // });
 
-        await step(
-          "스토어에 닉네임이 저장된 후엔 회원 가입 축하 모달이 나타난다.",
-          async () => {
-            const { nickname } = useAuthStore.getState();
-            const $landingHeadLineTitle = canvas.getByText(`${nickname}`);
-            const $landingHeadLineContent =
-              canvas.getByText("회원가입을 축하해요");
-            expect($landingHeadLineTitle).toBeInTheDocument();
-            expect($landingHeadLineContent).toBeInTheDocument();
-          },
-        );
+        // await step(
+        //   "스토어에 닉네임이 저장된 후엔 회원 가입 축하 모달이 나타난다.",
+        //   async () => {
+        //     const { nickname } = useAuthStore.getState();
+        //     const $landingHeadLineTitle = canvas.getByText(`${nickname}`);
+        //     const $landingHeadLineContent =
+        //       canvas.getByText("회원가입을 축하해요");
+        //     expect($landingHeadLineTitle).toBeInTheDocument();
+        //     expect($landingHeadLineContent).toBeInTheDocument();
+        //   },
+        // );
       },
     );
   },

--- a/src/features/auth/ui/userInfoRegistrationForm.stories.tsx
+++ b/src/features/auth/ui/userInfoRegistrationForm.stories.tsx
@@ -360,8 +360,6 @@ export const Default: Story = {
     await userEvent.clear($nicknameInput);
     await userEvent.type($nicknameInput, validNickname);
 
-    // todo: 유저 중복 snackbar 검사
-
     await step(
       "필수 약관에 동의하지 않은 상태에서 [회원가입] 버튼을 누르면, snackbar가 뜬다.",
       async () => {
@@ -381,106 +379,6 @@ export const Default: Story = {
             timeout: 1000,
           },
         );
-      },
-    );
-  },
-};
-
-export const ApiTest: Story = {
-  decorators: (Story) => {
-    useAuthStore.setState({
-      token: "accessToken-ROLE_NONE",
-      role: "ROLE_NONE",
-      nickname: null,
-    });
-
-    useUserInfoRegistrationFormStore.setState({
-      nickname: "",
-      gender: null,
-      ageRange: null,
-      region: [],
-      checkList: [false, false, false],
-    });
-
-    return <Story />;
-  },
-
-  render: () => <UserInfoRegistrationForm />,
-
-  parameters: {
-    msw: { handlers },
-  },
-
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-
-    const $nicknameInput = canvasElement.querySelector(
-      'input[name="nickname"]',
-    ) as HTMLInputElement;
-
-    const $genderTriggerButton = canvasElement.querySelector("#gender");
-    const $ageRangeTriggerButton = canvasElement.querySelector("#age-range");
-
-    const $firstAgreementCheckbox = canvas.getByText("이용약관 동의 (필수)");
-    const $secondAgreementCheckbox = canvas.getByText(
-      "개인정보 수집 및 이용 동의 (필수)",
-    );
-    const $regionSelectButton = canvas.getByText("동네 설정하기");
-
-    const $submitButton = canvas.getByText("회원가입");
-
-    await step(
-      '중복되는 닉네임을 적을 경우, "이미 존재하는 닉네임입니다." 안내 문구가 뜬다.',
-      async () => {
-        await userEvent.type($nicknameInput, "중복");
-        await userEvent.tab();
-
-        const $statusText =
-          await canvas.findByText("이미 존재하는 닉네임입니다.");
-        expect($statusText).toBeInTheDocument();
-      },
-    );
-
-    await userEvent.clear($nicknameInput);
-
-    await step(
-      "form을 올바르게 입력하고 필수 약관에 동의한 상태에서 [회원가입] 버튼을 누르면, nickname과 role을 store에 저장된다.",
-      async () => {
-        const validNickname = "hihihi";
-        await userEvent.type($nicknameInput, validNickname);
-
-        await userEvent.click($genderTriggerButton!);
-
-        const $bottomSheet = document.querySelector("#gender-select");
-        const $optionList = $bottomSheet?.querySelectorAll("li");
-        const $maleOption = $optionList?.[0];
-        await userEvent.click($maleOption!);
-
-        await userEvent.click($ageRangeTriggerButton!);
-
-        const $ageRangeBottomSheet =
-          document.querySelector("#age-range-select");
-        const $ageRangeOptionList =
-          $ageRangeBottomSheet?.querySelectorAll("li");
-        const $teenagerOption = $ageRangeOptionList?.[0];
-        await userEvent.click($teenagerOption!);
-
-        await userEvent.click($firstAgreementCheckbox);
-        await userEvent.click($secondAgreementCheckbox);
-
-        await userEvent.click($regionSelectButton);
-
-        const $regionSearchInput =
-          canvasElement.querySelector("#region-search")!;
-        await userEvent.type($regionSearchInput, "강남구 역삼동");
-
-        const $selectedRegion = await canvas.findByText(/강남구 역삼1동/);
-        await userEvent.click($selectedRegion);
-
-        const $confirmButton = canvas.getByText("확인");
-        await userEvent.click($confirmButton);
-
-        await userEvent.click($submitButton);
       },
     );
   },

--- a/src/features/auth/ui/userInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/userInfoRegistrationForm.tsx
@@ -1,11 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   AgreementCheckbox,
   SelectOpener,
   SignUpLandingModal,
 } from "@/entities/auth/ui";
 import type { Region } from "@/entities/map/types/server";
-import { AUTH_ERROR_MESSAGE } from "@/shared/constants";
 import { useModal } from "@/shared/lib";
 import { useAuthStore, useSnackbar } from "@/shared/store";
 import { Badge } from "@/shared/ui/badge";
@@ -267,25 +266,40 @@ const MyRegionList = () => {
 };
 
 const UserInfoRegistrationForm = () => {
+  const setNickname = useAuthStore((state) => state.setNickname);
+  const setToken = useAuthStore((state) => state.setToken);
+  const setRole = useAuthStore((state) => state.setRole);
+
   const {
-    handleOpen: openLandingModal,
-    onClose: onCloseLandingModal,
-    isOpen,
-  } = useModal(() => <SignUpLandingModal onClose={onCloseLandingModal} />);
+    mutate: putUserInfoRegistration,
+    data,
+    isSuccess,
+  } = usePutAddUserInfo();
+
+  const { handleOpen: openLandingModal, onClose: onCloseLandingModal } =
+    useModal(() => (
+      <SignUpLandingModal
+        nickname={data?.nickname ?? ""}
+        onClose={() => {
+          if (data) {
+            setNickname(data.nickname);
+            setToken(data.authorization);
+            setRole(data.role);
+
+            onCloseLandingModal();
+          }
+        }}
+      />
+    ));
   const handleOpenSnackbar = useSnackbar("default");
 
-  const token = useAuthStore((state) => state.token);
-  const role = useAuthStore((state) => state.role);
-
-  const { mutate: putUserInfoRegistration } = usePutAddUserInfo({
-    onSuccess: () => {
+  useEffect(() => {
+    if (isSuccess && data) {
       openLandingModal();
-    },
-  });
+    }
+  }, [isSuccess, data]);
 
-  if (!isOpen && role === "ROLE_GUEST") {
-    throw new Error(AUTH_ERROR_MESSAGE.NON_AUTHORIZED);
-  }
+  const token = useAuthStore((state) => state.token);
 
   const { isDuplicateNickname } = usePostCheckDuplicateNicknameState();
 

--- a/src/features/auth/ui/userInfoRegistrationForm.tsx
+++ b/src/features/auth/ui/userInfoRegistrationForm.tsx
@@ -5,6 +5,7 @@ import {
   SignUpLandingModal,
 } from "@/entities/auth/ui";
 import type { Region } from "@/entities/map/types/server";
+import { AUTH_ERROR_MESSAGE } from "@/shared/constants";
 import { useModal } from "@/shared/lib";
 import { useAuthStore, useSnackbar } from "@/shared/store";
 import { Badge } from "@/shared/ui/badge";
@@ -266,17 +267,25 @@ const MyRegionList = () => {
 };
 
 const UserInfoRegistrationForm = () => {
-  const { handleOpen: openLandingModal, onClose: onCloseLandingModal } =
-    useModal(() => <SignUpLandingModal onClose={onCloseLandingModal} />);
+  const {
+    handleOpen: openLandingModal,
+    onClose: onCloseLandingModal,
+    isOpen,
+  } = useModal(() => <SignUpLandingModal onClose={onCloseLandingModal} />);
   const handleOpenSnackbar = useSnackbar("default");
 
   const token = useAuthStore((state) => state.token);
+  const role = useAuthStore((state) => state.role);
 
   const { mutate: putUserInfoRegistration } = usePutAddUserInfo({
     onSuccess: () => {
       openLandingModal();
     },
   });
+
+  if (!isOpen && role === "ROLE_GUEST") {
+    throw new Error(AUTH_ERROR_MESSAGE.NON_AUTHORIZED);
+  }
 
   const { isDuplicateNickname } = usePostCheckDuplicateNicknameState();
 

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -127,15 +127,23 @@ const putAddUserInfoHandler = http.put<
     markings: [],
   };
 
-  return HttpResponse.json({
-    code: 200,
-    message: "success",
-    content: {
-      nickname,
-      authorization: "accessToken-ROLE_GUEST",
-      role: "ROLE_GUEST",
+  return HttpResponse.json(
+    {
+      code: 200,
+      message: "success",
+      content: {
+        nickname,
+        authorization: "accessToken-ROLE_GUEST",
+        role: "ROLE_GUEST",
+      },
     },
-  });
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "Set-Cookie": "Authorization-refresh=refreshToken-ROLE_GUEST",
+      },
+    },
+  );
 });
 
 const postCheckDuplicateNicknameHandler = http.post<

--- a/src/pages/sign-up/user-info/page.tsx
+++ b/src/pages/sign-up/user-info/page.tsx
@@ -14,6 +14,6 @@ const UserInfoRegistrationPage = withAuth(() => {
       </main>
     </div>
   );
-}, ["ROLE_NONE", "ROLE_GUEST"]);
+}, ["ROLE_NONE"]);
 
 export default UserInfoRegistrationPage;

--- a/src/pages/sign-up/user-info/page.tsx
+++ b/src/pages/sign-up/user-info/page.tsx
@@ -14,6 +14,6 @@ const UserInfoRegistrationPage = withAuth(() => {
       </main>
     </div>
   );
-}, ["ROLE_NONE"]);
+}, ["ROLE_NONE", "ROLE_GUEST"]);
 
 export default UserInfoRegistrationPage;


### PR DESCRIPTION
# 관련 이슈 번호

close #560

# 설명

사용자 정보를 입력하면 랜딩 모달이 뜨는 것이 아니라 에러 페이지를 노출하는 문제가 있었습니다.

https://github.com/user-attachments/assets/a8095181-a440-42f3-b3ca-2f1320b72fc6

현재 사용자 정보 등록에 성공하면 authStore의 role이 ROLE_GUEST로 업데이트되고, 랜딩 모달이 렌더링됩니다.
하지만, 사용자 정보 등록 페이지는 ROLE_NONE 외의 유저가 접근하면 에러를 throw하므로 store가 업데이트 되자마자 에러 페이지가 노출됩니다.

사용자 정보 등록 페이지에 접근할 수 있는 권한에서 ROLE_USER를 추가하여 ROLE_GUEST로 업데이트되어도 에러 페이지를 노출하는 것을 막았습니다.
그리고, ROLE_GUEST인 상태에서 정보 등록 페이지에 접근할 경우 에러 페이지를 보여주기 위해 `UserInfoRegistrationForm`에서 분기 처리를 해뒀습니다. authStore의 role이 ROLE_GUEST인 상태에서 랜딩 모달이 렌더링되지 않을 경우 에러 메세지를 던져 에러 페이지를 보여줍니다,

```typescript
const UserInfoRegistrationForm = () => {
  const {
    handleOpen: openLandingModal,
    onClose: onCloseLandingModal,
    isOpen,
  } = useModal(() => <SignUpLandingModal onClose={onCloseLandingModal} />);

  const role = useAuthStore((state) => state.role);

  if (!isOpen && role === "ROLE_GUEST") {
    throw new Error(AUTH_ERROR_MESSAGE.NON_AUTHORIZED);
  }
```

### 리팩토링 이후 발생하는 문제

리팩토링 했는데도, 랜딩 모달에서 버튼을 눌렀을 때 에러페이지가 노출되는 문제가 있었습니다.

https://github.com/user-attachments/assets/3b79c892-d3aa-412d-961e-01587081fcd2

문제의 원인은 mock 데이터에 있었습니다. 

1. 랜딩 모달에 있는 버튼 클릭
2. `MainLayout` 컴포넌트가 렌더링되어 refresh token으로 access token을 재발급 요청
3.  요청 보낸 쿠키값이 `refreshToken-ROLE_NONE`이므로 아래 데이터로 응답
```json
authorization: "accessToken-ROLE_NONE"
nickname: "뽀송송"
role: "ROLE_NONE"
```
4. role이 ROLE_NONE으로 업데이트되므로 에러 페이지 노출

실제 서버였다면 db에 있는 데이터를 가져오기 때문에 올바른 role이 응답으로 오겠지만, mock 데이터를 사용하고 있어서 생긴 문제였습니다.

그래서 msw handler에서 유저 정보 등록에 성공했으면 refresh token을 `refresh-ROLE_GUEST`로 업데이트하였습니다. 덕분에, access token을 재발급 요청하면 role이 `ROLE_GUEST`인 데이터가 응답으로 옵니다.
