### PR TITLE
[Refactor] 네비게이션 바 컴포넌트 리팩토링

### DIFF
--- a/src/pages/[nickname]/myProfilePage.tsx
+++ b/src/pages/[nickname]/myProfilePage.tsx
@@ -51,8 +51,8 @@ export const MyProfilePage = () => {
 const MyPageNavigationBar = () => {
   const nickname = useAuthStore((state) => state.nickname);
   return (
-    <NavigationBar>
-      {`${nickname}님`}
+    <NavigationBar justifyContent="between">
+      <h1>{`${nickname}님`}</h1>
       <Link
         to={ROUTER_PATH.SETTING}
         className="px-3 py-3 text-grey-500"

--- a/src/shared/ui/navigationBar/backwardNavigationBar.tsx
+++ b/src/shared/ui/navigationBar/backwardNavigationBar.tsx
@@ -31,9 +31,9 @@ export const BackwardNavigationBar = ({
   ...props
 }: BackwardNavigationBarProps) => {
   return (
-    <NavigationBar>
+    <NavigationBar justifyContent="start">
       <BackWardButton {...props} />
-      {children}
+      <h1>{children}</h1>
     </NavigationBar>
   );
 };

--- a/src/shared/ui/navigationBar/closeNavigationBar.tsx
+++ b/src/shared/ui/navigationBar/closeNavigationBar.tsx
@@ -29,8 +29,8 @@ export const CloseNavigationBar = ({
   const navigate = useNavigate();
 
   return (
-    <NavigationBar>
-      {children}
+    <NavigationBar justifyContent="between">
+      <h1>{children}</h1>
       <CloseButton onClick={() => navigate(-1)} {...props} />
     </NavigationBar>
   );

--- a/src/shared/ui/navigationBar/navigationBar.tsx
+++ b/src/shared/ui/navigationBar/navigationBar.tsx
@@ -1,26 +1,23 @@
-import { type ReactElement } from "react";
+const navigationStyles = {
+  start: "px-1 justify-start",
+  between: "pl-4 pr-1 justify-between",
+  end: "justify-end",
+};
 
 export interface NavigationBarProps {
-  children:
-    | [ReactElement<HTMLButtonElement | HTMLAnchorElement>, string | undefined]
-    | [string | undefined, ReactElement<HTMLButtonElement | HTMLAnchorElement>];
+  children: React.ReactNode;
+  justifyContent: keyof typeof navigationStyles;
 }
 
-export const NavigationBar = ({ children }: NavigationBarProps) => {
-  const isButtonLeft =
-    typeof children[1] === "string" || typeof children[1] === "undefined";
-
+export const NavigationBar = ({
+  children,
+  justifyContent,
+}: NavigationBarProps) => {
   return (
     <nav
-      className={`flex py-2 items-center ${isButtonLeft ? "px-1 justify-start" : children[0] ? "pl-4 pr-1 justify-between" : "justify-end"}`}
+      className={`flex py-2 items-center ${navigationStyles[justifyContent]}`}
     >
-      {children.map((child) =>
-        typeof child === "string" ? (
-          <h1 className="text-grey-900 title-1">{child}</h1>
-        ) : (
-          child
-        ),
-      )}
+      {children}
     </nav>
   );
 };

--- a/src/shared/ui/navigationBar/navigationBar.tsx
+++ b/src/shared/ui/navigationBar/navigationBar.tsx
@@ -15,7 +15,7 @@ export const NavigationBar = ({
 }: NavigationBarProps) => {
   return (
     <nav
-      className={`flex py-2 items-center ${navigationStyles[justifyContent]}`}
+      className={`flex py-2 items-center text-grey-900 title-1 ${navigationStyles[justifyContent]}`}
     >
       {children}
     </nav>


### PR DESCRIPTION
# 관련 이슈 번호
close #583
# 설명

이전의 네비게이션을 만들때 저의 잘못된 가치관이 이 문제를 일으켰다 볼 수 있습니다.

> ㅋㅋ 아 내부에서 이미 다 멋지게 구현 되어 있어서 외부에선 내부 모습 생각 안하고 칠드런만 넘겨주면 알아서 잘 판단해주는게 좋은 추상화야 

그렇게 생각했으니 안에서 이 말도 안되는 코드가 있었을 겁니다.

```tsx
export interface NavigationBarProps {
  children:
    | [ReactElement<HTMLButtonElement | HTMLAnchorElement>, string | undefined]
    | [string | undefined, ReactElement<HTMLButtonElement | HTMLAnchorElement>];

export const NavigationBar = ({ children }: NavigationBarProps) => {
  const isButtonLeft =
    typeof children[1] === "string" || typeof children[1] === "undefined";

...
return (
..
    {children.map((child) =>
        typeof child === "string" ? (
          <h1 className="text-grey-900 title-1">{child}</h1>
        ) : (
          child
        ),
      )}
)
```

추상화 된 똑똑이 코드가 정답인줄 알았는데 

네비게이션바 처럼 사용처에서 다양하게 수정 되어야 하는 경우에는 수정 사항을 외부에서 컨트롤 할 수 있도록 최대한 멍청하게 만들어야겠더군요 

그래서 네비게이션 바는 정말 컨테이너 역할만 하도록 수정합니다. 

```tsx
export const NavigationBar = ({
  children,
  justifyContent,
}: NavigationBarProps) => {
  return (
    <nav
      className={`flex py-2 items-center text-grey-900 title-1 ${navigationStyles[justifyContent]}`}
    >
      {children}
    </nav>
  );
};
``` 

그리고 특정 목적을 가진 `Backward , Close NavigationBar` 에서 적절한 스타일 키인 `jsutifyContent` 를 넣어줍니다. 




# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
