### PR TITLE
[Refactor] Modal 에서 mutation 성공 시 modal 자동으로 닫히던 로직 제거 

### DIFF
--- a/src/app/ReactQueryProvider/useCreateQueryClient.ts
+++ b/src/app/ReactQueryProvider/useCreateQueryClient.ts
@@ -1,11 +1,10 @@
 import { useRef } from "react";
 import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
 import { HttpError } from "@/shared/lib";
-import { useOverlayStore, useSnackbar } from "@/shared/store";
+import { useSnackbar } from "@/shared/store";
 import { useRefreshToken } from "./errorHandlers";
 
 export const useCreateQueryClient = () => {
-  const resetOverlays = useOverlayStore((state) => state.resetOverlays);
   const handleSnackbarOpen = useSnackbar("default");
   const { refreshTokenAndRetry } = useRefreshToken();
 
@@ -49,18 +48,6 @@ export const useCreateQueryClient = () => {
         },
       }),
       mutationCache: new MutationCache({
-        onSuccess: (_data, _variables, _context, mutation) => {
-          // * 중복 닉네임 체크인 경우에만 모달을 닫지 않습니다.
-          if (
-            mutation.options.mutationKey?.includes("checkDuplicateNickname")
-          ) {
-            return;
-          }
-
-          if (useOverlayStore.getState().overlays.length > 0) {
-            resetOverlays();
-          }
-        },
         onError: async (error, variables, _context, mutation) => {
           if (error instanceof HttpError && error.code === 401) {
             refreshTokenAndRetry(queryClient, undefined, mutation, variables);

--- a/src/features/marking/ui/editMarkingFormModal.tsx
+++ b/src/features/marking/ui/editMarkingFormModal.tsx
@@ -60,10 +60,12 @@ export const EditMarkingFormModal = ({
           <EditMarkingSaveButton
             markingId={markingId}
             putModifyMarkingArguments={putModifyMarkingArguments}
+            onClose={onClose}
           />
           <EditMarkingTempSaveButton
             markingId={markingId}
             putModifyMarkingArguments={putModifyMarkingArguments}
+            onClose={onClose}
           />
         </Modal.Footer>
       </Modal>
@@ -269,7 +271,8 @@ const EditMarkingTextArea = () => {
 const EditMarkingSaveButton = ({
   markingId,
   putModifyMarkingArguments,
-}: Omit<EditMarkingFormModalProps, "initialState" | "onClose">) => {
+  onClose,
+}: Omit<EditMarkingFormModalProps, "initialState">) => {
   const store = useEditMarkingFormContext();
   const handleOpenSnackbar = useSnackbar("default");
   const { mutate: putModifyTempMarking } = usePutModifyMarking(
@@ -296,14 +299,19 @@ const EditMarkingSaveButton = ({
       return;
     }
 
-    putModifyTempMarking({
-      content: content || "",
-      id: markingId,
-      removeIds: removedIds,
-      isTempSaved: false,
-      images: images.map(({ file }) => file),
-      isVisible,
-    });
+    putModifyTempMarking(
+      {
+        content: content || "",
+        id: markingId,
+        removeIds: removedIds,
+        isTempSaved: false,
+        images: images.map(({ file }) => file),
+        isVisible,
+      },
+      {
+        onSuccess: onClose,
+      },
+    );
   };
 
   return (
@@ -321,7 +329,8 @@ const EditMarkingSaveButton = ({
 const EditMarkingTempSaveButton = ({
   markingId,
   putModifyMarkingArguments,
-}: Omit<EditMarkingFormModalProps, "initialState" | "onClose">) => {
+  onClose,
+}: Omit<EditMarkingFormModalProps, "initialState">) => {
   const store = useEditMarkingFormContext();
   const handleOpenSnackbar = useSnackbar("default");
   const { mutate: putModifyTempMarking } = usePutModifyMarking(
@@ -337,14 +346,19 @@ const EditMarkingTempSaveButton = ({
       return;
     }
 
-    putModifyTempMarking({
-      content: content || "",
-      id: markingId,
-      removeIds: removedIds,
-      isTempSaved: true,
-      images: images.map(({ file }) => file),
-      isVisible,
-    });
+    putModifyTempMarking(
+      {
+        content: content || "",
+        id: markingId,
+        removeIds: removedIds,
+        isTempSaved: true,
+        images: images.map(({ file }) => file),
+        isVisible,
+      },
+      {
+        onSuccess: onClose,
+      },
+    );
   };
 
   return (

--- a/src/features/marking/ui/markingFormModal.tsx
+++ b/src/features/marking/ui/markingFormModal.tsx
@@ -46,8 +46,8 @@ export const MarkingFormModal = ({
       </Modal.Content>
       {/* 제출 버튼들 */}
       <Modal.Footer axis="col">
-        <SaveButton />
-        <TemporarySaveButton />
+        <SaveButton onClose={onCloseMarkingModal} />
+        <TemporarySaveButton onClose={onCloseMarkingModal} />
       </Modal.Footer>
     </Modal>
   );
@@ -258,7 +258,11 @@ const MarkingTextArea = () => {
   );
 };
 
-const SaveButton = () => {
+interface MarkingFormModalButtonProps {
+  onClose: () => void;
+}
+
+const SaveButton = ({ onClose }: MarkingFormModalButtonProps) => {
   const map = useMap();
 
   const isCompressing = useMarkingFormStore((state) => state.isCompressing);
@@ -298,14 +302,19 @@ const SaveButton = () => {
     const lat = center.lat();
     const lng = center.lng();
 
-    postMarkingData({
-      lat,
-      lng,
-      region,
-      isVisible,
-      images: images.map((image) => image.file),
-      content,
-    });
+    postMarkingData(
+      {
+        lat,
+        lng,
+        region,
+        isVisible,
+        images: images.map((image) => image.file),
+        content,
+      },
+      {
+        onSuccess: onClose,
+      },
+    );
   };
 
   return (
@@ -320,7 +329,8 @@ const SaveButton = () => {
     </Button>
   );
 };
-const TemporarySaveButton = () => {
+
+const TemporarySaveButton = ({ onClose }: MarkingFormModalButtonProps) => {
   const map = useMap();
   const isCompressing = useMarkingFormStore((state) => state.isCompressing);
   const handleOpenSnackbar = useSnackbar("map");
@@ -347,14 +357,19 @@ const TemporarySaveButton = () => {
     const lat = center.lat();
     const lng = center.lng();
 
-    postAddTempMarking({
-      lat,
-      lng,
-      region,
-      isVisible: isVisible,
-      images: compressedFiles,
-      content,
-    });
+    postAddTempMarking(
+      {
+        lat,
+        lng,
+        region,
+        isVisible: isVisible,
+        images: compressedFiles,
+        content,
+      },
+      {
+        onSuccess: onClose,
+      },
+    );
   };
 
   return (

--- a/src/features/setting/lib/useChangeRegionModal.tsx
+++ b/src/features/setting/lib/useChangeRegionModal.tsx
@@ -14,9 +14,14 @@ export const useChangeRegionModal = (regions: UseChangePetInfoModalParams) => {
       <RegionModal
         onClose={onClose}
         onSave={(regionList) => {
-          putChangeRegion({
-            newIds: regionList.map((region) => region.id),
-          });
+          putChangeRegion(
+            {
+              newIds: regionList.map((region) => region.id),
+            },
+            {
+              onSuccess: onClose,
+            },
+          );
         }}
         initialState={{
           regionList: regions,

--- a/src/features/setting/ui/changeNicknameModal.tsx
+++ b/src/features/setting/ui/changeNicknameModal.tsx
@@ -127,7 +127,6 @@ export const ChangeNicknameModal = ({
                         });
                       }
                     },
-                    onSuccess: onClose,
                   },
                 );
               },

--- a/src/features/setting/ui/changeNicknameModal.tsx
+++ b/src/features/setting/ui/changeNicknameModal.tsx
@@ -83,6 +83,7 @@ export const ChangeNicknameModal = ({
               message: changeNicknameFormErrorMessage.nickname.validate,
             });
         },
+        onSuccess: onClose,
       },
     );
   };
@@ -126,6 +127,7 @@ export const ChangeNicknameModal = ({
                         });
                       }
                     },
+                    onSuccess: onClose,
                   },
                 );
               },

--- a/src/features/setting/ui/passwordChangeModal.tsx
+++ b/src/features/setting/ui/passwordChangeModal.tsx
@@ -150,11 +150,16 @@ export const PasswordChangeModal = ({
     newPassword,
     confirmPassword,
   }) => {
-    putChangePassword({
-      password: currentPassword,
-      newPw: newPassword,
-      newPwChk: confirmPassword,
-    });
+    putChangePassword(
+      {
+        password: currentPassword,
+        newPw: newPassword,
+        newPwChk: confirmPassword,
+      },
+      {
+        onSuccess: onClose,
+      },
+    );
   };
 
   return (

--- a/src/features/setting/ui/passwordSetModal.tsx
+++ b/src/features/setting/ui/passwordSetModal.tsx
@@ -116,9 +116,7 @@ export const PasswordSetModal = ({ onClose }: PasswordSetModalProps) => {
     putSetPassword(
       { newPw: newPassword, newPwChk: confirmPassword },
       {
-        onSuccess: () => {
-          onClose();
-        },
+        onSuccess: onClose,
       },
     );
   };


### PR DESCRIPTION
# 관련 이슈 번호

close #590 

# 설명

`useModal` 을 호출하여 렌더링 되는 컴포넌트 내부에서 `useMutation` 이 호출 된 컴포넌트에 onSuccess 에 onClose 를 호출하도록 수정했습니다. 

- [x] `useCreateQueryClient` 에서 onSuccess 에서 useOverlay 초기화 로직 제거 

- useModal 이 호출되어 사용된 모든 모달 내부에서 onSuccess 에 onClose 로직 추가 혹은 확인
  - [x] deleteTemporaryMarkingModal : onClose 로직 이미 존재 
  - [x] useChangePetInfoModal : onSuccess 에 onClose 추가 
  - [x] useChangeRegionModal : onSuccess 에 onClose 추가
  - [x] PasswordCheckModal : onSuccess 에 onClose 이미 존재 
  - [x] LogoutModal : onSuccess 에 onClose 이미 존재 
  - [x] chageNicknameModal : onSuccess 에 onClose 추가 
  - [x] PasswordChangeModal : onSuccess 에 onClose 추가 
  - [x] PasswordSetModal : onSuccess 에 onClose 추가 
  - [x] PasswordCheckModal : onSuccess 에 onClose 이미 존재 
  - [x] MarkingFormModal.Save,TempSaveButton : onSuccess 에 onClose 추가 


### 리팩토링 이후 확인 해야 하는 사항(Optional)
- [x] 어떤 함수에 의존성을 갖고 있는 어떤 모듈의 정상적으로 동작

### 레퍼런스 이슈


# 첨부 파일 (Optional)

# 레퍼런스 (Optional)
