### PR TITLE
[Hotfix] 쿠키 cross origin 에서도 전송되도록 credentials 값 수정

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -4,6 +4,5 @@ import { APP_END_POINT } from "./ReactQueryProvider/constants";
 
 export const getAccessTokenByRefreshToken = () =>
   apiClient.get<SignUpResponse>(APP_END_POINT.REFRESH_ACCESS_TOKEN, {
-    credentials:
-      process.env.NODE_ENV === "development" ? "include" : "same-origin",
+    credentials: "include",
   });

--- a/src/entities/auth/ui/signUpLandingModal.stories.tsx
+++ b/src/entities/auth/ui/signUpLandingModal.stories.tsx
@@ -22,5 +22,7 @@ export const Default: StoryObj<typeof SignUpLandingModal> = {
     },
   ],
 
-  render: () => <SignUpLandingModal onClose={async () => {}} />,
+  render: () => (
+    <SignUpLandingModal onClose={async () => {}} nickname="뽀송송" />
+  ),
 };

--- a/src/features/auth/api/postAddPetInfo.ts
+++ b/src/features/auth/api/postAddPetInfo.ts
@@ -29,7 +29,7 @@ const postAddPetInfo = async ({
 
   return apiClient.post<PostPetInfoResponse>(SIGN_UP_END_POINT.PET_INFO, {
     withToken: true,
-    credentials: 'include'
+    credentials: "include",
     body: formData,
   });
 };

--- a/src/features/auth/api/postAddPetInfo.ts
+++ b/src/features/auth/api/postAddPetInfo.ts
@@ -29,8 +29,7 @@ const postAddPetInfo = async ({
 
   return apiClient.post<PostPetInfoResponse>(SIGN_UP_END_POINT.PET_INFO, {
     withToken: true,
-    credentials:
-      process.env.NODE_ENV === "development" ? "include" : "same-origin",
+    credentials: 'include'
     body: formData,
   });
 };

--- a/src/features/auth/api/putAddUserInfo.ts
+++ b/src/features/auth/api/putAddUserInfo.ts
@@ -16,7 +16,7 @@ type PutAddUserInfoResponse = SignUpResponse<"ROLE_GUEST">;
 const putAddUserInfo = async (userInfo: PostAddUserInfoRequest) => {
   return apiClient.put<PutAddUserInfoResponse>(SIGN_UP_END_POINT.USER_INFO, {
     withToken: true,
-    credentials: 'include'
+    credentials: "include",
     body: userInfo,
   });
 };

--- a/src/features/auth/api/putAddUserInfo.ts
+++ b/src/features/auth/api/putAddUserInfo.ts
@@ -16,8 +16,7 @@ type PutAddUserInfoResponse = SignUpResponse<"ROLE_GUEST">;
 const putAddUserInfo = async (userInfo: PostAddUserInfoRequest) => {
   return apiClient.put<PutAddUserInfoResponse>(SIGN_UP_END_POINT.USER_INFO, {
     withToken: true,
-    credentials:
-      process.env.NODE_ENV === "development" ? "include" : "same-origin",
+    credentials: 'include'
     body: userInfo,
   });
 };

--- a/src/features/setting/api/postLogout.ts
+++ b/src/features/setting/api/postLogout.ts
@@ -8,8 +8,7 @@ import { SETTING_END_POINT } from "../constants";
 const postLogout = async () => {
   return apiClient.post(SETTING_END_POINT.LOGOUT, {
     withToken: true,
-    credentials:
-      process.env.NODE_ENV === "development" ? "include" : "same-origin",
+    credentials: "include",
   });
 };
 


### PR DESCRIPTION
# 관련 이슈 번호

close #565 

# 설명

현재 배포된 사이트에서 클라이언트 origin (https://mungwitheme.site/) 과 백엔드 origin (https://api-mungwitheme/) 이 서로 달라

referesh token이 전송되지 않는 버그가 존재합니다.

이에 클라이언트 단에서 cross origin 이더라도 쿠키를 전송 하도록 수정합니다.

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)

