### PR TITLE
[Hotfix] 바텀 시트 경고 제거하기 위해 padding , paddingBottom 스타일 제거하고 모두 padding direciton 으로 스타일 변경

### DIFF
--- a/src/widgets/map/ui/mapBottomSheet.tsx
+++ b/src/widgets/map/ui/mapBottomSheet.tsx
@@ -50,7 +50,9 @@ export const MapBottomSheet = ({ children }: MapBottomSheetProps) => {
         <Sheet.Header />
         <Sheet.Content
           style={{
-            padding: 0,
+            paddingLeft: 0,
+            paddingRight: 0,
+            paddingTop: 0,
             paddingBottom: contentPaddingBottom,
           }}
         >


### PR DESCRIPTION

# 관련 이슈 번호

close #576 

# 설명

신기한게 패딩 바텀을 저 객체 값으로 줘서 생긴 경고가 아닌 

padding : 0  으로 설정해두고 패딩 바텀 값을 또 줌으로 인해 

스타일 간 충돌이 일어났다는 경고문구더군요 

```tsx
       <Sheet.Content
          style={{
            paddingLeft: 0,
            paddingRight: 0,
            paddingTop: 0,
            paddingBottom: contentPaddingBottom,
          }}
        >
```

이렇게 변경해주니 경고문구가 발생하지 않습니다. 

그나저나 저 스타일은 참 신기하네요 

# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
