### PR TITLE
[Hotfix] 탈퇴하기와 로그아웃의 msw handler 수정

### DIFF
--- a/src/features/setting/api/deleteAccount.ts
+++ b/src/features/setting/api/deleteAccount.ts
@@ -1,6 +1,8 @@
+import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import { ROUTER_PATH } from "@/shared/constants";
 import { apiClient } from "@/shared/lib";
+import { useAuthStore } from "@/shared/store";
 import { SETTING_END_POINT } from "../constants";
 
 interface DeleteAccountRequest {
@@ -15,12 +17,15 @@ const deleteAccount = async (deleteAccountData: DeleteAccountRequest) => {
 };
 
 export const useDeleteAccount = () => {
+  const reset = useAuthStore((state) => state.reset);
+  const navigate = useNavigate();
+
   return useMutation<unknown, Error, DeleteAccountRequest>({
     mutationFn: deleteAccount,
     mutationKey: ["deleteAccount"],
     onSuccess: () => {
-      // 메모리 초기화를 위해 window 객체를 이용한 라우
-      window.location.href = ROUTER_PATH.MAIN;
+      reset();
+      navigate(ROUTER_PATH.MAIN);
     },
     onError: (error) => {
       console.error(error);

--- a/src/mocks/handlers/setting.ts
+++ b/src/mocks/handlers/setting.ts
@@ -17,26 +17,41 @@ import { MY_PROFILE, updateMyProfile } from "../data/myProfile";
 import { updateMyProfileMarkingThumbnail } from "../data/profileMarking";
 import regionListData from "../data/regionList.json";
 
-const postLogoutHandler = http.post(SETTING_END_POINT.LOGOUT, ({ request }) => {
-  const token = request.headers.get("Authorization");
+const postLogoutHandler = http.post(
+  SETTING_END_POINT.LOGOUT,
+  ({ request, cookies }) => {
+    const token = request.headers.get("Authorization");
 
-  if (!token) {
+    if (!token) {
+      return HttpResponse.json(
+        {
+          code: 401,
+          message: "토큰 검증에 실패 했습니다.",
+        },
+        {
+          status: 401,
+        },
+      );
+    }
+
+    const headers = new Headers();
+    const cookieEntry = Object.entries(cookies);
+    cookieEntry.forEach(([key, value]) => {
+      if (key === "Authorization-refresh")
+        headers.append("Set-Cookie", `${key}=${value}; Max-Age=0; Path=/`);
+    });
+
     return HttpResponse.json(
       {
-        code: 401,
-        message: "토큰 검증에 실패 했습니다.",
+        code: 200,
+        message: "success",
       },
       {
-        status: 401,
+        headers,
       },
     );
-  }
-
-  return HttpResponse.json({
-    code: 200,
-    message: "success",
-  });
-});
+  },
+);
 
 const postChangeRegionHandler = http.post<PathParams, PostChangeRegionRequest>(
   SETTING_END_POINT.CHANGE_REGION,
@@ -79,7 +94,7 @@ const postChangeRegionHandler = http.post<PathParams, PostChangeRegionRequest>(
 
 const deleteAccountHandler = http.delete<PathParams, { password: string }>(
   SETTING_END_POINT.DELETE_ACCOUNT,
-  async ({ request }) => {
+  async ({ request, cookies }) => {
     await new Promise((res) => setTimeout(res, 1000));
 
     const token = request.headers.get("Authorization");
@@ -109,10 +124,22 @@ const deleteAccountHandler = http.delete<PathParams, { password: string }>(
       );
     }
 
-    return HttpResponse.json({
-      code: 200,
-      message: "회원 탈퇴가 완료 되었습니다.",
+    const headers = new Headers();
+    const cookieEntry = Object.entries(cookies);
+    cookieEntry.forEach(([key, value]) => {
+      if (key === "Authorization-refresh")
+        headers.append("Set-Cookie", `${key}=${value}; Max-Age=0; Path=/`);
     });
+
+    return HttpResponse.json(
+      {
+        code: 200,
+        message: "success",
+      },
+      {
+        headers,
+      },
+    );
   },
 );
 


### PR DESCRIPTION
# 관련 이슈 번호

close #587

# 설명

탈퇴하기와 로그아웃 msw handler에서 refresh token을 삭제하는 로직이 빠져있어 추가했습니다.